### PR TITLE
Syslog Item logging fix

### DIFF
--- a/sources/main.functions.php
+++ b/sources/main.functions.php
@@ -1680,7 +1680,7 @@ function logItems(
             'action=' . str_replace('at_', '', $action) .
                 ' attribute=' . str_replace('at_', '', $attribute[0]) .
                 ' itemno=' . $item_id .
-                ' user=' . is_null($login) === true ? '' : addslashes((string) $login) .
+                ' user=' . (is_null($login) === true ? '' : addslashes((string) $login)) .
                 ' itemname="' . addslashes($item_label) . '"',
             $SETTINGS['syslog_host'],
             $SETTINGS['syslog_port'],


### PR DESCRIPTION
The current syslog logs have a bug which prevents the string for being fully concatenated when the inline if is true.
By adding proper brackets the concatenation is fixed.