### PR TITLE
Fix default session path

### DIFF
--- a/sources/sessions.php
+++ b/sources/sessions.php
@@ -65,6 +65,10 @@ class CryptSession {
      */
     public function open($save_path, $session_name)
     {
+        // Default session path to temp dir
+        if($save_path == "") {
+            $save_path = sys_get_temp_dir();
+        }
         $this->_path    = $save_path.'/';
 	$this->_name    = $session_name;
 	$this->_keyName = "KEY_$session_name";


### PR DESCRIPTION
If save_path is empty, use the system temporary directory.

See: https://stackoverflow.com/questions/4927850/location-for-session-files-in-apache-php

It could be improved to take the second comment into account but I don't know any way to get the compile time location set on Debian and RedHat.
