### PR TITLE
Fix personal folder update script for 1476

### DIFF
--- a/sources/admin.queries.php
+++ b/sources/admin.queries.php
@@ -159,21 +159,24 @@ switch ($_POST['type']) {
                    ),
                    "title=%s AND parent_id=%i", $record['id'], 0
                 );
-            }
 
-            // correct bug #1414
-            // Get an array of all folders
-            $folders = $tree->getDescendants($data['id'], false, true, true);
-            foreach ($folders as $folder) {
-                //update PF field for user
-                DB::update(
-                    prefix_table("nested_tree"),
-                    array(
-                        'personal_folder' => '1'
-                   ),
-                    "id = %i",
-                    $folder
-                );
+                // correct bug #1414
+                // Get an array of all folders
+                $folders = $tree->getDescendants($record['id'], false, true, true);
+                $file = 'bugdump.txt';
+                file_put_contents ( $file , "ID: ".$data['id']."\n", FILE_APPEND );
+                foreach ($folders as $folder) {
+                file_put_contents ( $file , "iter:".$folder."\n", FILE_APPEND );
+                 //update PF field for user
+                    DB::update(
+                        prefix_table("nested_tree"),
+                        array(
+                            'personal_folder' => '1'
+                       ),
+                        "id = %s",
+                        $folder
+                    );
+                }          
             }
         }
 

--- a/sources/admin.queries.php
+++ b/sources/admin.queries.php
@@ -163,10 +163,7 @@ switch ($_POST['type']) {
                 // correct bug #1414
                 // Get an array of all folders
                 $folders = $tree->getDescendants($record['id'], false, true, true);
-                $file = 'bugdump.txt';
-                file_put_contents ( $file , "ID: ".$data['id']."\n", FILE_APPEND );
                 foreach ($folders as $folder) {
-                file_put_contents ( $file , "iter:".$folder."\n", FILE_APPEND );
                  //update PF field for user
                     DB::update(
                         prefix_table("nested_tree"),


### PR DESCRIPTION
Only attempt resetting personal subfolders if parent exists and didn't
have to be created.

Fixes bug #1476 all folders were set to be private folders if user
without root personal folder existed.