### PR TITLE
Fix syntax error in main.functions.php

### DIFF
--- a/sources/main.functions.php
+++ b/sources/main.functions.php
@@ -4266,7 +4266,7 @@ function storeTask(
     int $is_personal_folder,
     int $folder_destination_id,
     int $item_id,
-    string $object_keys,
+    string $object_keys
 )
 {
     if (in_array($taskName, ['item_copy', 'new_item', 'update_item'])) {


### PR DESCRIPTION
Syntax error, there is a trailing "," that shouldn't be there