### PR TITLE
Replace menu "bars" icon (from fontawesome) with png image

### DIFF
--- a/includes/css/passman.css
+++ b/includes/css/passman.css
@@ -395,4 +395,6 @@ div.dataTables_processing { z-index: 1; }
   display:block;
   content:url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAA8AAAANCAMAAABBwMRzAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAAAZQTFRFAAAAAAAApWe5zwAAAAJ0Uk5T/wDltzBKAAAAGUlEQVR42mJgZEAGjAwE+agAkz+w5gEEGAAggABP5U/AbAAAAABJRU5ErkJggg==');
   margin: 1px 1px 0px 1px;
+  width: 17px;
+  height: 15px;
   }

--- a/includes/css/passman.css
+++ b/includes/css/passman.css
@@ -353,7 +353,6 @@ div.dataTables_processing { z-index: 1; }
 #main_menu .btn-default {
   width: 32px; height: 26px;
   font-size: 10px;
-	vertical-align: center;
   padding: 2px 0 2px 0;
   margin: 0px;
   top: -5px;
@@ -392,9 +391,8 @@ div.dataTables_processing { z-index: 1; }
   padding: 1px 3px 4px 3px ;
 }
 
-.fa-bars {
-	font-size: 1.px
-	line-height: .80;
-	vertical-align: -20%;
-  margin: 3px;
-}
+.fa-bars:before {
+  display:block;
+  content:url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAA8AAAANCAMAAABBwMRzAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAAAZQTFRFAAAAAAAApWe5zwAAAAJ0Uk5T/wDltzBKAAAAGUlEQVR42mJgZEAGjAwE+agAkz+w5gEEGAAggABP5U/AbAAAAABJRU5ErkJggg==');
+  margin: 1px 1px 0px 1px;
+  }

--- a/includes/css/passman.css
+++ b/includes/css/passman.css
@@ -395,6 +395,6 @@ div.dataTables_processing { z-index: 1; }
   display:block;
   content:url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAA8AAAANCAMAAABBwMRzAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAAAZQTFRFAAAAAAAApWe5zwAAAAJ0Uk5T/wDltzBKAAAAGUlEQVR42mJgZEAGjAwE+agAkz+w5gEEGAAggABP5U/AbAAAAABJRU5ErkJggg==');
   margin: 1px 1px 0px 1px;
-  width: 17px;
+  width: 15px;
   height: 15px;
   }


### PR DESCRIPTION
The "hamburger" menu icon renders inconsistently and unevenly due to bad aliasing, hinting, and metrics of fontawesome at the desired size.

It is replaced in css with a png image, designed specifically for the size desired in TeamPass.

![uneven-menu-bars](https://cloud.githubusercontent.com/assets/1425520/18395057/a1d7ee5e-7671-11e6-8535-38ad256e89c5.png)

to 

![2fa-after](https://cloud.githubusercontent.com/assets/1425520/18427725/d1e51216-787e-11e6-8aaf-cb1fcaf9f3d0.png)


Ineffective css lines removed.
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/nilsteampassnet/TeamPass/pull/1487?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/nilsteampassnet/TeamPass/pull/1487'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>