### PR TITLE
Change Requirements Readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -33,7 +33,7 @@ Teampass is a Collaborative Passwords Manager
 
 * MySQL 5.7 or higher,
 * Mariadb 10.7 or higher
-* PHP 7.4 or higher,
+* PHP 8.0 or higher,
 * PHP extensions:
   * mcrypt
   * openssl


### PR DESCRIPTION
Main.function.php contains union type of declaration. It has been avaible since php 8.0
I spend my whole day to understand why it's not working :(