### PR TITLE
Add short timeout to fsocksopen and use host/port of duo API.

### DIFF
--- a/includes/language/french.php
+++ b/includes/language/french.php
@@ -1178,7 +1178,7 @@ return array(
     'login_with_sso' => 'Se connecter en SSO',
     'server_connected_to_internet' => 'Serveur connecté à internet',
     'server_not_connected_to_internet' => 'Serveur non connecté à internet',
-    'server_not_connected_to_internet_tip' => 'Cela peut engendré des disfonctionnements de certaines fonctionnalités du MFA par exemple.',
+    'server_not_connected_to_internet_tip' => 'Cela peut engendrer des dysfonctionnements de certaines fonctionnalités du MFA par exemple.',
     'tools' => 'Outils',
     'user_config_not_compliant' => 'User configuration is not compliant',
     'fix_personal_items_empty' => 'Fix personal items are empty',

--- a/pages/admin.php
+++ b/pages/admin.php
@@ -300,7 +300,7 @@ catch (Exception $e) {
                         }
 
                         // Test internet access
-                        $connected = @fsockopen("www.google.com", 80); // Le site web est google et le port est 80 (HTTP)
+                        $connected = @fsockopen("api-123456.duo.com", 443, $errno, $errstr, 1); // API Duo API (MFA).
                         if ($connected){
                             fclose($connected);
                             $internetAccess = '


### PR DESCRIPTION
Issue: https://github.com/nilsteampassnet/TeamPass/issues/4204
Add 1 second timeout.
Test a more useful host/port.
Correct translation text.