### PR TITLE
Seperated cron job and Email administrators upon any user login

### DIFF
--- a/pages/options.php
+++ b/pages/options.php
@@ -536,7 +536,17 @@ $zones = timezone_list();
                                 <input type='text' class='form-control form-control-sm' id='tasks_manager_refreshing_period' value='<?php echo isset($SETTINGS['tasks_manager_refreshing_period']) === true ? $SETTINGS['tasks_manager_refreshing_period'] : 20; ?>'>
                             </div>
                         </div>
-
+                        <div class='row mb-2 option' data-keywords="server setting cron job task email">
+                            <div class='col-10'>
+                                <?php echo langHdl('enable_backlog_mail'); ?>
+                                <small id='passwordHelpBlock' class='form-text text-muted'>
+                                    <?php echo langHdl('enable_backlog_mail'); ?>
+                                </small>
+                            </div>
+                            <div class='col-2'>
+                                <div class='toggle toggle-modern' id='enable_backlog_mail' data-toggle-on='<?php echo isset($SETTINGS['enable_backlog_mail']) && (int) $SETTINGS['enable_backlog_mail'] === 1 ? 'true' : 'false'; ?>'></div><input type='hidden' id='enable_backlog_mail_input' value='<?php echo isset($SETTINGS['enable_backlog_mail']) && (int) $SETTINGS['enable_backlog_mail'] === 1 ? '1' : '0'; ?>' />
+                            </div>
+                        </div>
                     </div>
                 </div>
 

--- a/scripts/background_tasks___sending_emails.php
+++ b/scripts/background_tasks___sending_emails.php
@@ -116,7 +116,7 @@ function sendEmailsNotSent(
     array $SETTINGS
 )
 {
-    if ((int) $SETTINGS['enable_send_email_on_user_login'] === 1) {
+    if ((int) $SETTINGS['enable_backlog_mail'] === 1) {
         $row = DB::queryFirstRow(
             'SELECT valeur FROM ' . prefixTable('misc') . ' WHERE type = %s AND intitule = %s',
             'cron',


### PR DESCRIPTION
Because i want to send all backlog emails but not get informed everytime if a new user login into the system.
So I added at cron configuration a new lever which enables sending the mail backlog or not.
Like meantioned in #2470 and #2171

Only thing which is missing is the language file.
Would be nice if you can show me how add strings into the language files via the editor, because I think I will contribute more things in the future until it is perfect for our environment.