### PR TITLE
Fix issue when adding existing item and duplication is not enabled

### DIFF
--- a/sources/items.queries.php
+++ b/sources/items.queries.php
@@ -390,8 +390,10 @@ if (isset($_POST['type'])) {
                 $returnValues = array("error" => "item_exists");
             }
 
-            // Update CACHE table
-            updateCacheTable("add_value", $newID);
+            // Add item to CACHE table if new item has been created
+            if($newID){
+                updateCacheTable("add_value", $newID);
+            }
 
             // Encrypt data to return
             echo prepareExchangedData($returnValues, "encode");


### PR DESCRIPTION
Adding an existing item (label) and duplication is not enabled throws a sql error : Column 'id' cannot be null