### PR TITLE
Change default role complexity to 48 on roles_title table for inital database creation

### DIFF
--- a/install/install.queries.php
+++ b/install/install.queries.php
@@ -916,7 +916,7 @@ $SETTINGS = array (';
                         if ($tmp === 0) {
                             $mysqli_result = mysqli_query(
                                 $dbTmp,
-                                "INSERT INTO `" . $var['tbl_prefix'] . "roles_title` (`id`, `title`, `allow_pw_change`, `complexity`, `creator_id`) VALUES (NULL, 'Default', '0', '50', '0')"
+                                "INSERT INTO `" . $var['tbl_prefix'] . "roles_title` (`id`, `title`, `allow_pw_change`, `complexity`, `creator_id`) VALUES (NULL, 'Default', '0', '48', '0')"
                             );
                         }
                     } elseif ($task === 'roles_values') {


### PR DESCRIPTION
Changed default role complexity from 50 to 48 when initially creating the database so that it matches one of the complexity levels (TP_PW_STRENGTH_4), avoiding cast errors when accessing roles page in the webinterface.

Fixes #3077 