### PR TITLE
Make email field in new LDAP user insertion null safe

### DIFF
--- a/sources/identify.php
+++ b/sources/identify.php
@@ -621,7 +621,7 @@ function identifyUser($sentData)
             array(
                 'login' => $username,
                 'pw' => $data['pw'],
-                'email' => @$user_info_from_ad[0]['mail'][0],
+                'email' => (!@$user_info_from_ad[0]['mail'][0]) ? '' : @$user_info_from_ad[0]['mail'][0],
                 'name' => $user_info_from_ad[0]['givenname'][0],
                 'lastname' => $user_info_from_ad[0]['sn'][0],
                 'admin' => '0',


### PR DESCRIPTION
Fix for issue "Teampass fails to insert LDAP user trying to log in for the first time into teampass_users table because of null email constraint".

https://github.com/nilsteampassnet/TeamPass/issues/1963