### PR TITLE
Fix rights based on roles for new folders.

### DIFF
--- a/sources/folders.queries.php
+++ b/sources/folders.queries.php
@@ -386,14 +386,15 @@ if (isset($_POST['newtitle'])) {
                     }
 
                     //If it is a subfolder, then give access to it for all roles that allows the parent folder
-                    $rows = DB::query("SELECT role_id FROM ".$pre."roles_values WHERE folder_id = %i", $parentId);
+                    $rows = DB::query("SELECT role_id, type FROM ".$pre."roles_values WHERE folder_id = %i", $parentId);
                     foreach ($rows as $record) {
                         //add access to this subfolder
                         DB::insert(
                             $pre.'roles_values',
                             array(
                                 'role_id' => $record['role_id'],
-                                'folder_id' => $newId
+                                'folder_id' => $newId,
+                                'type' => $record['type']
                            )
                         );
                     }


### PR DESCRIPTION
Without this fix, role rights of new folders were set as read only no matter if the parent has R or W.
