### PR TITLE
Fix bug for upgrading old passwords

### DIFF
--- a/install/upgrade_run_encryption_pwd.php
+++ b/install/upgrade_run_encryption_pwd.php
@@ -79,7 +79,7 @@ while ($data = mysqli_fetch_array($rows)) {
         // nothing to do - last encryption protocol (#3) used
         fputs($dbgDuo, "\nItem is correctly encrypted");
     } else {
-        if (!empty($data['pw_iv'])) {
+        if (!empty($data['pw'])) {
             // check if pw encrypted with protocol #2
             $pw = decrypt($data['pw']);
             if (empty($pw)) {


### PR DESCRIPTION
We tried to update TeamPass and wondered why no password was accessible afterwards. It turned out, that no password has been updated by the upgrade script. This commit fixes the problem.
