### PR TITLE
Add  column during DB creation

### DIFF
--- a/install/install.queries.php
+++ b/install/install.queries.php
@@ -227,6 +227,7 @@ if (isset($_POST['type'])) {
                             `label` varchar(100) NOT NULL,
                             `description` text NOT NULL,
                             `pw` text NOT NULL,
+                            `pw_iv` text NOT NULL,
                             `url` varchar(250) DEFAULT NULL,
                             `id_tree` varchar(10) DEFAULT NULL,
                             `perso` tinyint(1) NOT null DEFAULT '0',


### PR DESCRIPTION
Column `pw_iv` is not created in table `items` during installation.
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/nilsteampassnet/TeamPass/pull/1043?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/nilsteampassnet/TeamPass/pull/1043'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>