### PR TITLE
  First password is not re-encoded on upgrade

### DIFF
--- a/install/upgrade.php
+++ b/install/upgrade.php
@@ -157,7 +157,7 @@ if (
 
         function newEncryptPw(){
             var nb = 1;
-            var start = 1;
+            var start = 0;
             if ($("#change_pw_encryption_start").val() != "") {
                 start = $("#change_pw_encryption_start").val();
             } else {


### PR DESCRIPTION
During the upgrade process, the limit query starts on the position 1.
In a MySQL database, the first item has position 0.
Previously fixed in #765
<a href='#crh-start'></a><a href='#crh-data-%7B%22approved%22%3A%20%7B%22https%3A//github.com/nilsteampassnet%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1197546%3Fv%3D3%22%7D%7D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/nilsteampassnet/TeamPass/pull/899%23issuecomment-75607111%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%3Ashipit%3A%22%2C%20%22created_at%22%3A%20%222015-02-23T18%3A56%3A56Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1197546%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/nilsteampassnet%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%2C%20%22processed%22%3A%20%5B%22https%3A//github.com/nilsteampassnet/TeamPass/pull/899%23issuecomment-75607111%22%5D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>

<img src='http://www.codereviewhub.com/site/github-approved-avatar.png'><a href='https://github.com/nilsteampassnet'><img src='https://avatars.githubusercontent.com/u/1197546?v=3' width=34 height=34></a>

<a href='https://www.codereviewhub.com/nilsteampassnet/TeamPass/pull/899?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/nilsteampassnet/TeamPass/pull/899?approve=0'><img src='http://www.codereviewhub.com/site/github-undo-approve.png' height=26></a>&nbsp;<a href='https://github.com/nilsteampassnet/TeamPass/pull/899'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>