### PR TITLE
Reorder header css loading for correct priority

### DIFF
--- a/includes/css/passman.css
+++ b/includes/css/passman.css
@@ -153,7 +153,7 @@ float:left;
 
 .td_title{
 font-weight:bold;
-font-family: serif;
+// font-family: serif;
 min-width: 150px;
 }
 
@@ -344,12 +344,57 @@ div.dataTables_processing { z-index: 1; }
 
 .ui-color {background:#F59829 !important;}
 
-.btn-default {
-    width: 40px;
-}
-
 .round-grey {
   padding:2px 6px 2px 6px;
   font-size:9pt;
   border: 1px #f3f3f3;
+}
+
+#main_menu .btn-default {
+  width: 40px; height: 38px;
+  font-size: 13px;
+	vertical-align: center;
+  padding: 2px 0 2px 0;
+  margin: 0px;
+  top: -8px;
+  background: rgba(240,240,240,1);
+  background: -webkit-gradient(left top, left bottom, color-stop(0%, rgba(240,240,240,1)), color-stop(60%, rgba(246,246,246,1)), color-stop(100%, rgba(199,199,199,1)));
+  background: -webkit-linear-gradient(top, rgba(240,240,240,1) 0%, rgba(246,246,246,1) 60%, rgba(199,199,199,1) 100%);
+  background: linear-gradient(to bottom, rgba(240,240,240,1) 0%, rgba(236,236,236,1) 60%, rgba(199,199,199,1) 100%);
+}
+
+#main_menu > div > ul > li > i {
+  font-size: 20px ! important;
+}
+
+#main_menu > div > ul  {
+  border-radius: 4px;
+  height: 28px;
+}
+
+.ui-button-text-only .ui-button-text {
+  padding: 4px;
+}
+.ui-menu-item > i {
+  font-size: 1.6em;
+  line-height: .70em;
+  vertical-align: -20%;
+  padding: 2px 0 0 0 ;
+}
+.title .ui-button-text > i {
+  width: 1.0em;
+}
+
+.quick_menu {
+  border-radius: 4px;
+}
+.ui-menu  .ui-menu-item  {
+  padding: 1px 3px 4px 3px ;
+}
+
+.fa-bars {
+	font-size: 1.px
+	line-height: .80;
+	vertical-align: -20%;
+  margin: 3px;
 }

