### PR TITLE
BUGFIX - Redirect on item view after authentication if an unauthenticated user opened direct link.

### DIFF
--- a/index.php
+++ b/index.php
@@ -959,9 +959,7 @@ echo '
                 
 
                 <?php
-                    if ($session_initial_url !== null && empty($session_initial_url) === false) {
-                        include $session_initial_url;
-                    } elseif ($get['page'] === 'items') {
+                    if ($get['page'] === 'items') {
                         // SHow page with Items
                         if ((int) $session_user_admin !== 1) {
                             include $SETTINGS['cpassman_dir'] . '/pages/items.php';
@@ -1089,7 +1087,6 @@ echo '
             </script>';
         exit;
     }
-    $session->set('user-initial_url', '');
     
     // LOGIN form
     include $SETTINGS['cpassman_dir'] . '/includes/core/login.php';


### PR DESCRIPTION
Open this link before auth : https://teampass.host/index.php?page=items&group=6&id=7 
We can now see this item after login without having to reopen the direct link.
