### PR TITLE
Workaround for https://github.com/nilsteampassnet/TeamPass/issues/2486

### DIFF
--- a/sources/users.queries.php
+++ b/sources/users.queries.php
@@ -990,7 +990,7 @@ if (null !== filter_input(INPUT_POST, 'type', FILTER_SANITIZE_STRING)) {
                 foreach ($rows as $record) {
                     if ($_SESSION['is_admin'] === '1'
                         || (($_SESSION['user_manager'] === '1' || $_SESSION['user_can_manage_all_users'] === "1")
-                        && (in_array($record['id'], $my_functions) || $record['creator_id'] == $_SESSION['user_id']))
+                        && (in_array($record['id'], $my_functions) || in_array($record['id'], $users_functions) || $record['creator_id'] == $_SESSION['user_id']))
                     ) {
                         if (in_array($record['id'], $users_functions)) {
                             $tmp = ' selected="selected"';


### PR DESCRIPTION
Makes it so that the roles displayed in the role editing dialog for a manager will include the roles that the other party is a member of, which the manager is _not_ a member of. This avoids wiping the other roles of a user by omission.