### PR TITLE
API table width adjustment

### DIFF
--- a/admin.settings_duo.php
+++ b/admin.settings_duo.php
@@ -100,10 +100,10 @@ td {
   cursor:pointer;
 }
 .googleauth td:nth-child(1) {
-  width: 50%;
+  width: 40%;
 }
 .googleauth td:nth-child(2) {
-  width: 50%;
+  width: 60%;
 }
 .google_enabled { ', isset($_SESSION['settings']['google_authentication']) && $_SESSION['settings']['google_authentication'] == 1 ? '' : 'display:none;', ' }
 .duo_enabled { ', isset($_SESSION['settings']['duo']) && $_SESSION['settings']['duo'] == 1 ? '' : 'display:none;', ' }


### PR DESCRIPTION
API key table on right of API settings is wider than 50%/50% set in style when enabled, but width switches back to 50% width when disabled.

Adjusted main table width so Duo toggle doesn't jump around when enabling Duo two-factor authorization.

Problem revealed with shorter language string.
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/nilsteampassnet/TeamPass/pull/1502?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/nilsteampassnet/TeamPass/pull/1502'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>