### PR TITLE
Option to use login password as SALT key

### DIFF
--- a/admin.settings.php
+++ b/admin.settings.php
@@ -315,6 +315,10 @@ if (isset($_POST['save_button'])) {
     if (@$_SESSION['settings']['enable_personal_saltkey_cookie'] != $_POST['enable_personal_saltkey_cookie']) {
         updateSettings('enable_personal_saltkey_cookie', $_POST['enable_personal_saltkey_cookie']);
     }
+    // Update use_md5_password_as_salt
+    if (@$_SESSION['settings']['use_md5_password_as_salt'] != $_POST['use_md5_password_as_salt']) {
+        updateSettings('use_md5_password_as_salt', $_POST['use_md5_password_as_salt']);
+    }
     // Update personal_saltkey_cookie_duration
     if (@$_SESSION['settings']['personal_saltkey_cookie_duration'] != $_POST['personal_saltkey_cookie_duration']) {
         updateSettings('personal_saltkey_cookie_duration', $_POST['personal_saltkey_cookie_duration']);
@@ -793,6 +797,18 @@ echo '
                 <input type="radio" id="enable_pf_feature_radio1" name="enable_pf_feature" onclick="changeSettingStatus($(this).attr(\'name\'), 1) " value="1"', isset($_SESSION['settings']['enable_pf_feature']) && $_SESSION['settings']['enable_pf_feature'] == 1 ? ' checked="checked"' : '', ' /><label for="enable_pf_feature_radio1">'.$txt['yes'].'</label>
                 <input type="radio" id="enable_pf_feature_radio2" name="enable_pf_feature" onclick="changeSettingStatus($(this).attr(\'name\'), 0) " value="0"', isset($_SESSION['settings']['enable_pf_feature']) && $_SESSION['settings']['enable_pf_feature'] != 1 ? ' checked="checked"' : (!isset($_SESSION['settings']['enable_pf_feature']) ? ' checked="checked"':''), ' /><label for="enable_pf_feature_radio2">'.$txt['no'].'</label>
                         <span class="setting_flag" id="flag_enable_pf_feature"><img src="includes/images/status', isset($_SESSION['settings']['enable_pf_feature']) && $_SESSION['settings']['enable_pf_feature'] == 1 ? '' : '-busy', '.png" /></span>
+            </div>
+            </td</tr>';
+// enable Use MD5 passowrd as Personal SALTKEY
+echo '
+            <tr><td>
+                <span class="ui-icon ui-icon-disk" style="float: left; margin-right: .3em;">&nbsp;</span>
+                <label>'.$txt['use_md5_password_as_salt'].'</label>
+            </td><td>
+            <div class="div_radio">
+                <input type="radio" id="use_md5_password_as_salt_radio1" name="use_md5_password_as_salt" onclick="changeSettingStatus($(this).attr(\'name\'), 1) " value="1"', isset($_SESSION['settings']['use_md5_password_as_salt']) && $_SESSION['settings']['use_md5_password_as_salt'] == 1 ? ' checked="checked"' : '', ' /><label for="use_md5_password_as_salt_radio1">'.$txt['yes'].'</label>
+                <input type="radio" id="use_md5_password_as_salt_radio2" name="use_md5_password_as_salt" onclick="changeSettingStatus($(this).attr(\'name\'), 0) " value="0"', isset($_SESSION['settings']['use_md5_password_as_salt']) && $_SESSION['settings']['use_md5_password_as_salt'] != 1 ? ' checked="checked"' : (!isset($_SESSION['settings']['use_md5_password_as_salt']) ? ' checked="checked"':''), ' /><label for="use_md5_password_as_salt_radio2">'.$txt['no'].'</label>
+                        <span class="setting_flag" id="flag_use_md5_password_as_salt"><img src="includes/images/status', isset($_SESSION['settings']['use_md5_password_as_salt']) && $_SESSION['settings']['use_md5_password_as_salt'] == 1 ? '' : '-busy', '.png" /></span>
             </div>
             </td</tr>';
 // enable PF cookie for Personal SALTKEY

--- a/includes/language/english.php
+++ b/includes/language/english.php
@@ -94,6 +94,7 @@ $txt['user_activity'] = "User Activity";
 
 $txt['items'] = "Items";
 $txt['enable_personal_saltkey_cookie'] = "Enable personal SALTKey to be stored in a cookie";
+$txt['use_md5_password_as_salt'] = "Use the login password as SALTkey";
 $txt['personal_saltkey_cookie_duration'] = "Personal SALTKey cookie DAYS life time before expiration";
 $txt['admin_emails'] = "Emails";
 $txt['admin_emails_configuration'] = "Emails Configuration";

--- a/includes/language/spanish.php
+++ b/includes/language/spanish.php
@@ -507,6 +507,7 @@ $txt['pdf_password'] = "Clave de encriptación PDF";
 $txt['pdf_password_warning'] = "Debe proporcionar una clave de encriptación";
 $txt['personal_folder'] = "Carpeta personal";
 $txt['personal_saltkey_change_button'] = "Cámbialo";
+$txt['use_md5_password_as_salt'] = "Usar contrasenya de login como llave de encriptación SALT";
 $txt['personal_saltkey_cookie_duration'] = "Tiempo de vida en DIAS de la clave Salt personal antes de que expire";
 $txt['personal_saltkey_lost'] = "La he perdido";
 $txt['personal_salt_key'] = "Su clave Salt personal";

--- a/sources/main.queries.php
+++ b/sources/main.queries.php
@@ -415,6 +415,18 @@ switch ($_POST['type']) {
                 $_SESSION['user_language'] = $data['user_language'];
                 $_SESSION['user_email'] = $data['email'];
 
+                /* If this option is set user password MD5 is used as personal SALTKey */
+       if (isset($_SESSION['settings']['use_md5_password_as_salt']) &&
+                    $_SESSION['settings']['use_md5_password_as_salt'] == 1 ) {
+                    $_SESSION['my_sk'] = md5($passwordClear);
+                    setcookie(
+                       "TeamPass_PFSK_".md5($_SESSION['user_id']),
+                       encrypt($_SESSION['my_sk'], ""),
+                       time() + 60 * 60 * 24 * $_SESSION['settings']['personal_saltkey_cookie_duration'],
+                       '/'
+                    );
+                }
+
                 @syslog(
                     LOG_WARNING,
                     "User logged in - ".$_SESSION['user_id']." - ".date("Y/m/d H:i:s").


### PR DESCRIPTION
In the environment where I use TeamPass is more important the usability than security so we decided to implement the option to use login password as salt key by default.

Now if the personal folders are enabled the user can put and read passwords without setting the saltkey (is setted the login one)

This pull request also include the option to enable/disable this in the settings to enable this feature and the translation in English and Spanish of the string.

It the users has used saltkeys previowsly they should migrate to loginpassword before the administrator enables this feature.

This also tested with LDAP integration and works fine.
