### PR TITLE
fix for posix-search ldap user_not_exists problem

### DIFF
--- a/sources/identify.php
+++ b/sources/identify.php
@@ -212,7 +212,7 @@ function IdentifyUser($sentData)
         )
     );
     $counter = DB::count();
-    if ($counter == 0) {
+    if ($counter == 0 && !$ldapConnection) {
         echo '[{"value" : "error", "text":"user_not_exists"}]';
         exit;
     }
@@ -251,7 +251,7 @@ function IdentifyUser($sentData)
             prefix_table('users'),
             array(
                 'login' => $username,
-                'pw' => $password,
+                'pw' => $passwordClear,
                 'email' => "",
                 'admin' => '0',
                 'gestionnaire' => '0',


### PR DESCRIPTION
This fixes the user_not_exists problem whenever using the ldap posix search
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/nilsteampassnet/TeamPass/pull/1010?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/nilsteampassnet/TeamPass/pull/1010'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
