### PR TITLE
Create next child tree in personal folder => error [fix]

### DIFF
--- a/sources/items.queries.php
+++ b/sources/items.queries.php
@@ -2950,6 +2950,7 @@ if (isset($_POST['type'])) {
             foreach ($rows as $record) {
                 $selOptionsRoles .= '<option value="'.$record['role_id'].'" class="folder_rights_role">'.$record['title'].'</option>';
                 $selEOptionsRoles .= '<option value="'.$record['role_id'].'" class="folder_rights_role_edit">'.$record['title'].'</option>';
+            }
                 $rows2 = DB::query("SELECT id, login, fonction_id FROM ".prefix_table("users")." WHERE fonction_id LIKE '%".$record['role_id']."%'");
                 foreach ($rows2 as $record2) {
                     foreach (explode(";", $record2['fonction_id']) as $role) {
@@ -2960,7 +2961,7 @@ if (isset($_POST['type'])) {
                         }
                     }
                 }
-            }
+           
 
             // export data
             $data = array(


### PR DESCRIPTION
get_refined_list_of_users  for personal folders always return null
foreach rows2 inside  null::rows1
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/nilsteampassnet/TeamPass/pull/1132?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/nilsteampassnet/TeamPass/pull/1132'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>