### PR TITLE
Dependency & array update in install checks

### DIFF
--- a/install/install.js
+++ b/install/install.js
@@ -47,7 +47,7 @@ function checkPage()
         } else {
             const jsonValues = {"root_path":$("#root_path").val(), "url_path":$("#url_path").val()};
             data = JSON.stringify(jsonValues);
-            tasks = ["folder*install", "folder*includes", "folder*files", "folder*upload", "extension*mcrypt", "extension*mbstring", "extension*openssl", "extension*bcmath", "extension*iconv", "extension*gd", "function*mysqli_fetch_all", "version*php", "ini*max_execution_time", "folder*includes/avatars", "extension*xml", "folder*includes/libraries/csrfp/libs", "folder*includes/libraries/csrfp/js", "folder*includes/libraries/csrfp/log", "folder*includes/config", "extension*curl"];
+            tasks = ["folder*install", "folder*includes", "folder*includes/config", "folder*includes/avatars", "folder*includes/libraries/csrfp/libs", "folder*includes/libraries/csrfp/js", "folder*includes/libraries/csrfp/log", "folder*files", "folder*upload", "extension*mcrypt", "extension*mbstring", "extension*openssl", "extension*bcmath", "extension*iconv", "extension*gd", "extension*xml", "extension*curl", "version*php", "ini*max_execution_time"];
             multiple = true;
             $("#hid_abspath").val($("#root_path").val());
             $("#hid_url_path").val($("#url_path").val());

--- a/install/install.php
+++ b/install/install.php
@@ -117,24 +117,23 @@ echo '
     <ul>
     <li>Directory "/install/" is writable&nbsp;<span id="res2_check0"></span></li>
     <li>Directory "/includes/" is writable&nbsp;<span id="res2_check1"></span></li>
-    <li>Directory "/includes/config/" is writable&nbsp;<span id="res2_check18"></span></li>
-    <li>Directory "/includes/avatars/" is writable&nbsp;<span id="res2_check13"></span></li>
-    <li>Directory "/files/" is writable&nbsp;<span id="res2_check2"></span></li>
-    <li>Directory "/upload/" is writable&nbsp;<span id="res2_check3"></span></li>
-    <li>Directory "/includes/libraries/csrfp/libs/" is writable&nbsp;<span id="res2_check15"></span></li>
-    <li>Directory "/includes/libraries/csrfp/js/" is writable&nbsp;<span id="res2_check16"></span></li>
-    <li>Directory "/includes/libraries/csrfp/log/" is writable&nbsp;<span id="res2_check17"></span></li>
-    <li>PHP extension "mcrypt" is loaded&nbsp;<span id="res2_check4"></span></li>
-    <li>PHP extension "mbstring" is loaded&nbsp;<span id="res2_check5"></span></li>
-    <li>PHP extension "openssl" is loaded&nbsp;<span id="res2_check6"></span></li>
-    <li>PHP extension "bcmath" is loaded&nbsp;<span id="res2_check7"></span></li>
-    <li>PHP extension "iconv" is loaded&nbsp;<span id="res2_check8"></span></li>
+    <li>Directory "/includes/config/" is writable&nbsp;<span id="res2_check2"></span></li>
+    <li>Directory "/includes/avatars/" is writable&nbsp;<span id="res2_check3"></span></li>
+    <li>Directory "/includes/libraries/csrfp/libs/" is writable&nbsp;<span id="res2_check4"></span></li>
+    <li>Directory "/includes/libraries/csrfp/js/" is writable&nbsp;<span id="res2_check5"></span></li>
+    <li>Directory "/includes/libraries/csrfp/log/" is writable&nbsp;<span id="res2_check6"></span></li>
+    <li>Directory "/files/" is writable&nbsp;<span id="res2_check7"></span></li>
+    <li>Directory "/upload/" is writable&nbsp;<span id="res2_check8"></span></li>
+    <li>PHP extension "mcrypt" is loaded&nbsp;<span id="res2_check9"></span></li>
+    <li>PHP extension "mbstring" is loaded&nbsp;<span id="res2_check10"></span></li>
+    <li>PHP extension "openssl" is loaded&nbsp;<span id="res2_check11"></span></li>
+    <li>PHP extension "bcmath" is loaded&nbsp;<span id="res2_check12"></span></li>
+    <li>PHP extension "iconv" is loaded&nbsp;<span id="res2_check13"></span></li>
     <li>PHP extension "xml" is loaded&nbsp;<span id="res2_check14"></span></li>
-    <li>PHP extension "gd" is loaded&nbsp;<span id="res2_check9"></span></li>
-    <li>PHP extension "curl" is loaded&nbsp;<span id="res2_check19"></span></li>
-    <li>PHP function "mysqli_fetch_all" is available&nbsp;<span id="res2_check10"></span></li>
-    <li>PHP version is greater or equal to 5.5.0&nbsp;<span id="res2_check11"></span></li>
-    <li>Execution time limit&nbsp;<span id="res2_check12"></span></li>
+    <li>PHP extension "gd" is loaded&nbsp;<span id="res2_check15"></span></li>
+    <li>PHP extension "curl" is loaded&nbsp;<span id="res2_check16"></span></li>
+    <li>PHP version is greater or equal to 5.5.0&nbsp;<span id="res2_check17"></span></li>
+    <li>Execution time limit&nbsp;<span id="res2_check18"></span></li>
     </ul>
 </div>';
 

--- a/readme.md
+++ b/readme.md
@@ -36,7 +36,6 @@ Teampass is a Collaborative Passwords Manager
   * gd
   * openssl
   * curl
-* Function 'mysqli_fetch_all'
 
 ## Usage
 


### PR DESCRIPTION
Duplicate of my original pull request #1943 after I had to do a rebase on a different branch:

mysqli_fetch_all still does not seem to be used anywhere throughout teampass. So, pull request #1406 is imho right about removing this dependency (just like the Official Requirements Page did, it isn't even listed there.

Unfortunately by only removing the specific LOC of the dependency check for this function the check-layout in the routine get's broken because the array is misordered in terms of layout-referencing. This means after removal (like in pull request #1406, which seems to be abandoned and isn't based on actual code in master) the results after the checkpoints partially belong to other lines (example: check for writable /install shows missing extension).

I removed the dependency check for mysqli_fetch_all and reorganized the install.js check-array to reflect the actual order in install.php. Should also be easier to edit or expand in the future this way.

Tested with systematic dependency breaking and checking the results on install routine.
