### PR TITLE
Api read userfolders json fix

### DIFF
--- a/api/functions.php
+++ b/api/functions.php
@@ -544,7 +544,7 @@ function restGet()
                 * READ USER FOLDERS
                 * Sends back a list of folders
                 */
-                $json = "";
+                $json = array();
                 $username = $GLOBALS['request'][2];
                 if (strcmp($username, "admin") == 0) {
                     // forbid admin access


### PR DESCRIPTION
There was a syntax error in api call read/userfolders. The variable $json should be an array, not string.