### PR TITLE
Correct email formatting

### DIFF
--- a/scripts/background_tasks___userKeysCreation_subtaskHdl.php
+++ b/scripts/background_tasks___userKeysCreation_subtaskHdl.php
@@ -61,7 +61,7 @@ $arguments = $_SERVER['argv'];
 array_shift($arguments);
 
 
-$data = [
+$inputData = [
     'subTaskId' => $_SERVER['argv'][1],
     'index' => $_SERVER['argv'][2],
     'nb' => $_SERVER['argv'][3],
@@ -78,12 +78,6 @@ $filters = [
     'taskArguments' => 'trim|strip_tags',
     'taskId' => 'trim|escape',
 ];
-
-$inputData = dataSanitizer(
-    $data,
-    $filters
-);
-
 
 $taskArgs = json_decode($inputData['taskArguments'], true);
 /*


### PR DESCRIPTION
With the latest version of teampass, emails are very difficult to read because of an XSS filter:
![image](https://github.com/user-attachments/assets/c1f5a76d-6c98-482c-bfb7-9c6d59c94a94)

These filters seem useless in this use case.

Corrected:
![image](https://github.com/user-attachments/assets/055d0284-a4f9-4232-ab7c-880e09735ab7)
