### PR TITLE
fix: wget raw content when downloading docker-compose.yml

### DIFF
--- a/docs/install/installation.md
+++ b/docs/install/installation.md
@@ -157,7 +157,7 @@ apt install docker.io docker-compose
 
 ### Download docker compose 
 ```
-wget https://github.com/nilsteampassnet/TeamPass/blob/master/docker-compose.yml
+wget https://raw.githubusercontent.com/nilsteampassnet/TeamPass/master/docker-compose.yml
 ```
 
 ### Modify docker-compose.yml file to suit your env (look at this values) 


### PR DESCRIPTION
Tried to wget the provided link but got the whole page instead of the file content. Had to get the raw link from Github.