### PR TITLE
Fix: AD LDAP connection and users/groups fetching (#2936)

### DIFF
--- a/sources/ldap.queries.php
+++ b/sources/ldap.queries.php
@@ -106,7 +106,7 @@ switch ($post_type) {
         $config = [
             // Mandatory Configuration Options
             'hosts'            => [explode(",", $SETTINGS['ldap_hosts'])],
-            'base_dn'          => $SETTINGS['ldap_bdn'],
+            'base_dn'          => (isset($SETTINGS['ldap_dn_additional_user_dn']) ? $SETTINGS['ldap_dn_additional_user_dn'].',' : '').$SETTINGS['ldap_bdn'],
             'username'         => $SETTINGS['ldap_username'],
             'password'         => $SETTINGS['ldap_password'],
         
@@ -180,13 +180,12 @@ switch ($post_type) {
         }
 
         // User try to auth
-        $connection->query()
+        $userLogin = $connection->query()
             ->where($SETTINGS['ldap_user_attribute'], '=', $post_username)
             ->firstOrFail();
 
         try {
-            $connection->auth()->bind($SETTINGS['ldap_user_attribute'].'='.$post_username.','.(isset($SETTINGS['ldap_dn_additional_user_dn']) ? $SETTINGS['ldap_dn_additional_user_dn'].',' : '').$SETTINGS['ldap_bdn'], $post_password);
-
+            $connection->auth()->bind($userLogin[$SETTINGS['ldap_user_attribute']][0], $post_password);
         } catch (\LdapRecord\Auth\BindException $e) {
             $error = $e->getDetailedError();
             

--- a/sources/users.queries.php
+++ b/sources/users.queries.php
@@ -2285,7 +2285,7 @@ if (null !== $post_type) {
             $config = [
                 // Mandatory Configuration Options
                 'hosts'            => [explode(',', $SETTINGS['ldap_hosts'])],
-                'base_dn'          => $SETTINGS['ldap_bdn'],
+                'base_dn'          => (isset($SETTINGS['ldap_dn_additional_user_dn']) ? $SETTINGS['ldap_dn_additional_user_dn'].',' : '').$SETTINGS['ldap_bdn'],
                 'username'         => $SETTINGS['ldap_username'],
                 'password'         => $SETTINGS['ldap_password'],
             
@@ -2364,24 +2364,23 @@ if (null !== $post_type) {
             $teampassRoles = array();
             $adUsedAttributes = array('dn', 'mail', 'givenname', 'samaccountname', 'sn', $SETTINGS['ldap_user_attribute'], 'memberof', 'name', 'displayname', 'cn', 'shadowexpire');
 
-
             $users = $connection->query()->where([
                 ['objectclass', '=', 'top'],
                 ['objectclass', '=', 'person'],
                 ['objectclass', '=', 'organizationalperson'],
-                ['objectclass', '=', 'inetorgperson'],
             ])->get();
             
             foreach($users as $i => $adUser) {
-                //print_r($user);
+                //print_r($adUser);
 
                 // Build the list of all groups in AD
                 foreach($adUser['memberof'] as $j => $adUserGroup) {
-                    if (empty($adUserGroup) === false) {
+                    if (empty($adUserGroup) === false && $j !== "count") {
                         $adGroup = substr($adUserGroup, 3, strpos($adUserGroup, ',') - 3);
                         if (in_array($adGroup, $adRoles) === false && empty($adGroup) === false) {
                             array_push($adRoles, $adGroup);
                         }
+                        sort($adRoles);
                     }
                 }
 


### PR DESCRIPTION
I stumbled across the same problem as in issue #2936 and worked on a solution.

This PR solves not only the problem of the failing connection test, but also the non-functioning LDAP synchronization of AD users and groups.
In addition, the array containing the AD groups (for role mapping) is sorted alphabetically for a better overview.
This is especially helpful in large AD environments with a lot of groups.

I'm not sure, if this breaks other LDAP implementations, so please carefully test this PR.