### PR TITLE
Added randomization of OTV IDs

### DIFF
--- a/sources/items.queries.php
+++ b/sources/items.queries.php
@@ -2710,6 +2710,22 @@ if (isset($_POST['type'])) {
                 DB::delete(prefix_table('otv'), "id=%i", $record['id']);
             }
 
+            // get a list of pre-existing otv ids
+            $existingIDs = array();
+            $rows = DB::query("SELECT id FROM ".prefix_table("otv"));
+            foreach ($rows as $record) {
+                $existingIDs[] = $record['id'];
+            }
+            
+            // generate a new otv ID - up to 8 digits
+            $newID = '';
+            srand();
+            // If the ID already exists, try again until we find an unused one.
+            while (!$newID) {
+                $randomID = mt_rand(1,99999999);
+                if (!in_array($randomID,$existingIDs)) { $newID = $randomID; }
+            }
+
             // generate session
             $pwgen = new SplClassLoader('Encryption\PwGen', '../includes/libraries');
             $pwgen->register();
@@ -2721,14 +2737,13 @@ if (isset($_POST['type'])) {
             DB::insert(
                 prefix_table("otv"),
                 array(
-                	'id' => null,
+              	    'id' => $newID,
                     'item_id' => intval($_POST['id']),
                     'timestamp' => time(),
                     'originator' => intval($_SESSION['user_id']),
                     'code' => $otv_code
                    )
             );
-            $newID = DB::insertId();
 
             $otv_session = array(
                 "code"      => $otv_code,


### PR DESCRIPTION
A small snippet was added to sources/items.queries.php from lines 2713 to 2728. The new code creates a randomized OTP identifier, instead of using the sequential one that was previously in use. If the generated random identifier already exists, we keep creating new randoms until we find one that doesn't. While this can theoretically result in a link working twice, it prevents people who get one code from using sequential numbers to find others. An additional recommendation (though not implemented here) would be to never delete used codes, just mark them inactive and refuse to display them. In this case, you might want to use a larger random number than 99999999.
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/nilsteampassnet/TeamPass/pull/1015?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/nilsteampassnet/TeamPass/pull/1015'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>