### PR TITLE
Fix disabling admin role

### DIFF
--- a/sources/users.queries.php
+++ b/sources/users.queries.php
@@ -1430,7 +1430,7 @@ if (null !== $post_type) {
 
             // If user disables administrator role 
             // then ensure that it exists still one administrator
-            if (empty($post_is_admin) === false) {
+            if (empty($post_is_admin) === true) {
                 // count number of admins
                 $users = DB::query(
                     'SELECT id


### PR DESCRIPTION
it checked enabling action so it was impossible to enable an admin, if there was exactly one (with email and pw)