### PR TITLE
bug (added php-xml install check)

### DIFF
--- a/install/install.js
+++ b/install/install.js
@@ -55,7 +55,7 @@ function CheckPage()
             error = "Fields need to be filled in!";
         } else {
             data = '{"root_path":"'+$("#root_path").val()+'", "url_path":"'+$("#url_path").val()+'"}';
-            tasks = ["folder*install", "folder*includes", "folder*files", "folder*upload", "extension*mcrypt", "extension*mbstring", "extension*openssl", "extension*bcmath", "extension*iconv", "function*mysqli_fetch_all", "version*php", "ini*max_execution_time", "folder*includes/avatars"];
+            tasks = ["folder*install", "folder*includes", "folder*files", "folder*upload", "extension*mcrypt", "extension*mbstring", "extension*openssl", "extension*bcmath", "extension*iconv", "function*mysqli_fetch_all", "version*php", "ini*max_execution_time", "folder*includes/avatars", "extension*xml"];
             multiple = true;
         }
     }

--- a/install/install.php
+++ b/install/install.php
@@ -115,6 +115,7 @@ echo '
     <li>PHP extension "openssl" is loaded&nbsp;<span id="res2_check6"></span></li>
     <li>PHP extension "bcmath" is loaded&nbsp;<span id="res2_check7"></span></li>
     <li>PHP extension "iconv" is loaded&nbsp;<span id="res2_check8"></span></li>
+    <li>PHP extension "xml" is loaded&nbsp;<span id="res2_check13"></span></li>
     <li>PHP function "mysqli_fetch_all" is available&nbsp;<span id="res2_check9"></span></li>
     <li>PHP version is greater or equal to 5.3.0&nbsp;<span id="res2_check10"></span></li>
     <li>Execution time limit&nbsp;<span id="res2_check11"></span></li>


### PR DESCRIPTION
Added install (step 2) php-xml check as functions like "utf8_encode" are used in other files.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/nilsteampassnet/TeamPass/pull/1035%23issuecomment-139879495%22%2C%20%22https%3A//github.com/nilsteampassnet/TeamPass/pull/1035%23issuecomment-139883575%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/nilsteampassnet/TeamPass/pull/1035%23issuecomment-139879495%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Thanks%20for%20your%20pull%20request.%5Cr%5Cn%5Cr%5CnNEvertheless%20it%20seems%20that%20the%20test%20itself%20is%20missing.%20Can%20you%20provide%20it%20%3F%22%2C%20%22created_at%22%3A%20%222015-09-13T14%3A09%3A35Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1197546%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/nilsteampassnet%22%7D%7D%2C%20%7B%22body%22%3A%20%22Hello%20Nils%2C%5Cn%5CnI%20believe%20that%20is%20automatically%20passed%20to%20%5C%22install.queries.php%5C%22%20%28line%2077%29%5Cnwhich%20runs%20the%20tests%20for%20all%20extensions%3A%5Cn%5Cn%20%20%20%20%20%20%20%20%20%20%20%20if%20%28isset%28%24data%5B%27activity%27%5D%29%20%26%26%20%24data%5B%27activity%27%5D%20%3D%3D%5Cn%5C%22extension%5C%22%29%20%7B%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20if%20%28extension_loaded%28%24data%5B%27task%27%5D%29%29%20%7B%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20echo%20%27%5B%7B%5C%22error%5C%22%20%3A%20%5C%22%5C%22%2C%20%5C%22index%5C%22%20%3A%20%5C%22%27.%24_POST%5B%27index%27%5D.%27%5C%22%2C%5Cn%5C%22multiple%5C%22%20%3A%20%5C%22%27.%24_POST%5B%27multiple%27%5D.%27%5C%22%7D%5D%27%3B%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7D%20else%20%7B%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20echo%20%27%5B%7B%5C%22error%5C%22%20%3A%20%5C%22%20Extension%20%27.%24data%5B%27task%27%5D.%27%20is%20not%5Cnloaded%21%5C%22%2C%20%5C%22index%5C%22%20%3A%20%5C%22%27.%24_POST%5B%27index%27%5D.%27%5C%22%2C%20%5C%22multiple%5C%22%20%3A%5Cn%5C%22%27.%24_POST%5B%27multiple%27%5D.%27%5C%22%7D%5D%27%3B%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7D%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20break%3B%5Cn%20%20%20%20%20%20%20%20%20%20%20%20%7D%5Cn%5Cn%5CnThanks%21%5Cn%5CnOn%2013%20September%202015%20at%2015%3A09%2C%20Nils%20Laumaill%5Cu00e9%20%3Cnotifications%40github.com%3E%5Cnwrote%3A%5Cn%5Cn%3E%20Thanks%20for%20your%20pull%20request.%5Cn%3E%5Cn%3E%20NEvertheless%20it%20seems%20that%20the%20test%20itself%20is%20missing.%20Can%20you%20provide%20it%20%3F%5Cn%3E%5Cn%3E%20%5Cu2014%5Cn%3E%20Reply%20to%20this%20email%20directly%20or%20view%20it%20on%20GitHub%5Cn%3E%20%3Chttps%3A//github.com/nilsteampassnet/TeamPass/pull/1035%23issuecomment-139879495%3E%5Cn%3E%20.%5Cn%3E%5Cn%22%2C%20%22created_at%22%3A%20%222015-09-13T14%3A47%3A52Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7582422%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/pedroguima%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/nilsteampassnet/TeamPass/pull/1035#issuecomment-139879495'>General Comment</a></b>
- <a href='https://github.com/nilsteampassnet'><img border=0 src='https://avatars.githubusercontent.com/u/1197546?v=3' height=16 width=16'></a> Thanks for your pull request.
NEvertheless it seems that the test itself is missing. Can you provide it ?
- <a href='https://github.com/pedroguima'><img border=0 src='https://avatars.githubusercontent.com/u/7582422?v=3' height=16 width=16'></a> Hello Nils,
I believe that is automatically passed to "install.queries.php" (line 77)
which runs the tests for all extensions:
if (isset($data['activity']) && $data['activity'] ==
"extension") {
if (extension_loaded($data['task'])) {
echo '[{"error" : "", "index" : "'.$_POST['index'].'",
"multiple" : "'.$_POST['multiple'].'"}]';
} else {
echo '[{"error" : " Extension '.$data['task'].' is not
loaded!", "index" : "'.$_POST['index'].'", "multiple" :
"'.$_POST['multiple'].'"}]';
}
break;
}
Thanks!
On 13 September 2015 at 15:09, Nils Laumaillé <notifications@github.com>
wrote:
> Thanks for your pull request.
>
> NEvertheless it seems that the test itself is missing. Can you provide it ?
>
> —
> Reply to this email directly or view it on GitHub
> <https://github.com/nilsteampassnet/TeamPass/pull/1035#issuecomment-139879495>
> .
>


<a href='https://www.codereviewhub.com/nilsteampassnet/TeamPass/pull/1035?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/nilsteampassnet/TeamPass/pull/1035?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/nilsteampassnet/TeamPass/pull/1035'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>