### PR TITLE
BUGFIX - Upgrade process improvement and speedup

### DIFF
--- a/includes/config/include.php
+++ b/includes/config/include.php
@@ -40,7 +40,7 @@ define('TP_ADMIN_NO_INFO', false);
 define('TP_COPYRIGHT', '2009-'.date('Y'));
 define('TP_ALLOWED_TAGS', '<b><i><sup><sub><em><strong><u><br><br /><a><strike><ul><blockquote><blockquote><img><li><h1><h2><h3><h4><h5><ol><small><font>');
 define('TP_FILE_PREFIX', 'EncryptedFile_');
-define('NUMBER_ITEMS_IN_BATCH', 100);
+define('NUMBER_ITEMS_IN_BATCH', 30000);
 define('WIP', false);
 define('UPGRADE_SEND_EMAILS', true);
 define('KEY_LENGTH', 16);

--- a/includes/config/include.php
+++ b/includes/config/include.php
@@ -40,7 +40,7 @@ define('TP_ADMIN_NO_INFO', false);
 define('TP_COPYRIGHT', '2009-'.date('Y'));
 define('TP_ALLOWED_TAGS', '<b><i><sup><sub><em><strong><u><br><br /><a><strike><ul><blockquote><blockquote><img><li><h1><h2><h3><h4><h5><ol><small><font>');
 define('TP_FILE_PREFIX', 'EncryptedFile_');
-define('NUMBER_ITEMS_IN_BATCH', 30000);
+define('NUMBER_ITEMS_IN_BATCH', 1000);
 define('WIP', false);
 define('UPGRADE_SEND_EMAILS', true);
 define('KEY_LENGTH', 16);

--- a/includes/libraries/teampassclasses/passwordmanager/src/PasswordManager.php
+++ b/includes/libraries/teampassclasses/passwordmanager/src/PasswordManager.php
@@ -62,7 +62,7 @@ class PasswordManager
         // Vérifiez si le mot de passe a été haché avec passwordlib
         if ($this->isPasswordLibHash($hashedPassword)) {
             // Utilisez la vérification de passwordlib ici
-            if ($this->passwordLibVerify($hashedPassword, $plainPassword)) {
+            if ($this->passwordLibVerify($hashedPassword, html_entity_decode($plainPassword))) {
                 // Password is valid, hash it with new system
                 $newHashedPassword = $this->hashPassword($plainPassword);
                 $userInfo['pw'] = $newHashedPassword;

--- a/install/install.queries.php
+++ b/install/install.queries.php
@@ -1311,13 +1311,14 @@ $SETTINGS = array (';
                             $dbTmp,
                             "CREATE TABLE IF NOT EXISTS `" . $var['tbl_prefix'] . "background_tasks_logs` (
                             `increment_id` int(12) NOT NULL AUTO_INCREMENT,
-                            `created_at` varchar(20) NOT NULL,
+                            `created_at` INT NOT NULL,
                             `job` varchar(50) NOT NULL,
                             `status` varchar(10) NOT NULL,
-                            `updated_at` varchar(20) DEFAULT NULL,
-                            `finished_at` varchar(20) DEFAULT NULL,
+                            `updated_at` INT DEFAULT NULL,
+                            `finished_at` INT DEFAULT NULL,
                             `treated_objects` varchar(20) DEFAULT NULL,
-                            PRIMARY KEY (`increment_id`)
+                            PRIMARY KEY (`increment_id`),
+                            INDEX idx_created_at (`created_at`)
                             ) CHARSET=utf8;"
                         );
                     } else if ($task === 'ldap_groups_roles') {

--- a/install/install.queries.php
+++ b/install/install.queries.php
@@ -472,7 +472,8 @@ if (null !== $post_type) {
                             `updated_at` varchar(30) NULL,
                             `deleted_at` varchar(30) NULL,
                             PRIMARY KEY (`id`),
-                            KEY `restricted_inactif_idx` (`restricted_to`,`inactif`)
+                            KEY `restricted_inactif_idx` (`restricted_to`,`inactif`),
+                            INDEX items_perso_id_idx (`perso`, `id`)
                             ) CHARSET=utf8;"
                         );
                     } elseif ($task === 'log_items') {
@@ -487,7 +488,8 @@ if (null !== $post_type) {
                             `raison` text NULL,
                             `old_value` MEDIUMTEXT NULL DEFAULT NULL,
                             `encryption_type` VARCHAR(20) NOT NULL DEFAULT 'not_set',
-                            PRIMARY KEY (`increment_id`)
+                            PRIMARY KEY (`increment_id`),
+                            INDEX log_items_item_action_user_idx (`id_item`, `action`, `id_user`)
                             ) CHARSET=utf8;"
                         );
                         // create index

