### PR TITLE
BUGFIX - Fixing email content wrongly escaped and broken on mail client

### DIFF
--- a/sources/main.functions.php
+++ b/sources/main.functions.php
@@ -1254,10 +1254,14 @@ function buildEmail(
             $mail->addAddress($dest);
         }
         
+        // Check the email content to make sure it is safe
+        $textMailClean = $antiXss->xss_clean($textMail);
+        $textMailClean = htmlspecialchars($textMailClean, ENT_QUOTES, 'UTF-8');
+        if ($antiXss->isXssFound()) {
+            $textMail = $textMailClean;
+        }
         // Prepare HTML and AltBody
         $text_html = emailBody($textMail);
-        $text_html = $antiXss->xss_clean($text_html);
-        $text_html = htmlspecialchars($text_html, ENT_QUOTES, 'UTF-8');
         $mail->WordWrap = 80;
         $mail->isHtml(true);
         $mail->Subject = $subject;


### PR DESCRIPTION
After installing TeamPass _(version 3.1.2.60, PHP 8.2.20, Mysql 8.0.35)_, I discovered that the mails are broken.

### The issue : 

I tested with a manual Apache + PHP Installation on a VM and also with the provided `docker-compose` configuration.

I also verify in multiple client and the issue is the same everywhere.

All the HTML of the email is escaped so the mail client is displaying the whole escaped and non interpreted HTML.

Here is a screenshot on Gmail of the issue : 
![365093698-8f90ce42-db14-4e54-acbc-7c52dadcfebf](https://github.com/user-attachments/assets/387efe07-2c90-441f-b678-a849a606c2cc)
As you can see Gmail displays the "Raw" and escaped HTML.

There related opened issue here : https://github.com/nilsteampassnet/TeamPass/issues/4299

### Analysis of the root cause : 

The issue seems to be introduced here : https://github.com/nilsteampassnet/TeamPass/commit/7822610bfbd1cf871ba2056ee2295ec5e6a2053c on the 3.1.2.57 version.

In the file `sources/main.functions.php` lines 1261 & 1262, two instructions where added : 
```php
$text_html = $antiXss->xss_clean($text_html);
$text_html = htmlspecialchars($text_html, ENT_QUOTES, 'UTF-8');
```

So the whole email HTML, including the static templates generated by the `emailBody()` function is escaped.
Regarding this, the mail could not be displayed properly in any client.

### Proposed solution :

In this PR i implemented two things to fix the issue : 

1. Use the `AntiXSS::isXssFound()` method to verify is there is an XSS malicious part and do the escaping only in this case.
2. Apply the escape only on the `$textMail` content, because the email template generated by the `emailBody()` function is hard coded in the codebase and is safe.