### PR TITLE
Fix issue with database encoding in the upgrade scripts

### DIFF
--- a/install/upgrade_ajax.php
+++ b/install/upgrade_ajax.php
@@ -84,6 +84,7 @@ if (mysqli_connect(
         $database,
         $port
     );
+    $db_link->set_charset($encoding);
     $res = "Connection is successful";
 } else {
     $res = "Impossible to get connected to server. Error is: ".addslashes(mysqli_connect_error());

--- a/install/upgrade_run_2.1.26.php
+++ b/install/upgrade_run_2.1.26.php
@@ -80,6 +80,7 @@ if (mysqli_connect(
         $database,
         $port
     );
+    $db_link->set_charset($encoding);
 } else {
     $res = "Impossible to get connected to server. Error is: ".addslashes(mysqli_connect_error());
     echo '[{"finish":"1", "msg":"", "error":"Impossible to get connected to server. Error is: '.addslashes(mysqli_connect_error()).'!"}]';

--- a/install/upgrade_run_2.1.27.php
+++ b/install/upgrade_run_2.1.27.php
@@ -68,6 +68,7 @@ if (mysqli_connect(
         $database,
         $port
     );
+    $db_link->set_charset($encoding);
 } else {
     $res = "Impossible to get connected to server. Error is: ".addslashes(mysqli_connect_error());
     echo '[{"finish":"1", "msg":"", "error":"Impossible to get connected to server. Error is: '.addslashes(mysqli_connect_error()).'!"}]';

--- a/install/upgrade_run_db_original.php
+++ b/install/upgrade_run_db_original.php
@@ -131,6 +131,7 @@ if (mysqli_connect(
         $database,
         $port
     );
+    $db_link->set_charset($encoding);
 } else {
     $res = "Impossible to get connected to server. Error is: ".addslashes(mysqli_connect_error());
     echo '[{"finish":"1", "msg":"", "error":"Impossible to get connected to server. Error is: '.addslashes(mysqli_connect_error()).'!"}]';

--- a/install/upgrade_run_defuse_for_categories.php
+++ b/install/upgrade_run_defuse_for_categories.php
@@ -54,6 +54,7 @@ if (mysqli_connect(
         $database,
         $port
     );
+    $db_link->set_charset($encoding);
 } else {
     $res = "Impossible to get connected to server. Error is: ".addslashes(mysqli_connect_error());
     echo '[{"finish":"1", "error":"Impossible to get connected to server. Error is: '.addslashes(mysqli_connect_error()).'!"}]';

--- a/install/upgrade_run_defuse_for_custfields.php
+++ b/install/upgrade_run_defuse_for_custfields.php
@@ -54,6 +54,7 @@ if (mysqli_connect(
         $database,
         $port
     );
+    $db_link->set_charset($encoding);
 } else {
     $res = "Impossible to get connected to server. Error is: ".addslashes(mysqli_connect_error());
     echo '[{"finish":"1", "error":"Impossible to get connected to server. Error is: '.addslashes(mysqli_connect_error()).'!"}]';

--- a/install/upgrade_run_defuse_for_files.php
+++ b/install/upgrade_run_defuse_for_files.php
@@ -54,6 +54,7 @@ if (mysqli_connect(
         $database,
         $port
     );
+    $db_link->set_charset($encoding);
 } else {
     $res = "Impossible to get connected to server. Error is: ".addslashes(mysqli_connect_error());
     echo '[{"finish":"1", "error":"Impossible to get connected to server. Error is: '.addslashes(mysqli_connect_error()).'!"}]';

--- a/install/upgrade_run_defuse_for_files_step2.php
+++ b/install/upgrade_run_defuse_for_files_step2.php
@@ -59,6 +59,7 @@ if (mysqli_connect(
         $database,
         $port
     );
+    $db_link->set_charset($encoding);
 } else {
     $res = "Impossible to get connected to server. Error is: ".addslashes(mysqli_connect_error());
     echo '[{"finish":"1", "error":"Impossible to get connected to server. Error is: '.addslashes(mysqli_connect_error()).'!"}]';

--- a/install/upgrade_run_defuse_for_logs.php
+++ b/install/upgrade_run_defuse_for_logs.php
@@ -53,6 +53,7 @@ if (mysqli_connect(
         $database,
         $port
     );
+    $db_link->set_charset($encoding);
 } else {
     $res = "Impossible to get connected to server. Error is: ".addslashes(mysqli_connect_error());
     echo '[{"finish":"1", "error":"Impossible to get connected to server. Error is: '.addslashes(mysqli_connect_error()).'!"}]';

--- a/install/upgrade_run_defuse_for_pwds.php
+++ b/install/upgrade_run_defuse_for_pwds.php
@@ -54,6 +54,7 @@ if (mysqli_connect(
         $database,
         $port
     );
+    $db_link->set_charset($encoding);
 } else {
     $res = "Impossible to get connected to server. Error is: ".addslashes(mysqli_connect_error());
     echo '[{"finish":"1", "error":"Impossible to get connected to server. Error is: '.addslashes(mysqli_connect_error()).'!"}]';

--- a/install/upgrade_run_encryption_pwd.php
+++ b/install/upgrade_run_encryption_pwd.php
@@ -66,6 +66,7 @@ if (mysqli_connect(
         $database,
         $port
     );
+    $db_link->set_charset($encoding);
 } else {
     $res = "Impossible to get connected to server. Error is: ".addslashes(mysqli_connect_error());
     echo '[{"finish":"1", "error":"Impossible to get connected to server. Error is: '.addslashes(mysqli_connect_error()).'!"}]';

--- a/install/upgrade_run_encryption_suggestions.php
+++ b/install/upgrade_run_encryption_suggestions.php
@@ -66,6 +66,7 @@ if (mysqli_connect(
         $database,
         $port
     );
+    $db_link->set_charset($encoding);
 } else {
     $res = "Impossible to get connected to server. Error is: ".addslashes(mysqli_connect_error());
     echo '[{"finish":"1", "error":"Impossible to get connected to server. Error is: '.addslashes(mysqli_connect_error()).'!"}]';

--- a/install/upgrade_run_final.php
+++ b/install/upgrade_run_final.php
@@ -60,6 +60,7 @@ if (mysqli_connect(
         $database,
         $port
     );
+    $db_link->set_charset($encoding);
 } else {
     $res = "Impossible to get connected to server. Error is: ".addslashes(mysqli_connect_error());
     echo '[{"finish":"1", "next":"", "error":"Impossible to get connected to server. Error is: '.addslashes(mysqli_connect_error()).'!"}]';


### PR DESCRIPTION
Database encoding value from the configuration file **includes/config/settings** is ignored in teampass upgrade procedure.
The **set_charset**() method with the encoding value from the configuration file must be used during the connection to the database.