### PR TITLE
Update nginx image to supported PHP version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM richarvey/nginx-php-fpm:1.9.0
+FROM richarvey/nginx-php-fpm:1.10.3
 
 # The location of the web files
 ARG VOL=/var/www/html

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,7 @@ COPY teampass-docker-start.sh /teampass-docker-start.sh
 
 # Configure nginx-php-fpm image to pull our code.
 ENV REPO_URL https://github.com/nilsteampassnet/TeamPass.git
+#ENV GIT_TAG 3.0.0.14
 
 ENTRYPOINT ["/bin/sh"]
 CMD ["/teampass-docker-start.sh"]

--- a/teampass-docker-start.sh
+++ b/teampass-docker-start.sh
@@ -2,7 +2,11 @@
 if [ ! -d ${VOL}/.git ];
 then
 	echo "Initial setup..."
-	git clone $REPO_URL ${VOL}
+	if [ -z ${GIT_TAG+x} ]; then 
+	  git clone $REPO_URL ${VOL}
+	else
+	  git clone -b $GIT_TAG $REPO_URL ${VOL}
+	fi
 	mkdir ${VOL}/sk
 	chown -Rf nginx:nginx ${VOL}
 fi


### PR DESCRIPTION
This PR will update the nginx image used to one which has a supported version of PHP. It also adds support for specifying a specific git tag when performing the initial clone.