### PR TITLE
No need to specify CERT_NAME.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,8 @@ services:
     environment:
       VIRTUAL_HOST: YOUR_HOSTNAME
       VIRTUAL_PORT: 80
-      CERT_NAME: YOUR_CERTIFICATE
+      # uncomment if certificate's file name doesn't match VIRTUAL_HOST
+      #CERT_NAME: YOUR_CERTIFICATE
     volumes:
       - ./teampass-html:/var/www/html
     # uncomment ports to use without proxy


### PR DESCRIPTION
Tried to install Teampass with docker-compose and custom SSL certificate but a misconception about the CERT_NAME took me days to figure out.

As said in the [jwilder/nginx-proxy dockerhub page](https://hub.docker.com/r/jwilder/nginx-proxy) at the Wildcard and SNI sections indicate: there's no need to specify a CERT_NAME variable if the VIRTUAL_HOST is a subdomain of the certificate's filename (excluding .crt extension) and even if you want to specify a CERT_NAME, it should be mentioned that:
- The filename should end with .crt
- CERT_NAME should be equal to the filename excluding the .crt extension.

e.g.

For a VIRTUAL_HOST named foo.bar.com the filename could be bar.com.crt or foo.bar.com.crt and there's no need to have a CERT_NAME. If the file name is other than one of those such as shared.crt, then CERT_NAME should be "shared".