### PR TITLE
[CSV-Import] convert field to string bevore using replace()

### DIFF
--- a/includes/js/functions.js
+++ b/includes/js/functions.js
@@ -181,8 +181,8 @@ function unsanitizeString(string){
 **/
 function sanitizeString(string){
     if(string !== "" && string !== null && string !== undefined) {
-        string = string.replace(/\\/g,"&#92;").replace(/"/g,"&quot;");
-        string = string.replace(new RegExp("\\s*<script[^>]*>[\\s\\S]*?</script>\\s*","ig"), "");
+        string = string.toString().replace(/\\/g,"&#92;").replace(/"/g,"&quot;");
+        string = string.toString().replace(new RegExp("\\s*<script[^>]*>[\\s\\S]*?</script>\\s*","ig"), "");
     }
     return string;
 }


### PR DESCRIPTION
## Description
If you import this csv-file [demo-cvs.txt](https://github.com/nilsteampassnet/TeamPass/files/2198685/demo-cvs.txt) the import does stop and shows waiting:

![grafik](https://user-images.githubusercontent.com/5782951/42773347-3f94d358-892d-11e8-9f56-14bcedbb94f5.png)

## Error
![grafik](https://user-images.githubusercontent.com/5782951/42773425-73d605ba-892d-11e8-9ce3-0f40cee68433.png)

## Cause

Sometimes the values of the csv are interpreted as "number" and than the replace()-function fails, because it does not work on numbers.

![grafik](https://user-images.githubusercontent.com/5782951/42773709-600faad0-892e-11e8-8a60-fa84347a5b56.png)

## Fix
I fixed this with converting the variable `string` to string. With this fix the demo-CSV can be imported.