### PR TITLE
Folder and item edit dialog box language fixes

### DIFF
--- a/folders.php
+++ b/folders.php
@@ -110,15 +110,15 @@ echo '
 <div id="div_add_group" style="display:none;">
     <div id="addgroup_show_error" style="text-align:center;margin:2px;display:none;" class="ui-state-error ui-corner-all"></div>
 
-    <label for="ajouter_groupe_titre" class="label_cpm">'.$LANG['group_title'].' :</label>
+    <label for="ajouter_groupe_titre" class="label_cpm">'.$LANG['group_title'].'</label>
     <input type="text" id="ajouter_groupe_titre" class="input_text text ui-widget-content ui-corner-all" />
 
-    <label for="parent_id" class="label_cpm">'.$LANG['group_parent'].' :</label>
+    <label for="parent_id" class="label_cpm">'.$LANG['group_parent'].'</label>
     <select id="parent_id" class="input_text text ui-widget-content ui-corner-all">
 		'.$droplist.'
 	</select>
 
-    <label for="new_rep_complexite" class="label_cpm">'.$LANG['complex_asked'].' :</label>
+    <label for="new_rep_complexite" class="label_cpm">'.$LANG['complex_asked'].'</label>
     <select id="new_rep_complexite" class="input_text text ui-widget-content ui-corner-all">';
 foreach ($_SESSION['settings']['pwComplexity'] as $complex) {
     echo '<option value="'.$complex[0].'">'.$complex[1].'</option>';
@@ -126,17 +126,17 @@ foreach ($_SESSION['settings']['pwComplexity'] as $complex) {
 echo '
     </select>
 
-    <label for="add_node_renewal_period" class="label_cpm">'.$LANG['group_pw_duration'].' :</label>
+    <label for="add_node_renewal_period" class="label_cpm">'.$LANG['group_pw_duration'].'</label>
     <input type="text" id="add_node_renewal_period" value="0" class="input_text text ui-widget-content ui-corner-all" />
 
-	<label for="folder_block_creation" class="">'.$LANG['auth_creation_without_complexity'].' :</label>
+	<label for="folder_block_creation" class="">'.$LANG['auth_creation_without_complexity'].'</label>
 	<select id="folder_block_creation" class="ui-widget-content ui-corner-all">
 		<option value="0">'.$LANG['no'].'</option>
 		<option value="1">'.$LANG['yes'].'</option>
 	</select>
 
 	<div style="margin-top:10px;">
-		<label for="folder_block_modif">'.$LANG['auth_modification_without_complexity'].' :</label>
+		<label for="folder_block_modif">'.$LANG['auth_modification_without_complexity'].'</label>
 		<select id="folder_block_modif" class="ui-widget-content ui-corner-all">
 			<option value="0">'.$LANG['no'].'</option>
 			<option value="1">'.$LANG['yes'].'</option>
@@ -153,15 +153,15 @@ echo '
 <div id="div_edit_folder" style="display:none;">
     <div id="edit_folder_show_error" style="text-align:center;margin:2px;display:none;" class="ui-state-error ui-corner-all"></div>
 
-    <label for="edit_folder_title" class="label_cpm">'.$LANG['group_title'].' :</label>
+    <label for="edit_folder_title" class="label_cpm">'.$LANG['group_title'].'</label>
     <input type="text" id="edit_folder_title" class="input_text text ui-widget-content ui-corner-all" />
 
-    <label for="edit_parent_id" class="label_cpm">'.$LANG['group_parent'].' :</label>
+    <label for="edit_parent_id" class="label_cpm">'.$LANG['group_parent'].'</label>
     <select id="edit_parent_id" class="input_text text ui-widget-content ui-corner-all">'.
 		$droplist.'
     </select>
 
-    <label for="edit_folder_complexite" class="label_cpm">'.$LANG['complex_asked'].' :</label>
+    <label for="edit_folder_complexite" class="label_cpm">'.$LANG['complex_asked'].'</label>
     <select id="edit_folder_complexite" class="input_text text ui-widget-content ui-corner-all">';
 foreach ($_SESSION['settings']['pwComplexity'] as $complex) {
     echo '<option value="'.$complex[0].'">'.$complex[1].'</option>';
@@ -169,17 +169,17 @@ foreach ($_SESSION['settings']['pwComplexity'] as $complex) {
 echo '
     </select>
 
-    <label for="edit_folder_renewal_period" class="label_cpm">'.$LANG['group_pw_duration'].' :</label>
+    <label for="edit_folder_renewal_period" class="label_cpm">'.$LANG['group_pw_duration'].'</label>
     <input type="text" id="edit_folder_renewal_period" value="0" class="input_text text ui-widget-content ui-corner-all" />
 
-	<label for="edit_folder_block_creation" class="">'.$LANG['auth_creation_without_complexity'].' :</label>
+	<label for="edit_folder_block_creation" class="">'.$LANG['auth_creation_without_complexity'].'</label>
 	<select id="edit_folder_block_creation" class="ui-widget-content ui-corner-all">
 		<option value="0">'.$LANG['no'].'</option>
 		<option value="1">'.$LANG['yes'].'</option>
 	</select>
 
 	<div style="margin-top:10px;">
-		<label for="edit_folder_block_modif">'.$LANG['auth_modification_without_complexity'].' :</label>
+		<label for="edit_folder_block_modif">'.$LANG['auth_modification_without_complexity'].'</label>
 		<select id="edit_folder_block_modif" class="ui-widget-content ui-corner-all">
 			<option value="0">'.$LANG['no'].'</option>
 			<option value="1">'.$LANG['yes'].'</option>

--- a/sources/users.queries.php
+++ b/sources/users.queries.php
@@ -1070,7 +1070,7 @@ if (!empty($_POST['type'])) {
                 if ($_SESSION['is_admin'] || in_array($fonction['id'], $_SESSION['user_roles'])) {
                     if ($rowUser['isAdministratedByRole'] == $fonction['id']) $tmp = ' selected="selected"';
                     else $tmp = "";
-                    $managedBy .= '<option value="'.$fonction['id'].'"'.$tmp.'>'.$LANG['managers_of'].' "'.$fonction['title'].'</option>';
+                    $managedBy .= '<option value="'.$fonction['id'].'"'.$tmp.'>'.$LANG['managers_of'].' '.$fonction['title'].'</option>';
                 }
             }
 

--- a/users.load.php
+++ b/users.load.php
@@ -889,10 +889,13 @@ function check_domain(email)
         function(data) {
             data = $.parseJSON(data);
             $("#new_folder_role_domain").attr("disabled", "disabled");
-            if (data.folder == "not_exists" && data.role == "not_exists") {
+            if (data.folder == "not_exists" && data.role == "not_exists" && domain !="") {
                 $("#new_folder_role_domain").attr("disabled", "");
                 $("#auto_create_folder_role_span").html(domain);
                 $("#new_domain").val(domain);
+                $("#auto_create_folder_role").css('visibility', 'visible');
+            } else {
+                $("#auto_create_folder_role").css('visibility', 'hidden');
             }
             $("#ajax_loader_new_mail").hide();
         }

--- a/users.php
+++ b/users.php
@@ -163,7 +163,7 @@ if ($_SESSION['is_admin']) {
 foreach ($rolesList as $fonction) {
     if ($_SESSION['is_admin'] || in_array($fonction['id'], $_SESSION['user_roles'])) {
         echo '
-        <option value="'.$fonction['id'].'">'.$LANG['managers_of'].' "'.htmlentities($fonction['title'], ENT_QUOTES, "UTF-8").'"</option>';
+        <option value="'.$fonction['id'].'">'.$LANG['managers_of'].' '.htmlentities($fonction['title'], ENT_QUOTES, "UTF-8").'</option>';
     }
 }
 echo '
@@ -180,9 +180,9 @@ echo '
     <br />
     <input type="checkbox" id="new_personal_folder"', isset($_SESSION['settings']['enable_pf_feature']) && $_SESSION['settings']['enable_pf_feature'] == 1 ? ' checked="checked"':'', ' />
        <label for="new_personal_folder">'.$LANG['personal_folder'].'</label>
-    <div id="auto_create_folder_role">
+    <div id="auto_create_folder_role"  style="visibility:hidden;">
     <input type="checkbox" id="new_folder_role_domain" disabled="disabled" />
-    <label for="new_folder_role_domain">'.$LANG['auto_create_folder_role'].'&nbsp;`<span id="auto_create_folder_role_span"></span>`</label>
+    <label for="new_folder_role_domain">'.$LANG['auto_create_folder_role'].'&nbsp;&quot;<span id="auto_create_folder_role_span"></span>&quot;</label>
     <img id="ajax_loader_new_mail" style="display:none;" src="includes/images/ajax-loader.gif" alt="" />
     <input type="hidden" id="new_domain" />
     </div>
@@ -316,16 +316,16 @@ echo '
         </div>
     </div>
     <div style="width:100%; margin-top:10px;">
-        <label for="user_edit_functions_list" class="form_label">'.$LANG['functions'].' : </label>
+        <label for="user_edit_functions_list" class="form_label">'.$LANG['functions'].'</label>
         <select name="user_edit_functions_list" id="user_edit_functions_list" multiple="multiple"><option label="" style="display: none;"></option></select>
         <br />
-        <label for="user_edit_managedby" class="form_label" style="margin-top:10px;">'.$LANG['managed_by'].' : </label>
+        <label for="user_edit_managedby" class="form_label" style="margin-top:10px;">'.$LANG['managed_by'].'</label>
         <select name="user_edit_managedby" id="user_edit_managedby"><option label="" style="display: none;"></option></select>
         <br />
-        <label for="user_edit_auth" class="form_label" style="margin-top:10px;">'.$LANG['authorized_groups'].' : </label>
+        <label for="user_edit_auth" class="form_label" style="margin-top:10px;">'.$LANG['authorized_groups'].'</label>
         <select name="user_edit_auth" id="user_edit_auth" multiple="multiple"><option label="" style="display: none;"></option></select>
         <br />
-        <label for="user_edit_forbid" class="form_label" style="margin-top:10px;">'.$LANG['forbidden_groups'].' : </label>
+        <label for="user_edit_forbid" class="form_label" style="margin-top:10px;">'.$LANG['forbidden_groups'].'</label>
         <select name="user_edit_forbid" id="user_edit_forbid" multiple="multiple"><option label="" style="display: none;"></option></select>
         <br />
     </div>


### PR DESCRIPTION
1. In _Edit Users_,  "Managed by" "Managers of role" only had one quote character (")in front of role names, removed the unclosed quote, so there is no quote around the role name.

2. Colons (:) had an unnecessary space in front of them in some edit dialogs. Actually, the colons are _all_ unnecessary when used as labels. Removed colons from the labels in add/edit folders and add/edit items. This should improve language compatibility in non-latin and especially right-to-left languages.

3. Removed quote characters around role names in other edit boxes. Other languages may not use quotes in this way. Also, quote characters are allowed in role names, so this may confusing. HTML Markup would be better to emphasize the name, but not quickly supported in drop down menus.

4. _"Create folder and role for" domain_ option in add user is now hidden unless a new email domain is input. It is confusing if shown empty (it is confusing anyway).

5. Use HTML quot; for quotes around domain name in (4). Will commit HTML markup emphasis to the pull here, to continue eradication of quotes used in this manner.