### PR TITLE
Another fix for endless "in progress" bar when editing item

### DIFF
--- a/pages/items.js.php
+++ b/pages/items.js.php
@@ -2652,7 +2652,7 @@ $var['hidden_asterisk'] = '<i class="fas fa-asterisk mr-2"></i><i class="fas fa-
             itemsList = JSON.parse(store.get('teampassApplication').itemsList);
         }
         if (itemsList.length > 0) {
-            userItemRight = itemsList[store.get('teampassItem').id].rights;
+            userItemRight = itemsList[store.get('teampassItem').id]?.rights;
         }
 
         // Do checks
@@ -2697,7 +2697,7 @@ $var['hidden_asterisk'] = '<i class="fas fa-asterisk mr-2"></i><i class="fas fa-
                     }
                 );
                 return false;
-            } else if ($('#form-item-folder option:selected').attr('disabled') === 'disabled' && userItemRight <= 40) {
+            } else if ($('#form-item-folder option:selected').attr('disabled') === 'disabled' && userItemRight && userItemRight <= 40) {
                 // Folder is not allowed
                 toastr.remove();
                 toastr.error(


### PR DESCRIPTION
Another fix for bug when trying to edit an item and "In progress" bar will spin endlessly, providing the following error in console: jQuery.Deferred exception: Cannot read properties of undefined (reading 'rights') TypeError: Cannot read properties of undefined (reading 'rights') at showItemEditForm

Also possible fix for https://github.com/nilsteampassnet/TeamPass/issues/3448

<img width="537" alt="Bildschirm­foto 2023-03-10 um 11 51 54" src="https://user-images.githubusercontent.com/93118463/224300851-2dea6ef9-e3cb-427d-b6b0-84a5849b220b.png">

<img width="547" alt="Bildschirm­foto 2023-03-10 um 11 52 05" src="https://user-images.githubusercontent.com/93118463/224301071-52f73147-e664-4068-844b-1bad6b975285.png">
