### PR TITLE
Removed base64_decode used against plaintext in downloadFile.php

### DIFF
--- a/sources/downloadFile.php
+++ b/sources/downloadFile.php
@@ -97,7 +97,7 @@ if (isset($_GET['pathIsFiles']) && (int) $get_pathIsFiles === 1) {
         decryptUserObjectKey($file_info['share_key'], $_SESSION['user']['private_key'])
     );
     // Set the filename of the download
-    $filename = basename($file_info['name'], $file_info['extension']);
+    $filename = basename($file_info['name'], '.' . $file_info['extension']);
     // Output CSV-specific headers
     header('Pragma: public');
     header('Expires: 0');

--- a/sources/downloadFile.php
+++ b/sources/downloadFile.php
@@ -97,7 +97,7 @@ if (isset($_GET['pathIsFiles']) && (int) $get_pathIsFiles === 1) {
         decryptUserObjectKey($file_info['share_key'], $_SESSION['user']['private_key'])
     );
     // Set the filename of the download
-    $filename = base64_decode(basename($file_info['name'], $file_info['extension']));
+    $filename = basename($file_info['name'], $file_info['extension']);
     // Output CSV-specific headers
     header('Pragma: public');
     header('Expires: 0');


### PR DESCRIPTION
This was resulting in either garbled filenames when trying to download attachments, or causing the server to outright refuse the download due URL-unfriendly characters.  It seems self-evident by the use of the basename() that the 'name' and 'extension' fields are stored in plaintext in the {prefix}_files table, so I can only assume this was an oversight and that it's still in the code since 3.0.0 because few people use the attachments feature.