### PR TITLE
Automate Docker Build & Push

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+---
+version: 2
+updates:
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,29 @@
+---
+name: Docker Image CI
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Login to Docker Hub
+      uses: docker/login-action@v1
+      with:
+        username: imntreal@gmail.com
+        password: ${{ secrets['DOCKERHUB_TOKEN'] }}
+    - name: Extract metadata (tags, labels) for Docker
+      id: meta
+      uses: docker/metadata-action@v1
+      with:
+        images: teampass/teampass
+    - name: Build and push Docker image
+      uses: docker/build-push-action@v2
+      with:
+        context: .
+        push: true
+        tags: ${{ github['ref_name'] }}
+        labels: ${{ steps['meta']['outputs']['labels'] }}

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -13,7 +13,7 @@ jobs:
     - name: Login to Docker Hub
       uses: docker/login-action@v1
       with:
-        username: imntreal@gmail.com
+        username: ${{ secrets['DOCKERHUB_USERNAME'] }}
         password: ${{ secrets['DOCKERHUB_TOKEN'] }}
     - name: Extract metadata (tags, labels) for Docker
       id: meta


### PR DESCRIPTION
I sent an e-mail from my work account since I can't access gmail from my work PC, but if you like, you can use this PR to automatically build, and push Docker images o DockerHub on a GitHub release.

This may not make much sense except for changes to Dockerfile or the start script unless you move to a release model that includes the code in the Docker image, but you'll probably want this at some point.

You'll need to create two secrets that contain your DockerHub username (not e-mail address) and an access token from DockerHub as shown in the attached screenshot. Then, when publishing a new release, GitHub actions should automatically build and deploy an image for you
![ksnip_20220328-112330](https://user-images.githubusercontent.com/2048112/160432071-5b668c10-8794-4728-ba7f-ba96ce268c73.png)
.