### PR TITLE
Update DbCore.php to turn off strict mode

### DIFF
--- a/includes/libraries/Database/Core/DbCore.php
+++ b/includes/libraries/Database/Core/DbCore.php
@@ -77,6 +77,7 @@ class DbCore
 
         mysql_query("SET NAMES UTF8");
         mysql_query("SET CHARACTER SET 'utf8'");
+        mysql_query("SET sql_mode=''");
 
         // unset the data so it can't be dumped
         $this->server='';


### PR DESCRIPTION
MySQL at least in some installations is put into strict mode by default. As a result INSERT queries that do not include all columns in a table without default values fails. Most notably this was causing add user to (silently) fail. Setting sql_mode here prevents having to change the MySQL configuration.
