### PR TITLE
Extend XHTML DTD to include HTML5 custom attribute data-toggle-on

### DIFF
--- a/index.php
+++ b/index.php
@@ -31,7 +31,11 @@ require_once('./includes/libraries/csrfp/libs/csrf/csrfprotector.php');
 csrfProtector::init();
 
 ?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"
+[
+<!ATTLIST div data-toggle-on (true|false) #IMPLIED>
+]>
 <?php
 
 $_SESSION['CPM'] = 1;


### PR DESCRIPTION
XHTML does not allow custom attributes. HTML5 allows them in the form _data-xxxx="some data"_.

These html5 custom elements were used in Teampass to set the toggle state of jQuery toggles plugin, instead of writing jQuery functions to set them.

We extend the XHTML document type definition for TeamPass, adding the definitions required for these particular elements _data-toggle-on_ used in _div_, instead of changing hundreds of lines of code.
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/nilsteampassnet/TeamPass/pull/1501?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/nilsteampassnet/TeamPass/pull/1501'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>