### PR TITLE
Personal folders shouldn't be read-only

### DIFF
--- a/sources/main.functions.php
+++ b/sources/main.functions.php
@@ -486,7 +486,7 @@ function identifyUserRights($groupesVisiblesUser, $groupesInterditsUser, $isAdmi
         // get list of readonly folders
         // rule - if one folder is set as W in one of the Role, then User has access as W
         foreach ($listAllowedFolders as $folderId) {
-            if (!in_array($folderId, $listReadOnlyFolders) || (isset($pf) && $folderId != $pf['id'])) {
+            if (!in_array($folderId, $listReadOnlyFolders) && (isset($pf) && $folderId != $pf['id'])) {
                 DB::query(
                     "SELECT *
                     FROM ".prefix_table("roles_values")."


### PR DESCRIPTION
Since recent update to 2.1.23 users have their personal folder in read-only. I suspect this edit because in our case the conditions are respected and the following query return no results. Even more, I suppose the second condition, (isset($pf) && $folderId != $pf['id'])) be here to ensure personal folder isn't concerned by the RO check process.
<a href='#crh-start'></a><a href='#crh-data-%7B%22approved%22%3A%20%7B%7D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/nilsteampassnet/TeamPass/pull/914%23issuecomment-76375887%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%3Ashipit%3A%22%2C%20%22created_at%22%3A%20%222015-02-27T10%3A52%3A49Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1167556%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/amorce%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3Ashipit%3A%3Agun%3A%22%2C%20%22created_at%22%3A%20%222015-02-27T10%3A53%3A09Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1167556%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/amorce%22%7D%7D%2C%20%7B%22body%22%3A%20%22Bug%20already%20identified%20and%20commited%20in%20%5C%22development%5C%22%20branch.%5Cn%5CnBut%20anyway%2C%20many%20thanks%20for%20sharing%20a%20solution.%5Cn%22%2C%20%22created_at%22%3A%20%222015-02-27T12%3A19%3A03Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1197546%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/nilsteampassnet%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%2C%20%22processed%22%3A%20%5B%22https%3A//github.com/nilsteampassnet/TeamPass/pull/914%23issuecomment-76375887%22%2C%20%22https%3A//github.com/nilsteampassnet/TeamPass/pull/914%23issuecomment-76375942%22%2C%20%22https%3A//github.com/nilsteampassnet/TeamPass/pull/914%23issuecomment-76386417%22%5D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/nilsteampassnet/TeamPass/pull/914#issuecomment-76375887'>General Comment</a></b>
- <a href='https://github.com/amorce'><img border=0 src='https://avatars.githubusercontent.com/u/1167556?v=3' height=16 width=16'></a> :shipit:
- <a href='https://github.com/amorce'><img border=0 src='https://avatars.githubusercontent.com/u/1167556?v=3' height=16 width=16'></a> :shipit::gun:
- <a href='https://github.com/nilsteampassnet'><img border=0 src='https://avatars.githubusercontent.com/u/1197546?v=3' height=16 width=16'></a> Bug already identified and commited in "development" branch.
  But anyway, many thanks for sharing a solution.

<a href='https://www.codereviewhub.com/nilsteampassnet/TeamPass/pull/914?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/nilsteampassnet/TeamPass/pull/914?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/nilsteampassnet/TeamPass/pull/914'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
