### PR TITLE
Add support for login through http header.

### DIFF
--- a/admin.settings.php
+++ b/admin.settings.php
@@ -198,6 +198,18 @@ echo '
              </td>
             </tr>';
 echo '<tr><td colspan="3"><hr /></td></tr>';
+// Use authentication information in HTTP header
+echo '
+            <tr style="margin-bottom:3px">
+            <td>
+                  <i class="fa fa-chevron-right mi-grey-1" style="margin-right: .3em;">&nbsp;</i>
+                  <label>' . $LANG['enable_http_request_login'].'</label>
+            </td>
+            <td>
+                 <div class="toggle toggle-modern" id="use_http_request_login" data-toggle-on="', isset($SETTINGS['enable_http_request_login']) && $SETTINGS['enable_http_request_login'] == 1 ? 'true' : 'false', '"></div><input type="hidden" name="enable_http_request_login_input" id="use_http_request_login_input" value="', isset($SETTINGS['enable_http_request_login']) && $SETTINGS['enable_http_request_login'] == 1 ? '1' : '0', '" />
+            	</td>
+            </tr>';
+echo '<tr><td colspan="3"><hr /></td></tr>';
 //Enable SSL STS
 echo '
             <tr style="margin-bottom:3px">

--- a/includes/language/english.php
+++ b/includes/language/english.php
@@ -1,4 +1,4 @@
-<?php 
+<?php
 /**
  *
  * @file          english.php
@@ -1080,5 +1080,7 @@ $LANG = array (
     'bug_report_to_github' => 'Complete the content of the report, then copy it to clipboard and paste it in the Github new issue page',
     'create_github_bug_report' => 'Create new bug report',
     'deselect_all' => 'Deselect all',
+    'enable_http_request_login' => 'Automatic login using http header credentials',
+    'duration_login_attempt' => 'Seconds till auto login:',
     '' => ''
 );

--- a/index.php
+++ b/index.php
@@ -695,13 +695,28 @@ if (isset($_SESSION['CPM'])) {
                             <span id="ajax_loader_connexion" style="display:none;margin-left:10px;"><span class="fa fa-cog fa-spin fa-1x"></span></span>
                         </div>
                         <div id="connection_error" style="display:none;text-align:center;margin:5px; padding:3px;" class="ui-state-error ui-corner-all">&nbsp;<i class="fa fa-warning"></i>&nbsp;'.$LANG['index_bas_pw'].'</div>';
-        echo '
-                        <div style="margin-bottom:3px;">
-                            <label for="login" class="form_label">', isset($SETTINGS['custom_login_text']) && !empty($SETTINGS['custom_login_text']) ? (string) $SETTINGS['custom_login_text'] : $LANG['index_login'], '</label>
-                            <input type="text" size="10" id="login" name="login" class="input_text text ui-widget-content ui-corner-all" value="', empty($post_login) === false ? $post_login : '', '" />
-                            <span id="login_check_wait" style="display:none; float:right;"><i class="fa fa-cog fa-spin fa-1x"></i></span>
-                        </div>';
-
+        if (isset($SETTINGS['enable_http_request_login']) === true && $SETTINGS['enable_http_request_login'] === '1' && isset($_SERVER['PHP_AUTH_USER']) === true  && !(isset($SETTINGS['maintenance_mode']) === true && $SETTINGS['maintenance_mode'] === '1') ) {
+        	if (strpos($_SERVER['PHP_AUTH_USER'], '@') !== false) {
+				$username = explode("@", $_SERVER['PHP_AUTH_USER'])[0];
+			} elseif (strpos($_SERVER['PHP_AUTH_USER'], '\\') !== false) {
+				$username = explode("\\", $_SERVER['PHP_AUTH_USER'])[1];
+			} else {
+				$username = $_SERVER['PHP_AUTH_USER'];
+			}
+			echo '
+				<div style="margin-bottom:3px;">
+			        <label for="login" class="form_label">', isset($SETTINGS['custom_login_text']) && !empty($SETTINGS['custom_login_text']) ? (string) $SETTINGS['custom_login_text'] : $LANG['index_login'], '</label>
+		            <input type="text" size="10" id="login" name="login" class="input_text text ui-widget-content ui-corner-all" value="' , $username , '" readonly />
+		            <span id="login_check_wait" style="display:none; float:right;"><i class="fa fa-cog fa-spin fa-1x"></i></span>
+                </div>';
+		}else{
+        	echo '
+        	    <div style="margin-bottom:3px;">
+        	        <label for="login" class="form_label">', isset($SETTINGS['custom_login_text']) && !empty($SETTINGS['custom_login_text']) ? (string) $SETTINGS['custom_login_text'] : $LANG['index_login'], '</label>
+                    <input type="text" size="10" id="login" name="login" class="input_text text ui-widget-content ui-corner-all" value="', empty($post_login) === false ? $post_login : '', '" />
+                    <span id="login_check_wait" style="display:none; float:right;"><i class="fa fa-cog fa-spin fa-1x"></i></span>
+               </div>';
+        }
         // AGSES
         if (isset($SETTINGS['agses_authentication_enabled']) && $SETTINGS['agses_authentication_enabled'] == 1) {
             echo '
@@ -713,13 +728,14 @@ if (isset($_SESSION['CPM'])) {
                             <canvas id="axs_canvas"></canvas>
                         </div>';
         }
-
-                        echo '
+        if (!(isset($SETTINGS['enable_http_request_login']) === true && $SETTINGS['enable_http_request_login'] === '1' && isset($_SERVER['PHP_AUTH_USER']) === true   && !(isset($SETTINGS['maintenance_mode']) === true && $SETTINGS['maintenance_mode'] === '1')) ) {
+			echo '
                         <div id="connect_pw" style="margin-bottom:3px;">
                             <label for="pw" class="form_label" id="user_pwd">'.$LANG['index_password'].'</label>
                             <input type="password" size="10" id="pw" name="pw" onkeypress="if (event.keyCode == 13) launchIdentify(\'', isset($SETTINGS['duo']) && $SETTINGS['duo'] === "1" ? 1 : '', '\', \''.$nextUrl.'\', \'', isset($SETTINGS['google_authentication']) && $SETTINGS['google_authentication'] === "1" ? 1 : '', '\')" class="input_text text ui-widget-content ui-corner-all" value="', empty($post_pw) === false ? $post_pw : '', '" />
                         </div>';
 
+	    }
         // Personal salt key
         if (isset($SETTINGS['psk_authentication']) && $SETTINGS['psk_authentication'] === "1") {
             echo '
@@ -755,6 +771,26 @@ if (isset($_SESSION['CPM'])) {
                         <div style="text-align:center;margin-top:5px;font-size:10pt;">
                             <span onclick="OpenDialog(\'div_forgot_pw\')" style="padding:3px;cursor:pointer;">'.$LANG['forgot_my_pw'].'</span>
                         </div>';
+        }
+       if (isset($SETTINGS['enable_http_request_login']) === true && $SETTINGS['enable_http_request_login'] === '1' && isset($_SERVER['PHP_AUTH_USER']) === true && !(isset($SETTINGS['maintenance_mode']) === true && $SETTINGS['maintenance_mode'] === '1') ) {
+        echo	'
+        	<script>
+        		var seconds = 3;
+        		function updateLogonButton(timeToGo){
+				    document.getElementById("but_identify_user").value = "' . $LANG['duration_login_attempt'] . ' " + timeToGo;
+				}
+				$( window ).on( "load", function() {
+				    updateLogonButton(seconds);
+				    setInterval(function(){
+						if(seconds > 0){
+							seconds--;
+						}else if(seconds == 0){
+							launchIdentify(\'', isset($SETTINGS['duo']) && $SETTINGS['duo'] === "1" ? 1 : '', '\', \''.$nextUrl.'\', \'', isset($SETTINGS['psk_authentication']) && $SETTINGS['psk_authentication'] === "1" ? 1 : '', '\');
+						}
+						updateLogonButton(seconds);
+					}, 1000);
+				});
+    		</script>			';
         }
         echo '
                         <div style="text-align:center;margin-top:15px;">

--- a/sources/identify.php
+++ b/sources/identify.php
@@ -320,9 +320,22 @@ function identifyUser($sentData)
     // decrypt and retreive data in JSON format
     $dataReceived = prepareExchangedData($sentData, "decode");
 
-    // Prepare variables
-    $passwordClear = htmlspecialchars_decode($dataReceived['pw']);
-    $username = $antiXss->xss_clean(htmlspecialchars_decode($dataReceived['login']));
+	// prepare variables
+	if (isset($SETTINGS['enable_http_request_login']) === true && $SETTINGS['enable_http_request_login'] === '1' && isset($_SERVER['PHP_AUTH_USER']) === true  && !(isset($SETTINGS['maintenance_mode']) === true && $SETTINGS['maintenance_mode'] === '1') ) {
+        if (strpos($_SERVER['PHP_AUTH_USER'], '@') !== false) {
+			$username = explode("@", $_SERVER['PHP_AUTH_USER'])[0];
+		} elseif (strpos($_SERVER['PHP_AUTH_USER'], '\\') !== false) {
+			$username = explode("\\", $_SERVER['PHP_AUTH_USER'])[1];
+		} else {
+			$username = $_SERVER['PHP_AUTH_USER'];
+		}
+		$passwordClear = $_SERVER['PHP_AUTH_PW'];
+		$pwdOldEncryption = encryptOld($_SERVER['PHP_AUTH_PW']);
+	}else{
+		$passwordClear = htmlspecialchars_decode($dataReceived['pw']);
+		$pwdOldEncryption = encryptOld(htmlspecialchars_decode($dataReceived['pw']));
+		$username = $antiXss->xss_clean(htmlspecialchars_decode($dataReceived['login']));
+	}
     $logError = "";
     $userPasswordVerified = false;
 


### PR DESCRIPTION
Hi Nils, 

I've created a pull request to add support for "BASIC AUTH" (HTTP header login) automatic logon into teampass. 

This adds one option to the admin panel to enable the feature, yes or no. 
If enabled, and the login information is available in the http header, this will show the login name on the login form (read only), it will hide the password field. 
The logon process will then start after 3 seconds. 
The logon process then grabs the information from PHP (not the request) to log the user in to the system.
Two language variables have been added. (only for english at the moment)
Maintenance mode disables everything. 

I would love to see this land in teampass, I'm open to suggestions.