### PR TITLE
Make password not appear in plain text in ldap page

### DIFF
--- a/pages/ldap.php
+++ b/pages/ldap.php
@@ -499,7 +499,7 @@ $ldap_type = $SETTINGS['ldap_type'] ?? '';
                                                 <?php echo langHdl('ldap_test_username_pwd'); ?>
                                             </div>
                                             <div class='col-4'>
-                                                <input type='text' class='form-control' id='ldap-test-config-pwd' value=''>
+                                                <input type='password' class='form-control' id='ldap-test-config-pwd' value=''>
                                             </div>
                                         </div>
                                         <div class='card mb-2 hidden info' id='ldap-test-config-results'>


### PR DESCRIPTION
This modification makes avoids having the password displayed in plain text when testing the ldap configuration in the ldap page.

It simply changes the input field type from text to password.