### PR TITLE
Fix LDAP suffix Posix syntax

### DIFF
--- a/sources/admin.queries.php
+++ b/sources/admin.queries.php
@@ -2049,7 +2049,7 @@ switch ($_POST['type']) {
 
             // Posix style LDAP handles user searches a bit differently
             if ($dataReceived[0]['ldap_type'] === 'posix') {
-                $ldap_suffix = ','.$dataReceived[0]['ldap_suffix'].','.$dataReceived[0]['ldap_domain_dn'];
+                $ldap_suffix = $dataReceived[0]['ldap_suffix'].','.$dataReceived[0]['ldap_domain_dn'];
             } elseif ($dataReceived[0]['ldap_type'] === 'windows' && $ldap_suffix === '') { //Multiple Domain Names
                 $ldap_suffix = $dataReceived[0]['ldap_suffix'];
             }

--- a/sources/identify.php
+++ b/sources/identify.php
@@ -463,7 +463,7 @@ function identifyUser($sentData)
 
             // Posix style LDAP handles user searches a bit differently
             if ($_SESSION['settings']['ldap_type'] == 'posix') {
-                $ldap_suffix = ','.$_SESSION['settings']['ldap_suffix'].','.$_SESSION['settings']['ldap_domain_dn'];
+                $ldap_suffix = $_SESSION['settings']['ldap_suffix'].','.$_SESSION['settings']['ldap_domain_dn'];
             } elseif ($_SESSION['settings']['ldap_type'] == 'windows' && $ldap_suffix == '') {
                 //Multiple Domain Names
                 $ldap_suffix = $_SESSION['settings']['ldap_suffix'];


### PR DESCRIPTION
I was facing issue with LDAP auth; did a tcpdump to see what was wrong, and I saw a double , in the binddn ; with this fix it works.