### PR TITLE
Avoid bypass maximum_session_expiration_time parameter.

### DIFF
--- a/sources/identify.php
+++ b/sources/identify.php
@@ -543,7 +543,10 @@ function identifyUser(string $sentData, array $SETTINGS): bool
             $username,
             $SETTINGS,
         );
-        $lifetime = time() + ($dataReceived['duree_session'] * 60);
+        // Avoid unlimited session.
+        $max_time = $SETTINGS['maximum_session_expiration_time'] ?? 60;
+        $session_time = $dataReceived['duree_session'] <= $max_time ? $dataReceived['duree_session'] : $max_time;
+        $lifetime = time() + ($session_time * 60);
 
         //--- Handle the session duration and ID
         //$cookieParams = session_get_cookie_params();


### PR DESCRIPTION
Actually, user can bypass maximum_session_expiration_time parameter on login page:
![image](https://github.com/user-attachments/assets/eed88225-1950-47e3-8669-5b46ffc73bd9)

![image](https://github.com/user-attachments/assets/cff5d99e-244d-4bd0-8f88-1f092f8b2885)

End of session timestamp: 7723553611 -> Saturday 1 October 2214 23:33:31 GMT