### PR TITLE
fix endless "in progress" bar when editing item

### DIFF
--- a/pages/items.js.php
+++ b/pages/items.js.php
@@ -3049,8 +3049,8 @@ $var['hidden_asterisk'] = '<i class="fas fa-asterisk mr-2"></i><i class="fas fa-
             // is user allowed to edit this item - overpass readonly folder
             if (typeof store.get('teampassApplication').itemsList !== 'undefined') {
                 var itemsList = JSON.parse(store.get('teampassApplication').itemsList);
-                userItemRight = itemsList[store.get('teampassItem').id].rights;
-                if (userItemRight > 40 && $('#form-item-folder option:selected').attr('disabled') === 'disabled') {
+                userItemRight = itemsList[store.get('teampassItem').id]?.rights;
+                if (userItemRight && userItemRight > 40 && $('#form-item-folder option:selected').attr('disabled') === 'disabled') {
                     $('#form-item-folder option:selected').removeAttr('disabled');
                 }
             }


### PR DESCRIPTION
Fix for bug when trying to edit an item and "In progress" bar will spin endlessly, providing the following error in console: jQuery.Deferred exception: Cannot read properties of undefined (reading 'rights') TypeError: Cannot read properties of undefined (reading 'rights') at showItemEditForm

Also possible fix for https://github.com/nilsteampassnet/TeamPass/issues/3448

