### PR TITLE
Quickly support POST, working around a security vulnerability

### DIFF
--- a/api/functions.php
+++ b/api/functions.php
@@ -359,14 +359,26 @@ function restGet()
     global $api_version;
     global $SETTINGS;
     global $link;
+    global $body;
+    global $preg_res;
 
     if (!@count($GLOBALS['request']) == 0) {
         $request_uri = $GLOBALS['_SERVER']['REQUEST_URI'];
-        preg_match('/\/api(\/index.php|)\/(.*)\?apikey=(.*)/', $request_uri, $matches);
-        if (count($matches) == 0) {
-            restError('REQUEST_SENT_NOT_UNDERSTANDABLE');
-        }
-        $GLOBALS['request'] = explode('/', $matches[2]);
+        $preg_res = preg_match('/\/api(\/index.php|)\?apikey=(.*)/', $request_uri, $matches);
+	if ($preg_res == 1 ) {
+            $body = file_get_contents("php://input");
+	    if (strlen(body) == 0) {
+                restError('EMPTY');
+            } else {
+		$GLOBALS['request'] = explode('/', $body);
+            }
+	} else {
+	    preg_match('/\/api(\/index.php|)\/(.*)\?apikey=(.*)/', $request_uri, $matches);
+            if (count($matches) == 0) {
+                restError('REQUEST_SENT_NOT_UNDERSTANDABLE');
+            }
+            $GLOBALS['request'] = explode('/', $matches[2]);
+	}
     }
 
     if (apikeyChecker($GLOBALS['apikey'])) {

--- a/api/index.php
+++ b/api/index.php
@@ -35,6 +35,9 @@ $method = $_SERVER['REQUEST_METHOD'];
 $request = explode("/", substr(@$_SERVER['PATH_INFO'], 1));
 
 switch ($method) {
+    case 'POST':
+        restGet();
+        break;
     case 'GET':
         restGet();
         break;


### PR DESCRIPTION
Quickly support POST, working around a security vulnerability that would leave passwords easily discoverable on a web server's logs.

The API has everything as a GET including **writing** new passwords. This patch very quickly adds support to POST.

Even if not accepted, please fix this issue as it's a very bad issue. BASE64 on top of values hides nothing, really.