--- a/install/install.queries.php
+++ b/install/install.queries.php
@@ -382,7 +382,8 @@ if (null !== $post_type) {
 								`object_id` int(12) NOT NULL,
 								`user_id` int(12) NOT NULL,
 								`share_key` text NOT NULL,
-								PRIMARY KEY (`increment_id`)
+								PRIMARY KEY (`increment_id`),
+                                INDEX idx_object_user (`object_id`, `user_id`)
 							) CHARSET=utf8;'
                         );
                         $mysqli_result = mysqli_query(

--- a/install/upgrade.php
+++ b/install/upgrade.php
@@ -754,7 +754,7 @@ function aesEncrypt(text)
 function manageUpgradeScripts(file_number)
 {
     var start_at = 0;
-    var noitems_by_loop = 100;
+    var noitems_by_loop = 1000;
     var loop_number = 0;
 
     if (file_number == 0) {

--- a/install/upgrade_operations.php
+++ b/install/upgrade_operations.php
@@ -73,20 +73,15 @@ $database = DB_NAME;
 $port = DB_PORT;
 $user = DB_USER;
 
-if (mysqli_connect(
-    $server,
-    $user,
-    $pass,
-    $database,
-    $port
-)) {
-    $db_link = mysqli_connect(
+if ($db_link = mysqli_connect(
         $server,
         $user,
         $pass,
         $database,
         $port
-    );
+    )
+) {
+    $db_link->set_charset(DB_ENCODING);
 } else {
     $res = 'Impossible to get connected to server. Error is: ' . addslashes(mysqli_connect_error());
     echo '[{"finish":"1", "msg":"", "error":"Impossible to get connected to server. Error is: ' . addslashes(mysqli_connect_error()) . '!"}]';

--- a/install/upgrade_operations.php
+++ b/install/upgrade_operations.php
@@ -97,6 +97,9 @@ if (isset($post_operation) === true && empty($post_operation) === false && strpo
         // ---->
         // OPERATION - 20230604_1 - generate key for item_key
 
+        // Start transaction to avoid autocommit
+        mysqli_begin_transaction($db_link, MYSQLI_TRANS_START_READ_WRITE);
+
         // Get items to treat
         $rows = mysqli_query(
             $db_link,
@@ -108,6 +111,8 @@ if (isset($post_operation) === true && empty($post_operation) === false && strpo
         // Handle error on query
         if (!$rows) {
             echo '[{"finish":"1" , "error":"'.mysqli_error($db_link).'"}]';
+            mysqli_commit($db_link);
+            mysqli_close($db_link);
             exit();
         }
 
@@ -126,6 +131,8 @@ if (isset($post_operation) === true && empty($post_operation) === false && strpo
                 );
                 if (mysqli_error($db_link)) {
                     echo '[{"finish":"1", "next":"", "error":"MySQL Error! '.addslashes(mysqli_error($db_link)).'"}]';
+                    mysqli_commit($db_link);
+                    mysqli_close($db_link);
                     exit();
                 }
             }
@@ -153,12 +160,17 @@ if (isset($post_operation) === true && empty($post_operation) === false && strpo
     }
     // Return back
     echo '[{"finish":"'.$finish.'" , "next":"", "error":"", "total":"'.$total.'"}]';
+    // Commit transaction.
+    mysqli_commit($db_link);
 }
 
 
 function populateItemsTable_CreatedAt($pre, $post_nb)
 {
     global $db_link;
+    // Start transaction to avoid autocommit
+    mysqli_begin_transaction($db_link, MYSQLI_TRANS_START_READ_WRITE);
+
     // loop on items - created_at
     $items = mysqli_query(
         $db_link,
@@ -185,12 +197,19 @@ function populateItemsTable_CreatedAt($pre, $post_nb)
             "SELECT * FROM `" . $pre . "items` WHERE created_at IS NULL"
         )
     );
+
+    // Commit transaction.
+    mysqli_commit($db_link);
+
     return $remainingItems > 0 ? 0 : 1;
 }
 
 function populateItemsTable_UpdatedAt($pre)
 {
     global $db_link;
+    // Start transaction to avoid autocommit
+    mysqli_begin_transaction($db_link, MYSQLI_TRANS_START_READ_WRITE);
+
     // loop on items - updated_at
     $items = mysqli_query(
         $db_link,
@@ -207,12 +226,18 @@ function populateItemsTable_UpdatedAt($pre)
         }
     }
 
+    // Commit transaction.
+    mysqli_commit($db_link);
+
     return 1;
 }
 
 function populateItemsTable_DeletedAt($pre)
 {
     global $db_link;
+    // Start transaction to avoid autocommit
+    mysqli_begin_transaction($db_link, MYSQLI_TRANS_START_READ_WRITE);
+
     // loop on items - deleted_at
     $items = mysqli_query(
         $db_link,
@@ -228,6 +253,9 @@ function populateItemsTable_DeletedAt($pre)
             );
         }
     }
+
+    // Commit transaction.
+    mysqli_commit($db_link);
 
     return 1;
 }
@@ -268,6 +296,9 @@ function installPurgeUnnecessaryKeys(bool $allUsers = true, int $user_id=0, stri
 function installPurgeUnnecessaryKeysForUser(int $user_id=0, string $pre)
 {
     global $db_link;
+    // Start transaction to avoid autocommit
+    mysqli_begin_transaction($db_link, MYSQLI_TRANS_START_READ_WRITE);
+
     if ($user_id === 0) {
         return;
     }
@@ -314,6 +345,9 @@ function installPurgeUnnecessaryKeysForUser(int $user_id=0, string $pre)
             WHERE object_id IN ('.$pfItemsList.') AND user_id NOT IN ('.TP_USER_ID.', '.$user_id.')'
         );
     }
+
+    // Commit transaction.
+    mysqli_commit($db_link);
 }
 
 

--- a/install/upgrade_run_3.0.0.php
+++ b/install/upgrade_run_3.0.0.php
@@ -243,7 +243,8 @@ mysqli_query(
         `object_id` int(12) NOT NULL,
         `user_id` int(12) NOT NULL,
         `share_key` text NOT NULL,
-        PRIMARY KEY (`increment_id`)
+        PRIMARY KEY (`increment_id`),
+        INDEX idx_object_user (`object_id`, `user_id`)
     ) CHARSET=utf8;'
 );
 

