### PR TITLE
Avoid break tp.config.php file with single quote in parameter value.

### DIFF
--- a/sources/admin.queries.php
+++ b/sources/admin.queries.php
@@ -2234,6 +2234,9 @@ switch ($post_type) {
             );
         }
 
+        // Avoid break tp.config.php file with ' in parameter.
+        $dataReceived['value'] = addslashes($dataReceived['value']);
+
         // store in SESSION
         $SETTINGS[$post_field] = $post_value;
 


### PR DESCRIPTION
POC:
![image](https://github.com/nilsteampassnet/TeamPass/assets/107032768/1a3bebf8-7731-4c9d-94ac-688430350cc9)

tp.config.php:
![image](https://github.com/nilsteampassnet/TeamPass/assets/107032768/fc430136-86f1-4b39-8908-8985cd659698)

HTTP 500:
![image](https://github.com/nilsteampassnet/TeamPass/assets/107032768/68138f4c-397c-4c96-9a87-86fc7bf54e1f)
