### PR TITLE
Fix issue #653 (Passwords preprended during upgrade)

### DIFF
--- a/install/upgrade_ajax.php
+++ b/install/upgrade_ajax.php
@@ -1694,9 +1694,17 @@ require_once \"".$skFile."\";
                 if (empty($pw)) {
                     $pw = decryptOld($data['pw']);
 
-                    // generate Key and encode PW
-                    $randomKey = generateKey();
-                    $pw = $randomKey.$pw;
+                    // if no key ... then add it
+                    $resData = mysqli_query($dbTmp,
+                        "SELECT COUNT(*) FROM ".$_SESSION['tbl_prefix']."keys
+                        WHERE `table` = 'items' AND id = ".$data['id']
+                    ) or die(mysqli_error($dbTmp));
+                    $dataTemp = mysqli_fetch_row($resData);
+                    if ($dataTemp[0] == 0) {
+                        // generate Key and encode PW
+                        $randomKey = generateKey();
+                        $pw = $randomKey.$pw;
+                    }
                     $pw = encrypt($pw, $_SESSION['session_start']);
 
                     // store Password


### PR DESCRIPTION
Fix for : #653
Sometimes passwords encrypted with old process already have a salt key !

Tested from 2.1.7 to 2.1.21 + this patch = passwords ok.