--- a/load.php
+++ b/load.php
@@ -19,22 +19,13 @@ if (!isset($_SESSION['CPM']) || $_SESSION['CPM'] != 1) {
 
 // Common elements
 $htmlHeaders = '
-        <link rel="stylesheet" href="includes/css/passman.css" type="text/css" />
         <link rel="stylesheet" href="includes/js/jquery-ui/jquery-ui.min.css" type="text/css" />
         <link rel="stylesheet" href="includes/js/jquery-ui/jquery-ui.structure.min.css" type="text/css" />
         <link rel="stylesheet" href="includes/js/jquery-ui/jquery-ui.theme.min.css" type="text/css" />
-        <link rel="stylesheet" href="includes/font-awesome/css/font-awesome.min.css" />
-
-        <script type="text/javascript" src="includes/js/functions.js"></script>
-
         <script type="text/javascript" src="includes/js/jquery-ui/external/jquery/jquery.js"></script>
         <script type="text/javascript" src="includes/js/jquery-ui/jquery-ui.min.js"></script>
-
-        <link rel="stylesheet" href="includes/js/tooltipster/css/tooltipster.css" />
-        <script type="text/javascript" src="includes/js/tooltipster/js/jquery.tooltipster.min.js"></script>
-
-        <script language="JavaScript" type="text/javascript" src="includes/js/simplePassMeter/simplePassMeter.js"></script>
         <script src="includes/js/jeditable/jquery.jeditable.js" type="text/javascript"></script>
+        <script type="text/javascript" src="includes/js/tooltipster/js/jquery.tooltipster.min.js"></script>
         <script type="text/javascript" src="includes/libraries/Encryption/Crypt/aes.min.js"></script>
 
         <script type="text/javascript" src="includes/libraries/Plupload/plupload.full.min.js"></script>
@@ -42,31 +33,27 @@ $htmlHeaders = '
         <link rel="stylesheet" href="includes/js/nprogress/nprogress.css" />
         <script type="text/javascript" src="includes/js/nprogress/nprogress.js"></script>';
 
+        <link rel="stylesheet" href="includes/css/passman.css" type="text/css" />';
 // For ITEMS page, load specific CSS files for treeview
 if (isset($_GET['page']) && $_GET['page'] == "items") {
     $htmlHeaders .= '
-        <link rel="stylesheet" type="text/css" href="includes/css/items.css" />
         <link rel="stylesheet" href="includes/js/jstree/themes/default/style.css" type="text/css" />
         <script type="text/javascript" src="includes/js/jstree/jstree.min.js"></script>
         <script type="text/javascript" src="includes/js/jstree/jquery.cookie.js"></script>
-
         <script type="text/javascript" src="includes/js/bgiframe/jquery.bgiframe.min.js"></script>
-
         <script type="text/javascript" src="includes/js/ckeditor/ckeditor.js"></script>
         <script type="text/javascript" src="includes/js/ckeditor/adapters/jquery.js"></script>
-
         <link rel="stylesheet" type="text/css" href="includes/js/multiselect/jquery.multiselect.css" />
         <script type="text/javascript" src="includes/js/multiselect/jquery.multiselect.min.js"></script>
         <link rel="stylesheet" type="text/css" href="includes/js/multiselect/jquery.multiselect.filter.css" />
         <script type="text/javascript" src="includes/js/multiselect/jquery.multiselect.filter.js"></script>
-
         <script type="text/javascript" src="includes/js/tinysort/jquery.tinysort.min.js"></script>
         <script type="text/javascript" src="includes/js/clipboard/clipboard.min.js"></script>
-
         <!--
         <link rel="stylesheet" href="includes/bootstrap/css/bootstrap.min.css" />
         <script src="includes/bootstrap/js/bootstrap.min.js"></script>
-        -->';
+        -->
+        <link rel="stylesheet" type="text/css" href="includes/css/items.css" />';
 } else if (isset($_GET['page']) && $_GET['page'] == "manage_settings") {
     $htmlHeaders .= '
         <link rel="stylesheet" href="includes/js/toggles/css/toggles.css" />
@@ -91,22 +78,18 @@ if (isset($_GET['page']) && $_GET['page'] == "items") {
         <script type="text/javascript" src="includes/js/datatable/js/dataTables.jqueryui.js"></script>';
 } else if (isset($_GET['page']) && ($_GET['page'] == "find" || $_GET['page'] == "kb")) {
     $htmlHeaders .= '
-        <link rel="stylesheet" type="text/css" href="includes/css/kb.css" />
-
         <script type="text/javascript" src="includes/js/ckeditor/ckeditor.js"></script>
         <script type="text/javascript" src="includes/js/ckeditor/adapters/jquery.js"></script>
-
         <link rel="stylesheet" type="text/css" href="includes/js/datatable/css/jquery.dataTables.min.css" />
         <link rel="stylesheet" type="text/css" href="includes/js/datatable/css/dataTables.jqueryui.min.css" />
         <script type="text/javascript" src="includes/js/datatable/js/jquery.dataTables.min.js"></script>
         <script type="text/javascript" src="includes/js/datatable/js/dataTables.jqueryui.min.js"></script>
-
         <link rel="stylesheet" type="text/css" href="includes/js/ui-multiselect/css/ui.multiselect.css" />
-        <script type="text/javascript" src="includes/js/ui-multiselect/js/ui.multiselect.min.js"></script>';
+        <script type="text/javascript" src="includes/js/ui-multiselect/js/ui.multiselect.min.js"></script>
+        <link rel="stylesheet" type="text/css" href="includes/css/kb.css" />';
 } else if (isset($_GET['page']) && ($_GET['page'] == "suggestion")) {
     $htmlHeaders .= '
         <link rel="stylesheet" type="text/css" href="includes/css/kb.css" />
-
         <link rel="stylesheet" type="text/css" href="includes/js/datatable/css/jquery.dataTables.min.css" />
         <link rel="stylesheet" type="text/css" href="includes/js/datatable/css/dataTables.jqueryui.min.css" />
         <script type="text/javascript" src="includes/js/datatable/js/jquery.dataTables.min.js"></script>

--- a/load.php
+++ b/load.php
@@ -26,13 +26,14 @@ $htmlHeaders = '
         <script type="text/javascript" src="includes/js/jquery-ui/jquery-ui.min.js"></script>
         <script src="includes/js/jeditable/jquery.jeditable.js" type="text/javascript"></script>
         <script type="text/javascript" src="includes/js/tooltipster/js/jquery.tooltipster.min.js"></script>
+        <link rel="stylesheet" href="includes/js/tooltipster/css/tooltipster.css" type="text/css" />
+        <script type="text/javascript" src="includes/js/simplePassMeter/simplePassMeter.js"></script>
         <script type="text/javascript" src="includes/libraries/Encryption/Crypt/aes.min.js"></script>
-
         <script type="text/javascript" src="includes/libraries/Plupload/plupload.full.min.js"></script>
-
-        <link rel="stylesheet" href="includes/js/nprogress/nprogress.css" />
-        <script type="text/javascript" src="includes/js/nprogress/nprogress.js"></script>';
-
+        <link rel="stylesheet" href="includes/js/nprogress/nprogress.css" type="text/css" />
+        <script type="text/javascript" src="includes/js/nprogress/nprogress.js"></script>
+        <script type="text/javascript" src="includes/js/functions.js"></script>
+        <link rel="stylesheet" href="includes/font-awesome/css/font-awesome.min.css" type="text/css" />
         <link rel="stylesheet" href="includes/css/passman.css" type="text/css" />';
 // For ITEMS page, load specific CSS files for treeview
 if (isset($_GET['page']) && $_GET['page'] == "items") {


### PR DESCRIPTION
TeamPass CSS file should override any CSS from libraries, but it was first in the list. The last to load has precedence.

With the order corrected, we now can do great things, like correct the appearance of menu icons and the menu bars.

![teampass-css-fix](https://cloud.githubusercontent.com/assets/1425520/18290618/0e073cd2-7439-11e6-8abc-05edd45a0151.png)

(this is just a small fix, I've already put a new main menu for TeamPass into production.)
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/nilsteampassnet/TeamPass/pull/1475?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/nilsteampassnet/TeamPass/pull/1475'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>