### PR TITLE
Fix an issue for one time password changes if current user is not root

### DIFF
--- a/sources/utils.queries.php
+++ b/sources/utils.queries.php
@@ -446,7 +446,11 @@ if (null !== $post_type) {
                 } else {
                     // send ssh script for user change
                     $ret .= "<br />".$LANG['ssh_answer_from_server'].':&nbsp;<div style="margin-left:20px;font-style: italic;">';
-                    $ret_server = $ssh->exec('echo -e "'.$dataReceived['new_pwd'].'\n'.$dataReceived['new_pwd'].'" | passwd '.$dataItem['login']);
+                    if ("root" === $dataReceived['ssh_root']) {
+                        $ret_server = $ssh->exec('echo -e "'.$dataReceived['new_pwd'].'\n'.$dataReceived['new_pwd'].'" | passwd '.$dataItem['login']);
+                    } else {
+                        $ret_server = $ssh->exec('echo -e "'.$dataReceived['ssh_pwd'].'\n'.$dataReceived['new_pwd'].'\n'.$dataReceived['new_pwd'].'" | passwd '.$dataItem['login']);
+                    }
                     if (strpos($ret_server, "updated successfully") !== false) {
                         $err = false;
                     } else {


### PR DESCRIPTION
If the login user is not root, type in the current password firstly, then type in the new password.