### PR TITLE
Proposed fix for blocking Step.5 of upgrade process

### DIFF
--- a/install/upgrade_ajax.php
+++ b/install/upgrade_ajax.php
@@ -1039,7 +1039,7 @@ if (isset($_POST['type'])) {
 
                 //Check if path is ok
                 if (is_dir($securePath)) {
-                    if (is_writable(dirname($securePath))) {
+                    if (is_writable($securePath)) {
                         //Do nothing
                     } else {
                         echo 'document.getElementById("res_step5").innerHTML = "<img src=\"images/exclamation-red.png\"> The SK path must be writable!";


### PR DESCRIPTION
The function dirname returns the parent folder of the $securePath. This causes user input to be truncated from say /path/to/my/sk to /path/to/my. This parent folder may not have been made writable by the upgrade script even if the child is. In that case, the upgrade process stalls with an error that does not make sense to the user since the path he provided was writable.
