### PR TITLE
add ldap_search_base record for db init

### DIFF
--- a/install/install.queries.php
+++ b/install/install.queries.php
@@ -313,6 +313,7 @@ if (isset($_POST['type'])) {
                             array('admin','ldap_ssl','0'),
                             array('admin','ldap_tls','0'),
                             array('admin','ldap_elusers','0'),
+                            array('admin','ldap_search_base','0'),
                             array('admin','richtext','0'),
                             array('admin','allow_print','0'),
                             array('admin','roles_allowed_to_print','0'),


### PR DESCRIPTION
Add ldap_search_base, or the ldap search function will not work
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/nilsteampassnet/TeamPass/pull/1301?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/nilsteampassnet/TeamPass/pull/1301'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>