### PR TITLE
Wrap all non-GROUP BY columns in an aggregate function (MIN)

### DIFF
--- a/sources/items.queries.php
+++ b/sources/items.queries.php
@@ -1737,12 +1737,12 @@ if (isset($_POST['type'])) {
                         mysqli_real_escape_string($link, filter_var($items_to_display_once, FILTER_SANITIZE_NUMBER_INT));
 
                     $rows = DB::query(
-                        "SELECT i.id AS id, i.restricted_to AS restricted_to, i.perso AS perso,
-                        i.label AS label, i.description AS description, i.pw AS pw, i.login AS login,
-                        i.pw_iv AS pw_iv,
-                        i.anyone_can_modify AS anyone_can_modify, l.date AS date,
-                        n.renewal_period AS renewal_period,
-                        l.action AS log_action, l.id_user AS log_user
+                        "SELECT i.id AS id, MIN(i.restricted_to) AS restricted_to, MIN(i.perso) AS perso,
+                        MIN(i.label) AS label, MIN(i.description) AS description, MIN(i.pw) AS pw, MIN(i.login) AS login,
+                        MIN(i.pw_iv) AS pw_iv,
+                        MIN(i.anyone_can_modify) AS anyone_can_modify, l.date AS date,
+                        MIN(n.renewal_period) AS renewal_period,
+                        MIN(l.action) AS log_action, l.id_user AS log_user
                         FROM ".prefix_table("items")." AS i
                         INNER JOIN ".prefix_table("nested_tree")." AS n ON (i.id_tree = n.id)
                         INNER JOIN ".prefix_table("log_items")." AS l ON (i.id = l.id_item)
@@ -1756,12 +1756,12 @@ if (isset($_POST['type'])) {
                     $where->add('i.inactif=%i',0);
 
                     $rows = DB::query(
-                        "SELECT i.id AS id, i.restricted_to AS restricted_to, i.perso AS perso,
-                        i.label AS label, i.description AS description, i.pw AS pw, i.login AS login,
-                        i.pw_iv AS pw_iv,
-                        i.anyone_can_modify AS anyone_can_modify,l.date AS date,
-                        n.renewal_period AS renewal_period,
-                        l.action AS log_action, l.id_user AS log_user
+                        "SELECT i.id AS id, MIN(i.restricted_to) AS restricted_to, MIN(i.perso) AS perso,
+                        MIN(i.label) AS label, MIN(i.description) AS description, MIN(i.pw) AS pw, MIN(i.login) AS login,
+                        MIN(i.pw_iv) AS pw_iv,
+                        MIN(i.anyone_can_modify) AS anyone_can_modify,l.date AS date,
+                        MIN(n.renewal_period) AS renewal_period,
+                        MIN(l.action) AS log_action, l.id_user AS log_user
                         FROM ".prefix_table("items")." AS i
                         INNER JOIN ".prefix_table("nested_tree")." AS n ON (i.id_tree = n.id)
                         INNER JOIN ".prefix_table("log_items")." AS l ON (i.id = l.id_item)

--- a/sources/views.queries.php
+++ b/sources/views.queries.php
@@ -140,7 +140,7 @@ switch ($_POST['type']) {
         //ITEMS deleted
         $texte .= "<tr><td><span class='fa fa-key'></span>&nbsp;<u><b>".$LANG['email_altbody_1']."</b></u></td></tr>";
         $rows = DB::query(
-            "SELECT u.login as login, i.id as id, i.label as label, i.id_tree as id_tree, l.date as date
+            "SELECT MIN(u.login) as login, MIN(i.id) as id, MIN(i.label) as label, MIN(i.id_tree) as id_tree, MIN(l.date) as date
             FROM ".prefix_table("log_items")." as l
             INNER JOIN ".prefix_table("items")." as i ON (l.id_item=i.id)
             INNER JOIN ".prefix_table("users")." as u ON (l.id_user=u.id)


### PR DESCRIPTION
MySQL 5.7 changes the default behavior of `GROUP BY`, so all columns need to either be in the `GROUP BY` clause, or use an aggregate function.

Wrapped all the non-`GROUP BY` columns in `MIN()` to work around this without potentially breaking the group-by precedence.
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/nilsteampassnet/TeamPass/pull/1344?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/nilsteampassnet/TeamPass/pull/1344'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>