--- a/install/upgrade_run_3.0.0.php
+++ b/install/upgrade_run_3.0.0.php
@@ -78,20 +78,15 @@ $database = DB_NAME;
 $port = DB_PORT;
 $user = DB_USER;
 
-if (mysqli_connect(
-    $server,
-    $user,
-    $pass,
-    $database,
-    $port
-)) {
-    $db_link = mysqli_connect(
+if ($db_link = mysqli_connect(
         $server,
         $user,
         $pass,
         $database,
         $port
-    );
+    )
+) {
+    $db_link->set_charset(DB_ENCODING);
 } else {
     $res = 'Impossible to get connected to server. Error is: ' . addslashes(mysqli_connect_error());
     echo '[{"finish":"1", "msg":"", "error":"Impossible to get connected to server. Error is: ' . addslashes(mysqli_connect_error()) . '!"}]';

--- a/install/upgrade_run_3.0.0_fields.php
+++ b/install/upgrade_run_3.0.0_fields.php
@@ -69,21 +69,14 @@ $database = DB_NAME;
 $port = DB_PORT;
 $user = DB_USER;
 
-if (mysqli_connect(
-    $server,
-    $user,
-    $pass,
-    $database,
-    $port
-)
-) {
-    $db_link = mysqli_connect(
+if ($db_link = mysqli_connect(
         $server,
         $user,
         $pass,
         $database,
         $port
-    );
+    )
+) {
 	$db_link->set_charset(DB_ENCODING);
 } else {
     $res = 'Impossible to get connected to server. Error is: '.addslashes(mysqli_connect_error());

--- a/install/upgrade_run_3.0.0_fields.php
+++ b/install/upgrade_run_3.0.0_fields.php
@@ -154,7 +154,7 @@ while ($data = mysqli_fetch_array($rows)) {
         );
 
         // Encrypt with Object Key
-        $cryptedStuff = doDataEncryption($passwd['string']);
+        $cryptedStuff = doDataEncryption(html_entity_decode($passwd['string']));
 
         // Store new password in DB
         mysqli_query(

--- a/install/upgrade_run_3.0.0_files.php
+++ b/install/upgrade_run_3.0.0_files.php
@@ -74,21 +74,14 @@ $database = DB_NAME;
 $port = DB_PORT;
 $user = DB_USER;
 
-if (mysqli_connect(
-    $server,
-    $user,
-    $pass,
-    $database,
-    $port
-)
-) {
-    $db_link = mysqli_connect(
+if ($db_link = mysqli_connect(
         $server,
         $user,
         $pass,
         $database,
         $port
-    );
+    )
+) {
 	$db_link->set_charset(DB_ENCODING);
 } else {
     $res = 'Impossible to get connected to server. Error is: '.addslashes(mysqli_connect_error());

--- a/install/upgrade_run_3.0.0_logs.php
+++ b/install/upgrade_run_3.0.0_logs.php
@@ -69,7 +69,7 @@ $database = DB_NAME;
 $port = DB_PORT;
 $user = DB_USER;
 
-if (mysqli_connect(
+if ($db_link = mysqli_connect(
     $server,
     $user,
     $pass,
@@ -77,13 +77,6 @@ if (mysqli_connect(
     $port
 )
 ) {
-    $db_link = mysqli_connect(
-        $server,
-        $user,
-        $pass,
-        $database,
-        $port
-    );
 	$db_link->set_charset(DB_ENCODING);
 } else {
     $res = 'Impossible to get connected to server. Error is: '.addslashes(mysqli_connect_error());

--- a/install/upgrade_run_3.0.0_logs.php
+++ b/install/upgrade_run_3.0.0_logs.php
@@ -156,7 +156,7 @@ while ($data = mysqli_fetch_array($rows)) {
         );
 
         // Encrypt with Object Key
-        $cryptedStuff = doDataEncryption($passwd['string']);
+        $cryptedStuff = doDataEncryption(html_entity_decode($passwd['string']));
 
         // Store new password in DB
         mysqli_query(

--- a/install/upgrade_run_3.0.0_passwords.php
+++ b/install/upgrade_run_3.0.0_passwords.php
@@ -157,7 +157,7 @@ while ($data = mysqli_fetch_array($rows)) {
         );
 
         // Encrypt with Object Key
-        $cryptedStuff = doDataEncryption($passwd['string']);
+        $cryptedStuff = doDataEncryption(html_entity_decode($passwd['string']));
 
         // Store new password in DB
         mysqli_query(

--- a/install/upgrade_run_3.0.0_passwords.php
+++ b/install/upgrade_run_3.0.0_passwords.php
@@ -121,20 +121,14 @@ if (isset($userPassword) === false || empty($userPassword) === true
 }
 
 // Get total items
-$rows = mysqli_query(
+$total = mysqli_fetch_array(mysqli_query(
     $db_link,
-    'SELECT id
+    'SELECT COUNT(id)
     FROM '.$pre.'items
     WHERE perso = 0'
-);
-if (!$rows) {
-    echo '[{"finish":"1" , "error":"'.mysqli_error($db_link).'"}]';
-    exit();
-}
+))[0];
 
-$total = mysqli_num_rows($rows);
-
-// Loop on Items
+// Get items by batch
 $rows = mysqli_query(
     $db_link,
     'SELECT id, pw, encryption_type
@@ -142,10 +136,28 @@ $rows = mysqli_query(
     WHERE perso = 0
     LIMIT '.$post_start.', '.$post_nb
 );
+
+// No more items
 if (!$rows) {
     echo '[{"finish":"1" , "error":"'.mysqli_error($db_link).'"}]';
     exit();
 }
+
+// Use transaction to save 80% of execution time.
+mysqli_begin_transaction($db_link, MYSQLI_TRANS_START_READ_WRITE);
+
+// Update items statement
+$updateStmt = mysqli_prepare($db_link, '
+    UPDATE ' . $pre . 'items
+        SET pw = ?,
+            encryption_type = "teampass_aes"
+        WHERE id = ?');
+
+// Insert sharekey items statement
+$insertStmt = mysqli_prepare($db_link, "
+    INSERT INTO " . $pre . "sharekeys_items
+        (increment_id, object_id, user_id, share_key)
+        VALUES (NULL, ?, ?, ?)");
 
 while ($data = mysqli_fetch_array($rows)) {
     if ($data['encryption_type'] !== 'teampass_aes') {
@@ -158,23 +170,24 @@ while ($data = mysqli_fetch_array($rows)) {
 
         // Encrypt with Object Key
         $cryptedStuff = doDataEncryption(html_entity_decode($passwd['string']));
+        $_SESSION['items_object_keys'][$data['id']] = $cryptedStuff['objectKey'];
 
         // Store new password in DB
-        mysqli_query(
-            $db_link,
-            'UPDATE '.$pre."items
-            SET pw = '".$cryptedStuff['encrypted']."', encryption_type = 'teampass_aes'
-            WHERE id = ".$data['id']
-        );
+        mysqli_stmt_bind_param($updateStmt, 'si', $cryptedStuff['encrypted'], $data['id']);
+        mysqli_stmt_execute($updateStmt);
 
         // Insert in DB the new object key for this item by user
-        mysqli_query(
-            $db_link,
-            "INSERT INTO `".$pre."sharekeys_items` (`increment_id`, `object_id`, `user_id`, `share_key`) 
-            VALUES (NULL, '".$data['id']."', '".$userId."', '".encryptUserObjectKey($cryptedStuff['objectKey'], $userPublicKey)."');"
-        );
+        $encryptedKey = encryptUserObjectKey($cryptedStuff['objectKey'], $userPublicKey);
+        mysqli_stmt_bind_param($insertStmt, 'iis', $data['id'], $userId, $encryptedKey);
+        mysqli_stmt_execute($insertStmt);
     }
 }
+
+// Commit transaction and close db connection
+mysqli_commit($db_link);
+mysqli_stmt_close($updateStmt);
+mysqli_stmt_close($insertStmt);
+mysqli_close($db_link);
 
 if ($next >= $total) {
     $finish = 1;

--- a/install/upgrade_run_3.0.0_passwords.php
+++ b/install/upgrade_run_3.0.0_passwords.php
@@ -70,21 +70,14 @@ $database = DB_NAME;
 $port = DB_PORT;
 $user = DB_USER;
 
-if (mysqli_connect(
-    $server,
-    $user,
-    $pass,
-    $database,
-    $port
-)
-) {
-    $db_link = mysqli_connect(
+if ($db_link = mysqli_connect(
         $server,
         $user,
         $pass,
         $database,
         $port
-    );
+    )
+) {
 	$db_link->set_charset(DB_ENCODING);
 } else {
     $res = 'Impossible to get connected to server. Error is: '.addslashes(mysqli_connect_error());

--- a/install/upgrade_run_3.0.0_suggestions.php
+++ b/install/upgrade_run_3.0.0_suggestions.php
@@ -71,21 +71,14 @@ $database = DB_NAME;
 $port = DB_PORT;
 $user = DB_USER;
 
-if (mysqli_connect(
-    $server,
-    $user,
-    $pass,
-    $database,
-    $port
-)
-) {
-    $db_link = mysqli_connect(
+if ($db_link = mysqli_connect(
         $server,
         $user,
         $pass,
         $database,
         $port
-    );
+    )
+) {
 	$db_link->set_charset(DB_ENCODING);
 } else {
     $res = "Impossible to get connected to server. Error is: ".addslashes(mysqli_connect_error());

--- a/install/upgrade_run_3.0.0_suggestions.php
+++ b/install/upgrade_run_3.0.0_suggestions.php
@@ -160,7 +160,7 @@ while ($data = mysqli_fetch_array($rows)) {
         );
 
         // Encrypt with Object Key
-        $cryptedStuff = doDataEncryption($passwd['string']);
+        $cryptedStuff = doDataEncryption(html_entity_decode($passwd['string']));
 
         // Store new password in DB
         mysqli_query(

--- a/install/upgrade_run_3.0.0_users.php
+++ b/install/upgrade_run_3.0.0_users.php
@@ -71,21 +71,14 @@ $database = DB_NAME;
 $port = DB_PORT;
 $user = DB_USER;
 
-if (mysqli_connect(
-    $server,
-    $user,
-    $pass,
-    $database,
-    $port
-)
-) {
-    $db_link = mysqli_connect(
+if ($db_link = mysqli_connect(
         $server,
         $user,
         $pass,
         $database,
         $port
-    );
+    )
+) {
     $db_link->set_charset(DB_ENCODING);
 } else {
     $res = 'Impossible to get connected to server. Error is: ' . addslashes(mysqli_connect_error());

--- a/install/upgrade_run_3.0.php
+++ b/install/upgrade_run_3.0.php
@@ -62,20 +62,15 @@ $database = DB_NAME;
 $port = DB_PORT;
 $user = DB_USER;
 
-if (mysqli_connect(
-    $server,
-    $user,
-    $pass,
-    $database,
-    $port
-)) {
-    $db_link = mysqli_connect(
+if ($db_link = mysqli_connect(
         $server,
         $user,
         $pass,
         $database,
         $port
-    );
+    )
+) {
+    $db_link->set_charset(DB_ENCODING);
 } else {
     $res = 'Impossible to get connected to server. Error is: ' . addslashes(mysqli_connect_error());
     echo '[{"finish":"1", "msg":"", "error":"Impossible to get connected to server. Error is: ' . addslashes(mysqli_connect_error()) . '!"}]';

--- a/install/upgrade_run_3.1.php
+++ b/install/upgrade_run_3.1.php
@@ -60,20 +60,15 @@ $database = DB_NAME;
 $port = DB_PORT;
 $user = DB_USER;
 
-if (mysqli_connect(
-    $server,
-    $user,
-    $pass,
-    $database,
-    $port
-)) {
-    $db_link = mysqli_connect(
+if ($db_link = mysqli_connect(
         $server,
         $user,
         $pass,
         $database,
         $port
-    );
+    )
+) {
+    $db_link->set_charset(DB_ENCODING);
 } else {
     $res = 'Impossible to get connected to server. Error is: ' . addslashes(mysqli_connect_error());
     echo '[{"finish":"1", "msg":"", "error":"Impossible to get connected to server. Error is: ' . addslashes(mysqli_connect_error()) . '!"}]';

--- a/install/upgrade_run_3.1.php
+++ b/install/upgrade_run_3.1.php
@@ -368,6 +368,18 @@ if ($result) {
     }
 }
 
+// Add field allowed_to_create to api table
+$res = addColumnIfNotExist(
+    $pre . 'api',
+    'allowed_to_read',
+    "INT(1) NOT NULL DEFAULT '0';"
+);
+if ($res === false) {
+    echo '[{"finish":"1", "msg":"", "error":"An error appears when adding field allowed_to_read to table api! ' . mysqli_error($db_link) . '!"}]';
+    mysqli_close($db_link);
+    exit();
+}
+
 // Alter type for column 'allowed_to_read' in table api
 modifyColumn(
     $pre . 'api',

--- a/install/upgrade_run_3.1.php
+++ b/install/upgrade_run_3.1.php
@@ -450,6 +450,34 @@ try {
     mysqli_rollback($db_link);
 }
 
+// Add index on items.
+try {
+    $alter_table_query = "
+        ALTER TABLE `" . $pre . "items`
+        ADD INDEX items_perso_id_idx (`perso`, `id`)
+    ";
+    mysqli_begin_transaction($db_link);
+    mysqli_query($db_link, $alter_table_query);
+    mysqli_commit($db_link);
+} catch (Exception $e) {
+    // Rollback transaction if index already exists.
+    mysqli_rollback($db_link);
+}
+
+// Add index on log_items.
+try {
+    $alter_table_query = "
+        ALTER TABLE `" . $pre . "log_items`
+        ADD INDEX log_items_item_action_user_idx (`id_item`, `action`, `id_user`)
+    ";
+    mysqli_begin_transaction($db_link);
+    mysqli_query($db_link, $alter_table_query);
+    mysqli_commit($db_link);
+} catch (Exception $e) {
+    // Rollback transaction if index already exists.
+    mysqli_rollback($db_link);
+}
+
 //---<END 3.1.3
 
 //---------------------------------------------------------------------

--- a/install/upgrade_run_3.1.php
+++ b/install/upgrade_run_3.1.php
@@ -424,6 +424,20 @@ try {
     mysqli_rollback($db_link);
 }
 
+// Add index on sharekeys_items.
+try {
+    $alter_table_query = "
+        ALTER TABLE `" . $pre . "sharekeys_items`
+        ADD INDEX idx_object_user (`object_id`, `user_id`)
+    ";
+    mysqli_begin_transaction($db_link);
+    mysqli_query($db_link, $alter_table_query);
+    mysqli_commit($db_link);
+} catch (Exception $e) {
+    // Rollback transaction if index already exists.
+    mysqli_rollback($db_link);
+}
+
 //---<END 3.1.3
 
 //---------------------------------------------------------------------

--- a/install/upgrade_run_3.1.php
+++ b/install/upgrade_run_3.1.php
@@ -405,6 +405,27 @@ if (intval($tmp) === 0) {
 //---<END 3.1.2
 
 
+//--->BEGIN 3.1.2
+
+// Add index and change created/updated/finished_at type.
+try {
+    $alter_table_query = "
+        ALTER TABLE `" . $pre . "background_tasks_logs`
+        ADD INDEX idx_created_at (`created_at`),
+        MODIFY `created_at` INT,
+        MODIFY `updated_at` INT,
+        MODIFY `finished_at` INT
+    ";
+    mysqli_begin_transaction($db_link);
+    mysqli_query($db_link, $alter_table_query);
+    mysqli_commit($db_link);
+} catch (Exception $e) {
+    // Rollback transaction if index already exists.
+    mysqli_rollback($db_link);
+}
+
+//---<END 3.1.3
+
 //---------------------------------------------------------------------
 
 

--- a/scripts/background_tasks___userKeysCreation_subtaskHdl.php
+++ b/scripts/background_tasks___userKeysCreation_subtaskHdl.php
@@ -305,7 +305,10 @@ function cronContinueReEncryptingUserSharekeysStep20(
     // get user private key
     $ownerInfo = getOwnerInfo($extra_arguments['owner_id'], $extra_arguments['creator_pwd'], $SETTINGS);
     $userInfo = getOwnerInfo($extra_arguments['new_user_id'], $extra_arguments['new_user_pwd'], $SETTINGS);
-    
+
+    // Start transaction for better performance
+    DB::startTransaction();
+
     // Loop on items
     $rows = DB::query(
         'SELECT id, pw, perso
@@ -381,6 +384,9 @@ function cronContinueReEncryptingUserSharekeysStep20(
         'SELECT *
         FROM ' . prefixTable('items')
     );
+
+    // Commit transaction
+    DB::commit();
 
     $next_start = (int) $post_start + (int) $post_length;
     return [

--- a/sources/main.queries.php
+++ b/sources/main.queries.php
@@ -2747,7 +2747,7 @@ function migrateTo3_DoUserPersonalItemsEncryption(
                     );
 
                     // Encrypt with Object Key
-                    $cryptedStuff = doDataEncryption($passwd['string']);
+                    $cryptedStuff = doDataEncryption(html_entity_decode($passwd['string']));
 
                     // Store new password in DB
                     DB::update(

--- a/vendor/teampassclasses/passwordmanager/src/PasswordManager.php
+++ b/vendor/teampassclasses/passwordmanager/src/PasswordManager.php
@@ -62,7 +62,7 @@ class PasswordManager
         // Vérifiez si le mot de passe a été haché avec passwordlib
         if ($this->isPasswordLibHash($hashedPassword)) {
             // Utilisez la vérification de passwordlib ici
-            if ($this->passwordLibVerify($hashedPassword, $plainPassword)) {
+            if ($this->passwordLibVerify($hashedPassword, html_entity_decode($plainPassword))) {
                 // Password is valid, hash it with new system
                 $newHashedPassword = $this->hashPassword($plainPassword);
                 $userInfo['pw'] = $newHashedPassword;


### PR DESCRIPTION
**Fix db_link initialization :**
![image](https://github.com/user-attachments/assets/d538abfc-37a1-4477-a709-f35563b7842f)

**Improve scheduler performance :** see issue #4210

**Improve scheduler performance on sharekeys_items generation:** Reduce CPU load keys and generation time.

**Fix TP2 -> TP3 password encoding:**
TP2 :
![Capture d'écran 2024-07-16 114710](https://github.com/user-attachments/assets/89b13162-5e40-4bfc-a245-b32d173b4308)
Json sent to frontend :
![Capture d'écran 2024-07-16 114655](https://github.com/user-attachments/assets/30bc9783-62f5-4da5-b0ae-7c08aea00959)

TP3 :
![Capture d'écran 2024-07-16 115027](https://github.com/user-attachments/assets/690ce340-0a2d-44ab-a3fb-26cbab828ba3)
Same json :
![Capture d'écran 2024-07-16 115007](https://github.com/user-attachments/assets/bcea2932-11fe-4120-88f2-523d045f66ab)

The migration process must absolutely change the password storage strategy.

**Do not sanitize one time codes which may contain & (avoid amp;):**
This is a key generated during upgrade: r&igVj&8kMfOQ&k1
With FILTER_SANITIZE_FULL_SPECIAL_CHARS, '&' becomes '&amp;amp;' and code check fails:
![image](https://github.com/user-attachments/assets/1a79f5fa-94f4-4921-ac4d-f4150fceba21)

**Fix user password migration v2 to v3:**
Users with special characters (&, €, ...) on their personal passwords cannot log back into teampass after upgrade.
We must undo HTML encoding in the migration process.

**Improve v2 -> v3 migration times.**
About 85% time saving during a TP2 to TP3 migration:
- MySQL queries improvements (about 30% time saved):
  - Limit mysql queries in large loops.
  - Use bulk inserts or transactions (avoid autocommit) to speed up.
  - Select count(PK) instead of reporting unnecessary data.
- Increase the number of items processed at a time to reduce the number of requests and avoid browser OutOfMemory (between 15 and 20% time saved - need less than 1 second to process 1000 items).
- Use PHP sessions to keep key items and not decrypt them in each loop (11.5s/1000 items to 1.2s/1000 items -> more than 70% of global time saved).

With my smallest teampass instance of around 5000 items and 30 users, I went from 42 minutes and x seconds of migration to 5 minutes 43 seconds.

**Add composite index on sharekeys_items for big instances.**
For a very big teampass instance (about 600 users / 27 000 items), we need an additional index.
Before:
```sql
mysql> SELECT COUNT(items.id) FROM teampass_items AS items LEFT JOIN teampass_sharekeys_items AS sharekeys_items ON items.id = sharekeys_items.object_id AND sharekeys_items.user_id = 1 WHERE items.perso = 0 LIMIT 0, 30000;
+-----------------+
| COUNT(items.id) |
+-----------------+
|           20141 |
+-----------------+
1 row in set (42,65 sec)

mysql> explain SELECT items.id, items.pw, items.encryption_type, sharekeys_items.share_key FROM teampass_items AS items LEFT JOIN teampass_sharekeys_items AS sharekeys_items ON items.id = sharekeys_items.object_id AND sharekeys_items.user_id = 1 WHERE items.perso = 0 LIMIT 0, 30000;
+----+-------------+-----------------+------------+------+---------------+--------+---------+---------------------+-------+----------+-------------+
| id | select_type | table           | partitions | type | possible_keys | key    | key_len | ref                 | rows  | filtered | Extra       |
+----+-------------+-----------------+------------+------+---------------+--------+---------+---------------------+-------+----------+-------------+
|  1 | SIMPLE      | items           | NULL       | ALL  | NULL          | NULL   | NULL    | NULL                | 25459 |    10.00 | Using where |
|  1 | SIMPLE      | sharekeys_items | NULL       | ref  | OBJECT,USER   | OBJECT | 4       | teampassdb.items.id |   205 |   100.00 | Using where |
+----+-------------+-----------------+------------+------+---------------+--------+---------+---------------------+-------+----------+-------------+
2 rows in set, 1 warning (0,00 sec)
```
After:
```sql
mysql> CREATE INDEX idx_object_user ON teampass_sharekeys_items(object_id, user_id);
Query OK, 0 rows affected (31,65 sec)
Records: 0  Duplicates: 0  Warnings: 0

mysql> explain SELECT items.id, items.pw, items.encryption_type, sharekeys_items.share_key FROM teampass_items AS items LEFT JOIN teampass_sharekeys_items AS sharekeys_items ON items.id = sharekeys_items.object_id AND sharekeys_items.user_id = 1 WHERE items.perso = 0 LIMIT 0, 30000;
+----+-------------+-----------------+------------+------+-----------------------------+-----------------+---------+---------------------------+-------+----------+-------------+
| id | select_type | table           | partitions | type | possible_keys               | key             | key_len | ref                       | rows  | filtered | Extra       |
+----+-------------+-----------------+------------+------+-----------------------------+-----------------+---------+---------------------------+-------+----------+-------------+
|  1 | SIMPLE      | items           | NULL       | ALL  | NULL                        | NULL            | NULL    | NULL                      | 25459 |    10.00 | Using where |
|  1 | SIMPLE      | sharekeys_items | NULL       | ref  | OBJECT,USER,idx_object_user | idx_object_user | 8       | teampassdb.items.id,const |     1 |   100.00 | NULL        |
+----+-------------+-----------------+------------+------+-----------------------------+-----------------+---------+---------------------------+-------+----------+-------------+
2 rows in set, 1 warning (0,01 sec)

mysql> SELECT COUNT(items.id) FROM teampass_items AS items LEFT JOIN teampass_sharekeys_items AS sharekeys_items ON items.id = sharekeys_items.object_id AND sharekeys_items.user_id = 1 WHERE items.perso = 0 LIMIT 0, 30000;
+-----------------+
| COUNT(items.id) |
+-----------------+
|           20141 |
+-----------------+
1 row in set (0,11 sec)
```

**Add index to improve create personal folder scheduler:**
Personal folder scheduled hourly, index added betwen 10h and 11h:
![image](https://github.com/user-attachments/assets/f1777cb9-e028-40a7-8ad5-705f02c7f432)

Before:
```sql
 mysql> explain SELECT id
    ->         FROM teampass_items AS i
    ->         INNER JOIN teampass_log_items AS li ON li.id_item = i.id
    ->         WHERE i.perso = 1 AND li.action = "at_creation" AND li.id_user IN (10000063, 9999997);
+----+-------------+-------+------------+------+--------------------------------+--------------------------------+---------+-----------------+-------+----------+-------------+
| id | select_type | table | partitions | type | possible_keys                  | key                            | key_len | ref             | rows  | filtered | Extra       |
+----+-------------+-------+------------+------+--------------------------------+--------------------------------+---------+-----------------+-------+----------+-------------+
|  1 | SIMPLE      | i     | NULL       | ALL  | PRIMARY                        | NULL                           | NULL    | NULL            | 24394 |    10.00 | Using where |
|  1 | SIMPLE      | li    | NULL       | ref  | teampass_log_items_id_item_IDX | teampass_log_items_id_item_IDX | 4       | teampassdb.i.id |    73 |     2.00 | Using where |
+----+-------------+-------+------------+------+--------------------------------+--------------------------------+---------+-----------------+-------+----------+-------------+
2 rows in set, 1 warning (0,00 sec) 
```
After:
```sql
mysql> explain SELECT id
    ->         FROM teampass_items AS i
    ->         INNER JOIN teampass_log_items AS li ON li.id_item = i.id
    ->         WHERE i.perso = 1 AND li.action = "at_creation" AND li.id_user IN (10000281, 9999997);
+----+-------------+-------+------------+------+---------------------------------------------------------------+--------------------------------+---------+-----------------------+------+----------+--------------------------+
| id | select_type | table | partitions | type | possible_keys                                                 | key                            | key_len | ref                   | rows | filtered | Extra                    |
+----+-------------+-------+------------+------+---------------------------------------------------------------+--------------------------------+---------+-----------------------+------+----------+--------------------------+
|  1 | SIMPLE      | i     | NULL       | ref  | PRIMARY,items_perso_id_idx                                    | items_perso_id_idx             | 1       | const                 | 7180 |   100.00 | Using index              |
|  1 | SIMPLE      | li    | NULL       | ref  | teampass_log_items_id_item_IDX,log_items_item_action_user_idx | log_items_item_action_user_idx | 757     | teampassdb.i.id,const |   11 |    20.00 | Using where; Using index |
+----+-------------+-------+------------+------+---------------------------------------------------------------+--------------------------------+---------+-----------------------+------+----------+--------------------------+
2 rows in set, 1 warning (0,00 sec)
```

Let each request from 0.5s to 0s.