### PR TITLE
Attempt to fix #875 by removing ldap_mode check for salt key display,…

### DIFF
--- a/index.php
+++ b/index.php
@@ -224,7 +224,7 @@ if (isset($_SESSION['login'])) {
                     <ul class="menu" style="">
                         <li class="" style="padding:4px;width:40px; text-align:center;"><i class="fa fa-dashboard fa-fw"></i>&nbsp;
                             <ul class="menu_200" style="text-align:left;">',
-                                (isset($_SESSION['settings']['ldap_mode']) && $_SESSION['settings']['ldap_mode'] == 1) || $_SESSION['user_admin'] == 1 ? '' :
+                                $_SESSION['user_admin'] == 1 ? '' :
                                 isset($_SESSION['settings']['enable_pf_feature']) && $_SESSION['settings']['enable_pf_feature'] == 1 ? '
                                 <li><i class="fa fa-key fa-fw"></i> &nbsp;'.$LANG['home_personal_saltkey'].'
                                     <ul>

--- a/items.php
+++ b/items.php
@@ -553,9 +553,6 @@ echo '
             <div class="ui-state-highlight ui-corner-all" style="padding:10px;">
                 <img src="includes/images/lock.png" alt="" />&nbsp;<b>'.$LANG['home_personal_saltkey_info'].'</b>
                 <br />
-                <div style="text-align:center;">
-                    <u><a href="index.php">'.$LANG['home'].'</a></u>
-                </div>
             </div>
         </div>';
 

--- a/sources/items.queries.php
+++ b/sources/items.queries.php
@@ -1823,6 +1823,7 @@ if (isset($_POST['type'])) {
                     );
                 } else {
                     $items_to_display_once = "max";
+                    $where->add('i.inactif=%i', 0);
                     /*
                     if ($items_to_display_once != 'max') {
                         $query_limit = " LIMIT ".$start.",".$items_to_display_once;

--- a/sources/main.functions.php
+++ b/sources/main.functions.php
@@ -486,7 +486,7 @@ function identifyUserRights($groupesVisiblesUser, $groupesInterditsUser, $isAdmi
         // get list of readonly folders
         // rule - if one folder is set as W in one of the Role, then User has access as W
         foreach ($listAllowedFolders as $folderId) {
-            if (!in_array($folderId, $listReadOnlyFolders) || (isset($pf) && $folderId != $pf['id'])) {
+            if ((isset($pf) && $folderId != $pf['id']) || !in_array($folderId, $listReadOnlyFolders)) {
                 DB::query(
                     "SELECT *
                     FROM ".prefix_table("roles_values")."


### PR DESCRIPTION
Attempt to fix #875 by removing ldap_mode check for salt key display, hiding inactive items, and reversing the order on a permissions check. Also removed the link to the no-longer-existing 'Home' page from items.php
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/nilsteampassnet/TeamPass/pull/1007?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/nilsteampassnet/TeamPass/pull/1007'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>