### PR TITLE
Fix for the missing move options in the list of items

### DIFF
--- a/sources/items.queries.php
+++ b/sources/items.queries.php
@@ -2624,6 +2624,8 @@ if (null !== $post_type) {
                     }
                 }
                 
+                $accessLevel = empty($arrTmp) ? $accessLevel : max($arrTmp);
+                $uniqueLoadData['accessLevel'] = $accessLevel;
                 // check if this folder is a PF. If yes check if saltket is set
                 if ((!isset($_SESSION['user_settings']['encrypted_psk']) || empty($_SESSION['user_settings']['encrypted_psk'])) && $folderIsPf === true) {
                     $showError = "is_pf_but_no_saltkey";


### PR DESCRIPTION
In the source code of **items.queries.php** variable _$arrTmp_ is assigned an access type value for the folder, but later this variable is never used. As a result, a user who has full rights to the source and destination folders cannot transfer items between them.

I added the missing logic needed to check if item can be moved between folders.