### PR TITLE
Update ItemController.php (API error)

### DIFF
--- a/api/Controller/Api/ItemController.php
+++ b/api/Controller/Api/ItemController.php
@@ -29,9 +29,8 @@ class ItemController extends BaseController
      * Manage case inFolder
      *
      * @param array $userData
-     * @return string
      */
-    public function inFoldersAction(array $userData): string
+    public function inFoldersAction(array $userData): void
     {
         $superGlobal = new protect\SuperGlobal\SuperGlobal();
         $strErrorDesc = '';


### PR DESCRIPTION
Change return value type of function inFoldersAction from string to void.

Similar to the issue https://github.com/nilsteampassnet/TeamPass/issues/3337#issue-1385054834

Every API GET item/inFolders generates an error:
PHP Fatal error:  Uncaught TypeError: ItemController::inFoldersAction(): Return value must be of type string, none returned in /var/www/html/TeamPass/api/Controller/Api/ItemController.php:103 
Because of this, the request returns code 500 "Internal Server Error", although it returns the response body with items.