### PR TITLE
Update POEditor link on readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -93,7 +93,7 @@ Teampass is currently available in the following languages:
 * UKRAINIAN
 * VIETNAMESE
 
-Languages strings are managed at [POEditor.com](https://poeditor.com/projects/view?id=16418).
+Languages strings are managed at [POEditor.com](https://poeditor.com/join/project?hash=0vptzClQrM).
 
 ## Licence Agreement
 


### PR DESCRIPTION
The old link did direct to a 404 page. The new link was provided in #3000. This PR just updates the link in the readme file.