### PR TITLE
Update Dockerfile to use $uri and $args variables

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ echo
 # Search last } and insert configuration rows before
 RUN sed -i "/^}/i \
   location /api/ {\
-          try_files $uri $uri/ /api/index.php?$args;\
+          try_files \$uri \$uri/ /api/index.php?\$args;\
   }" /etc/nginx/sites-enabled/default.conf
 
 COPY teampass-docker-start.sh /teampass-docker-start.sh


### PR DESCRIPTION
Since the Docker-Containers were having trouble with the API, the provided solution (adding the /api/ location to NGINX) solves the problem, however it was implemented wrong. Those variables have to be escaped in the Dockerfile, otherwise the value of the variable will be added (in this case a empty value).