### PR TITLE
moved the file close inside the if/else statment 

### DIFF
--- a/sources/admin.queries.php
+++ b/sources/admin.queries.php
@@ -68,8 +68,9 @@ switch ($_POST['type']) {
             if (!feof($fp)) {
                 $error = "Error: unexpected fgets() fail\n";
             }
+            fclose($fp);
         }
-        fclose($fp);
+        
         if (count($handle_distant) > 0) {
             while (list($cle,$val) = each($handle_distant)) {
                 if (substr($val, 0, 3) == "nom") {


### PR DESCRIPTION
on line 72 the fclose() is happening even if the file is not openned.
I moved the close inside the else statment so file is closed only if it was opened.

Note to the author : you better use something else (iframe ?) to let the browser open the page instead of using a fopen....
