### PR TITLE
 Allow RFC2307bis group membership checks. 

### DIFF
--- a/sources/admin.queries.php
+++ b/sources/admin.queries.php
@@ -2072,7 +2072,9 @@ switch ($post_type) {
                     );
                     if (isset($dataReceived[0]['ldap_usergroup'])) {
                         $GroupRestrictionEnabled = false;
-                        $filter_group = "memberUid=".$dataReceived[0]['username'];
+
+                        $user_dn = ldap_get_entries($ldapconn, $result)[0]['dn'];
+                        $filter_group = "(|(memberUid=".$dataReceived[0]['username'].")(member=".$user_dn."))";
                         $result_group = ldap_search(
                             $ldapconn,
                             $dataReceived[0]['ldap_search_base'],

--- a/sources/identify.php
+++ b/sources/identify.php
@@ -613,8 +613,8 @@ function identifyUser(
                         // Should we restrain the search in specified user groups
                         $GroupRestrictionEnabled = false;
                         if (isset($SETTINGS['ldap_usergroup']) === true && empty($SETTINGS['ldap_usergroup']) === false) {
-                            // New way to check User's group membership
-                            $filter_group = "memberUid=".$username;
+                            // New way to check User's group membership & also allow RFC2307bis group membership
+                            $filter_group = "(|(memberUid=".$username.")(member=".$user_dn."))";
                             $result_group = ldap_search(
                                 $ldapconn,
                                 $SETTINGS['ldap_search_base'],

--- a/sources/main.functions.php
+++ b/sources/main.functions.php
@@ -2450,8 +2450,8 @@ function connectLDAP($username, $password, $SETTINGS)
                     // Should we restrain the search in specified user groups
                     $GroupRestrictionEnabled = false;
                     if (isset($SETTINGS['ldap_usergroup']) === true && empty($SETTINGS['ldap_usergroup']) === false) {
-                        // New way to check User's group membership
-                        $filter_group = "memberUid=".$username;
+                        // New way to check User's group membership & also allow RFC2307bis group membership
+                        $filter_group = "(|(memberUid=".$username.")(member=".$user_dn.")";
                         $result_group = ldap_search(
                             $ldapconn,
                             $SETTINGS['ldap_search_base'],


### PR DESCRIPTION
Group members are stored under member=<member_dn> attributes entries in each Group entity where the member belongs. This search filter allows these to be picked up as well.