### PR TITLE
Sanitize ampersand to URL encoding  in csrfp.config

### DIFF
--- a/includes/libraries/csrfp/libs/csrf/csrfprotector.php
+++ b/includes/libraries/csrfp/libs/csrf/csrfprotector.php
@@ -397,12 +397,13 @@ if (!defined('__CSRF_PROTECTOR__')) {
             //best section to add, after <body> tag
             $buffer = preg_replace("/<body[^>]*>/", "$0 <noscript>" .self::$config['disabledJavascriptMessage'] .
                 "</noscript>", $buffer);
-
-            $hiddenInput = '<input type="hidden" id="' . CSRFP_FIELD_TOKEN_NAME.'" value="'
-                            .self::$config['CSRFP_TOKEN'] .'">' .PHP_EOL;
+            $hiddenInput = '<fieldset style="display: none"><legend>CSRF Protection</legend>' .PHP_EOL;
+            $hiddenInput .= '<input type="hidden" id="' . CSRFP_FIELD_TOKEN_NAME.'" value="'
+                            .self::$config['CSRFP_TOKEN'] .'" />' .PHP_EOL;
 
             $hiddenInput .= '<input type="hidden" id="' .CSRFP_FIELD_URLS .'" value=\''
-                            .json_encode(self::$config['verifyGetFor']) .'\'>';
+                            .json_encode(str_replace("&","%26",self::$config['verifyGetFor'])) .'\' />' .PHP_EOL;
+            $hiddenInput .= '</fieldset>';
 
             //implant hidden fields with check url information for reading in javascript
             $buffer = str_ireplace('</body>', $hiddenInput . '</body>', $buffer);


### PR DESCRIPTION
The verifyGetFor array element in
includes\libraries\csrfp\libs\csrfp.config.sample.php contains an
ampersand as part of a URL. Inserted directly into index.php HTML as a value attribute, it looks like
this:

input type="hidden" id="csrfp_hidden_data_urls"
value='["*page=items&type=duo_check*"]' 

The ampersand is parsed as the start of an HTML entity (like & nbsp;).
and breaks interpretation of the rest of the HTML element.

This value will be in every user's config file, so we can't correct it there.

This quick fix rewrites the & character with %26 which is the ampersand
url-encoded. 

This fix needs verification of functionality by users of the Duo Security page needing this hidden url rule.

Also fixed is proper closing of elements.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/nilsteampassnet/TeamPass/pull/1438%23issuecomment-243194190%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/nilsteampassnet/TeamPass/pull/1438%23issuecomment-243194190%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Correct.%5Cr%5Cn%5Cr%5CnThanks%22%2C%20%22created_at%22%3A%20%222016-08-29T17%3A32%3A05Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1197546%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/nilsteampassnet%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/nilsteampassnet/TeamPass/pull/1438#issuecomment-243194190'>General Comment</a></b>
- <a href='https://github.com/nilsteampassnet'><img border=0 src='https://avatars.githubusercontent.com/u/1197546?v=3' height=16 width=16'></a> Correct.
Thanks


<a href='https://www.codereviewhub.com/nilsteampassnet/TeamPass/pull/1438?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/nilsteampassnet/TeamPass/pull/1438?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/nilsteampassnet/TeamPass/pull/1438'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>