### PR TITLE
Updated Settings frontend to allow for bind account and password, added ...

### DIFF
--- a/admin.settings.php
+++ b/admin.settings.php
@@ -244,6 +244,14 @@ if (isset($_POST['save_button'])) {
     if (@$_SESSION['settings']['ldap_domain_dn'] != $_POST['ldap_domain_dn']) {
         updateSettings('ldap_domain_dn', $_POST['ldap_domain_dn']);
     }
+    // Update LDAP ldap_bind_dn
+    if (@$_SESSION['settings']['ldap_bind_dn'] != $_POST['ldap_bind_dn']) {
+        updateSettings('ldap_bind_dn', $_POST['ldap_bind_dn']);
+    }
+    // Update LDAP ldap_bind_pw
+    if (@$_SESSION['settings']['ldap_bind_pw'] != $_POST['ldap_bind_pw']) {
+        updateSettings('ldap_bind_pw', $_POST['ldap_bind_pw']);
+    }
     // Update LDAP ldap_domain_controler
     if (@$_SESSION['settings']['ldap_domain_controler'] != $_POST['ldap_domain_controler']) {
         updateSettings('ldap_domain_controler', $_POST['ldap_domain_controler']);
@@ -1432,6 +1440,18 @@ echo '
                     <tr>
                         <td><label for="ldap_domain_controler">'.$txt['settings_ldap_domain_controler'].'&nbsp;<img src="includes/images/question-small-white.png" class="tip" alt="" title="'.$txt['settings_ldap_domain_controler_tip'].'" /></label></td>
                         <td><input type="text" size="50" id="ldap_domain_controler" name="ldap_domain_controler" class="text ui-widget-content" title="dc01.mydomain.local,dc02.mydomain.local" value="', isset($_SESSION['settings']['ldap_domain_controler']) ? $_SESSION['settings']['ldap_domain_controler'] : '', '" /></td>
+                    </tr>';
+// Domain Bind User
+echo '
+                    <tr>
+                        <td><label for="ldap_bind_dn">'.$txt['settings_ldap_bind_dn'].'</label></td>
+                        <td><input type="text" size="50" id="ldap_bind_dn" name="ldap_bind_dn" class="text ui-widget-content" value="', isset($_SESSION['settings']['ldap_bind_dn']) ? $_SESSION['settings']['ldap_bind_dn'] : '', '" /></td>
+                    </tr>';
+// Domain Bind Password
+echo '
+                    <tr>
+                        <td><label for="ldap_bind_pw">'.$txt['settings_ldap_bind_pw'].'</label></td>
+                        <td><input type="text" size="50" id="ldap_bind_pw" name="ldap_bind_pw" class="text ui-widget-content" title="" value="', isset($_SESSION['settings']['ldap_bind_pw']) ? $_SESSION['settings']['ldap_bind_pw'] : '', '" /></td>
                     </tr>';
 // AD SSL
 echo '

--- a/includes/language/english.php
+++ b/includes/language/english.php
@@ -625,6 +625,8 @@ $txt['settings_ldap_domain'] = "LDAP account suffix for your domain";
 $txt['settings_ldap_domain_controler'] = "LDAP array of domain controllers";
 $txt['settings_ldap_domain_controler_tip'] = "<span style='font-size:11px;max-width:300px;'>Specifiy multiple controllers if you would like the class to balance the LDAP queries amongst multiple servers.<br />You must delimit the domains by a comma (,)!<br />By example: domain_1,domain_2,domain_3</span>";
 $txt['settings_ldap_domain_dn'] = "LDAP base dn for your domain";
+$txt['settings_ldap_bind_dn'] = "LDAP bind dn for your domain";
+$txt['settings_ldap_bind_pw'] = "LDAP password for binding account";
 $txt['settings_ldap_mode'] = "Enable users authentification through LDAP server";
 $txt['settings_ldap_mode_tip'] = "Enable only if you have an LDAP server and if you want to use it to authentify TeamPass users through it.";
 $txt['settings_ldap_ssl'] = "Use LDAP through SSL (LDAPS)";

--- a/includes/libraries/LDAP/adLDAP/adLDAP.php
+++ b/includes/libraries/LDAP/adLDAP/adLDAP.php
@@ -81,7 +81,7 @@ class adLDAP
     protected $_base_dn = "dc = example, dc = com";
 
     /**
-    * Array of domain controllers. Specifiy multiple controllers if you
+    * Array of domain controllers. Specify multiple controllers if you
     * would like the class to balance the LDAP queries amongst multiple servers
     *
     * @var array
@@ -234,11 +234,12 @@ class adLDAP
     }
 
     /**
-    * Set whether to detect the true primary group
-    *
-    * @param bool $_real_primary_group
-    * @return void
-    */
+     * Set whether to detect the true primary group
+     *
+     * @param $_real_primarygroup
+     * @internal param bool $_real_primary_group
+     * @return void
+     */
     public function set_real_primarygroup($_real_primarygroup)
     {
           $this->_real_primarygroup = $_real_primarygroup;
@@ -318,17 +319,17 @@ class adLDAP
     }
 
     /**
-    * Default Constructor
-    *
-    * Tries to bind to the AD domain over LDAP or LDAPs
-    *
-    * @param array $options Array of options to pass to the constructor
-    * @throws Exception - if unable to bind to Domain Controller
-    * @return bool
-    */
+     * Default Constructor
+     *
+     * Tries to bind to the AD domain over LDAP or LDAPs
+     *
+     * @param array $options Array of options to pass to the constructor
+     * @throws adLDAPException
+     * @return \LDAP\adLDAP\adLDAP
+     */
     public function __construct($options = array())
     {
-        // You can specifically overide any of the default configuration options setup above
+        // You can specifically override any of the default configuration options setup above
         if (count($options) > 0) {
             if (array_key_exists("account_suffix", $options)) {
                 $this->_account_suffix = $options["account_suffix"];
@@ -379,10 +380,11 @@ class adLDAP
     }
 
     /**
-    * Connects and Binds to the Domain Controller
-    *
-    * @return bool
-    */
+     * Connects and Binds to the Domain Controller
+     *
+     * @throws adLDAPException
+     * @return bool
+     */
     public function connect()
     {
         // Connect to the AD/LDAP server as the username/password
@@ -403,7 +405,7 @@ class adLDAP
 
         // Bind as a domain admin if they've set it up
         if ($this->_ad_username != null && $this->_ad_password!= null) {
-            $this->_bind = @ldap_bind($this->_conn, $this->_ad_username.$this->_account_suffix, $this->_ad_password);
+            $this->_bind = ldap_bind($this->_conn, $this->_ad_username.$this->_account_suffix, $this->_ad_password);
             if (!$this->_bind) {
                 if ($this->_use_ssl && !$this->_use_tls) {
                     // If you have problems troubleshooting, remove the @ character from the ldap_bind command above to get the actual error message
@@ -432,13 +434,14 @@ class adLDAP
     }
 
     /**
-    * Validate a user's login credentials
-    *
-    * @param string $username A user's AD username
-    * @param string $password A user's AD password
-    * @param bool optional $prevent_rebind
-    * @return bool
-    */
+     * Validate a user's login credentials
+     *
+     * @param string $username A user's AD username
+     * @param string $password A user's AD password
+     * @param bool $prevent_rebind
+     * @throws adLDAPException
+     * @return bool
+     */
     public function authenticate($username, $password, $prevent_rebind = false)
     {
         // Prevent null binding
@@ -889,14 +892,14 @@ class adLDAP
     }
 
     /**
-    * Returns a complete list of the groups in AD based on a SAM Account Type
-    *
-    * @param string $samaccounttype The account type to return
-    * @param bool $include_desc Whether to return a description
-    * @param string $search Search parameters
-    * @param bool $sorted Whether to sort the results
-    * @return array
-    */
+     * Returns a complete list of the groups in AD based on a SAM Account Type
+     *
+     * @param int|string $samaccounttype The account type to return
+     * @param bool $include_desc Whether to return a description
+     * @param string $search Search parameters
+     * @param bool $sorted Whether to sort the results
+     * @return array
+     */
     public function search_groups($samaccounttype = ADLDAP_SECURITY_GLOBAL_GROUP, $include_desc = false, $search = "*", $sorted = true)
     {
         if (!$this->_bind) {
@@ -979,13 +982,14 @@ class adLDAP
     // USER FUNCTIONS
 
     /**
-    * Create a user
-    *
-    * If you specify a password here, this can only be performed over SSL
-    *
-    * @param array $attributes The attributes to set to the user account
-    * @return bool
-    */
+     * Create a user
+     *
+     * If you specify a password here, this can only be performed over SSL
+     *
+     * @param array $attributes The attributes to set to the user account
+     * @throws adLDAPException
+     * @return bool
+     */
     public function user_create($attributes)
     {
         // Check for compulsory fields
@@ -1182,13 +1186,13 @@ class adLDAP
     }
 
     /**
-    * Determine a user's password expiry date
-    *
-    * @param string $username The username to query
-    * @param book $isGUID Is the username passed a GUID or a samAccountName
-    * @requires bcmath http://www.php.net/manual/en/book.bc.php
-    * @return array
-    */
+     * Determine a user's password expiry date
+     *
+     * @param string $username The username to query
+     * @param bool|\LDAP\adLDAP\book $isGUID Is the username passed a GUID or a samAccountName
+     * @requires bcmath http://www.php.net/manual/en/book.bc.php
+     * @return array
+     */
     public function user_password_expiry($username, $isGUID = false)
     {
         if ($username === null) {
@@ -1260,13 +1264,14 @@ class adLDAP
     }
 
     /**
-    * Modify a user
-    *
-    * @param string $username The username to query
-    * @param array $attributes The attributes to modify.  Note if you set the enabled attribute you must not specify any other attributes
-    * @param bool $isGUID Is the username passed a GUID or a samAccountName
-    * @return bool
-    */
+     * Modify a user
+     *
+     * @param string $username The username to query
+     * @param array $attributes The attributes to modify.  Note if you set the enabled attribute you must not specify any other attributes
+     * @param bool $isGUID Is the username passed a GUID or a samAccountName
+     * @throws adLDAPException
+     * @return bool
+     */
     public function user_modify($username, $attributes, $isGUID = false)
     {
         if ($username === null) {
@@ -1352,13 +1357,14 @@ class adLDAP
     }
 
     /**
-    * Set the password of a user - This must be performed over SSL
-    *
-    * @param string $username The username to modify
-    * @param string $password The new password
-    * @param bool $isGUID Is the username passed a GUID or a samAccountName
-    * @return bool
-    */
+     * Set the password of a user - This must be performed over SSL
+     *
+     * @param string $username The username to modify
+     * @param string $password The new password
+     * @param bool $isGUID Is the username passed a GUID or a samAccountName
+     * @throws adLDAPException
+     * @return bool
+     */
     public function user_password($username, $password, $isGUID = false)
     {
         if ($username === null) {
@@ -1509,12 +1515,13 @@ class adLDAP
     }
 
     /**
-    * Determine the list of groups a contact is a member of
-    *
-    * @param string $distinguisedname The full DN of a contact
-    * @param bool $recursive Recursively check groups
-    * @return array
-    */
+     * Determine the list of groups a contact is a member of
+     *
+     * @param $distinguishedname
+     * @param bool $recursive Recursively check groups
+     * @internal param string $distinguisedname The full DN of a contact
+     * @return array
+     */
     public function contact_groups($distinguishedname, $recursive = null)
     {
         if ($distinguishedname === null) {
@@ -1542,12 +1549,13 @@ class adLDAP
     }
 
     /**
-    * Get contact information
-    *
-    * @param string $distinguisedname The full DN of a contact
-    * @param array $fields Attributes to be returned
-    * @return array
-    */
+     * Get contact information
+     *
+     * @param $distinguishedname
+     * @param array $fields Attributes to be returned
+     * @internal param string $distinguisedname The full DN of a contact
+     * @return array
+     */
     public function contact_info($distinguishedname, $fields = null)
     {
         if ($distinguishedname === null) {
@@ -1929,20 +1937,21 @@ class adLDAP
     }
 
     /**
-    * Add an X400 address to Exchange
-    * See http://tools.ietf.org/html/rfc1685 for more information.
-    * An X400 Address looks similar to this X400:c = US;a =  ;p = Domain;o = Organization;s = Doe;g = John;
-    *
-    * @param string $username The username of the user to add the X400 to to
-    * @param string $country Country
-    * @param string $admd Administration Management Domain
-    * @param string $pdmd Private Management Domain (often your AD domain)
-    * @param string $org Organization
-    * @param string $surname Surname
-    * @param string $givenName Given name
-    * @param bool $isGUID Is the username passed a GUID or a samAccountName
-    * @return bool
-    */
+     * Add an X400 address to Exchange
+     * See http://tools.ietf.org/html/rfc1685 for more information.
+     * An X400 Address looks similar to this X400:c = US;a =  ;p = Domain;o = Organization;s = Doe;g = John;
+     *
+     * @param string $username The username of the user to add the X400 to to
+     * @param string $country Country
+     * @param string $admd Administration Management Domain
+     * @param string $pdmd Private Management Domain (often your AD domain)
+     * @param string $org Organization
+     * @param string $surname Surname
+     * @param $givenname
+     * @param bool $isGUID Is the username passed a GUID or a samAccountName
+     * @internal param string $givenName Given name
+     * @return bool
+     */
     public function exchange_add_X400($username, $country, $admd, $pdmd, $org, $surname, $givenname, $isGUID = false)
     {
         if ($username === null) {

--- a/sources/main.queries.php
+++ b/sources/main.queries.php
@@ -257,6 +257,8 @@ switch ($_POST['type']) {
                     'account_suffix' => $ldap_suffix,
                     'domain_controllers' => explode(",", $_SESSION['settings']['ldap_domain_controler']),
                     'use_ssl' => $_SESSION['settings']['ldap_ssl'],
+                    'ad_username' => $_SESSION['settings']['ldap_bind_dn'],
+                    'ad_password' => $_SESSION['settings']['ldap_bind_pw'],
                     'use_tls' => $_SESSION['settings']['ldap_tls']
                 )
             );


### PR DESCRIPTION
...English translation for new fields (native), updated adLdap instantiation to include user/pass, update some phpdoc in adLdap library
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/nilsteampassnet/TeamPass/pull/432%23issuecomment-27278336%22%2C%20%22https%3A//github.com/nilsteampassnet/TeamPass/pull/432%23issuecomment-27305860%22%2C%20%22https%3A//github.com/nilsteampassnet/TeamPass/pull/432%23issuecomment-27844546%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/nilsteampassnet/TeamPass/pull/432%23issuecomment-27278336%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Thank%20you%20for%20your%20pull%20request.%5Cr%5CnI%20have%202%20questions.%5Cr%5Cn%5Cr%5Cn1/%5Cr%5CnAs%20I%20have%20no%20knowledge%20of%20LDAP%20and%20even%20no%20way%20to%20test%20it%2C%20can%20you%20tell%20me%20if%20if%20this%20pull%20request%20is%20compatible%20with%20the%20pull%20request%20%23423%3F%5Cr%5CnIndeed%20as%20the%202%20are%20dealing%20with%20ldap%2C%20I%20need%20to%20know%20if%20the%202%20pulls%20can%20be%20used%20together.%5Cr%5Cn%5Cr%5Cn2/%5Cr%5CnIf%20this%20pull%20is%20merged%2C%20are%20the%202%20new%20parameters%20introduced%20%28ldap_bind_dn%20and%20ldap_bind_pw%29%20mandatory%20or%20are%20they%20optional%3F%5Cr%5CnWhat%20I%20want%20to%20check%20is%20that%20for%20actual%20users%2C%20do%20those%20changes%20have%20an%20impact%20on%20the%20configuration%20they%20have%20%28without%20those%202%20new%20parameters%29%3F%5Cr%5Cn%5Cr%5CnThank%20you%22%2C%20%22created_at%22%3A%20%222013-10-29T04%3A40%3A45Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1197546%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/nilsteampassnet%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20can%20tell%20you%20that%20my%20changes%20are%20used%20in%20a%20live%20enterprise%20AD%20environment%20and%20are%20authenticating%20successfully.%20%20This%20was%20my%20test%20case%20and%20I%20didn%27t%20send%20my%20commit%20until%20then.%5Cr%5Cn%5Cr%5CnI%20think%20that%20there%20could%20be%20some%20name%20collision%2C%20but%20I%20don%27t%20touch%20the%20Posix%20methods%20at%20all.%20%20My%20changes%20are%20changes%20to%20add%20a%20bind%20user/pass%20to%20AD%20only%2C%20I%20could%20probably%20change%20the%20variables%20that%20I%20use%20to%20have%20setting_ldap_ad_bindpw%20to%20create%20them%20and%20he%20could%20update%20is%20to%20have%20posix_%2A%20into%20his.%20%20This%20should%20minimize%20the%20name%20collision%20of%20the%202%20pull%20requests.%20%20This%20will%20make%20bind%20user/pass%20mandatory%20for%20all%20AD%20access%2C%20I%20could%20probably%20update%20it%20further%20to%20allow%20anonymous.%20%20Anonymous%20Access%20of%20AD%20was%20removed%20in%20Server%202003%20domain%20controllers.%20%20This%20changes%20bring%20the%20application%20up%20to%20current%20standards%20where%20you%20usually%20have%20a%20service%20account%20that%20allows%20ldapsearch%20to%20deeper%20levels%20of%20the%20tree.%5Cr%5Cn%5Cr%5CnReference%3A%20http%3A//support.microsoft.com/kb/326690%5Cr%5Cn%5Cr%5Cn%40fsniper%20What%20do%20you%20think%20of%20my%20name%20collision%20solution%3F%22%2C%20%22created_at%22%3A%20%222013-10-29T14%3A14%3A06Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1433666%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tarcinil%22%7D%7D%2C%20%7B%22body%22%3A%20%22THank%20you%20for%20your%20answer.%5Cr%5Cn%5Cr%5CnIt%20could%20be%20good%20to%20update%20the%20patch%20in%20the%20way%20you%20explain%20in%20order%20to%20prevent%20this%20naming%20collision.%5Cr%5CnI%27ve%20asked%20%40fsniper%20the%20same%20too%20%3B-%29%22%2C%20%22created_at%22%3A%20%222013-11-06T05%3A48%3A14Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1197546%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/nilsteampassnet%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/nilsteampassnet/TeamPass/pull/432#issuecomment-27278336'>General Comment</a></b>
- <a href='https://github.com/nilsteampassnet'><img border=0 src='https://avatars.githubusercontent.com/u/1197546?v=3' height=16 width=16'></a> Thank you for your pull request.
I have 2 questions.
1/
As I have no knowledge of LDAP and even no way to test it, can you tell me if if this pull request is compatible with the pull request #423?
Indeed as the 2 are dealing with ldap, I need to know if the 2 pulls can be used together.
2/
If this pull is merged, are the 2 new parameters introduced (ldap_bind_dn and ldap_bind_pw) mandatory or are they optional?
What I want to check is that for actual users, do those changes have an impact on the configuration they have (without those 2 new parameters)?
Thank you
- <a href='https://github.com/tarcinil'><img border=0 src='https://avatars.githubusercontent.com/u/1433666?v=3' height=16 width=16'></a> I can tell you that my changes are used in a live enterprise AD environment and are authenticating successfully.  This was my test case and I didn't send my commit until then.
I think that there could be some name collision, but I don't touch the Posix methods at all.  My changes are changes to add a bind user/pass to AD only, I could probably change the variables that I use to have setting_ldap_ad_bindpw to create them and he could update is to have posix_* into his.  This should minimize the name collision of the 2 pull requests.  This will make bind user/pass mandatory for all AD access, I could probably update it further to allow anonymous.  Anonymous Access of AD was removed in Server 2003 domain controllers.  This changes bring the application up to current standards where you usually have a service account that allows ldapsearch to deeper levels of the tree.
Reference: http://support.microsoft.com/kb/326690
@fsniper What do you think of my name collision solution?
- <a href='https://github.com/nilsteampassnet'><img border=0 src='https://avatars.githubusercontent.com/u/1197546?v=3' height=16 width=16'></a> THank you for your answer.
It could be good to update the patch in the way you explain in order to prevent this naming collision.
I've asked @fsniper the same too ;-)


<a href='https://www.codereviewhub.com/nilsteampassnet/TeamPass/pull/432?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/nilsteampassnet/TeamPass/pull/432?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/nilsteampassnet/TeamPass/pull/432'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>