### PR TITLE
Fix login when AD LDAP with non-expiring user passwords is used

### DIFF
--- a/sources/identify.php
+++ b/sources/identify.php
@@ -761,12 +761,6 @@ function identifyUser(
                     $ldapConnection = true;
                 }
 
-                // Is user expired?
-                if (is_array($adldap->user()->passwordExpiry($auth_username)) === false) {
-                    echo '[{"value" : "user_not_exists '.$auth_username.'", "text":""}]';
-                    exit();
-                }
-
                 // Update user's password
                 if ($ldapConnection === true) {
                     $data['pw'] = $pwdlib->createPasswordHash($passwordClear);


### PR DESCRIPTION
If the user is disabled due to password expired, LDAP bind does
not succeed, i.e. the removed code would never be effective.

You could fix this also by handling all return values from passwordExpiry but I see no reason as the LDAP bind fails when the user's password is expired or when the user is inactive (expired).