### PR TITLE
Change the input type of the db password install and upgrade

### DIFF
--- a/install/install.php
+++ b/install/install.php
@@ -135,7 +135,7 @@ echo '
     <label for="db_login" class="label_block">Login :</label><input type="text" id="db_login" style="width:250px;" />
     </div>
     <div class="line_entry">
-    <label for="db_pw" class="label_block">Password :</label><input type="text" id="db_pw" tilte="Double quotes not allowed!" style="width:250px;" />
+    <label for="db_pw" class="label_block">Password :</label><input type="password" id="db_pw" tilte="Double quotes not allowed!" style="width:250px;" />
     </div>
     <div class="line_entry">
     <label for="db_port" class="label_block">Port :</label><input type="text" id="db_port" value="3306" style="width:250px;" />

--- a/install/upgrade.php
+++ b/install/upgrade.php
@@ -317,7 +317,7 @@ if (!isset($_GET['step']) && !isset($_POST['step'])) {
                      <label for="db_host">Host :</label><input type="text" id="db_host" name="db_host" class="step" value="'.$_SESSION['server'].'" /><br />
                      <label for="db_db">DataBase name :</label><input type="text" id="db_bdd" name="db_bdd" class="step" value="'.$_SESSION['database'].'" /><br />
                      <label for="db_login">Login :</label><input type="text" id="db_login" name="db_login" class="step" value="'.$_SESSION['user'].'" /><br />
-                     <label for="db_pw">Password :</label><input type="text" id="db_pw" name="db_pw" class="step" value="'.$_SESSION['pass'].'" /><br />
+                     <label for="db_pw">Password :</label><input type="password" id="db_pw" name="db_pw" class="step" value="'.$_SESSION['pass'].'" /><br />
                      <label for="db_port">Port :</label><input type="text" id="db_port" name="db_port" class="step" value="',isset($_SESSION['port']) ? $_SESSION['port'] : "3306",'" /><br />
                      <label for="tbl_prefix">Table prefix :</label><input type="text" id="tbl_prefix" name="tbl_prefix" class="step" value="'.$_SESSION['pre'].'" />
                      </fieldset>


### PR DESCRIPTION
Hi Nils,
Actually, the password is displayed in clear text in update and install forms, it's better to hide it.
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/nilsteampassnet/TeamPass/pull/952?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/nilsteampassnet/TeamPass/pull/952'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
