### PR TITLE
BUGFIX - Escaping email inner content only when necessary

### DIFF
--- a/sources/main.functions.php
+++ b/sources/main.functions.php
@@ -1239,7 +1239,11 @@ class EmailSettings
 function sanitizeEmailBody($textMail, $antiXss): string
 {
     $textMailClean = $antiXss->xss_clean($textMail);
-    return htmlspecialchars($textMailClean, ENT_QUOTES, 'UTF-8');
+    if ($antiXss->isXssFound()) {
+        return htmlspecialchars($textMailClean, ENT_QUOTES, 'UTF-8');
+    }
+
+    return $textMail;
 }
 
 


### PR DESCRIPTION
In TeamPass (version 3.1.2.69, PHP 8.2.20, Mysql 8.0.35), I discovered that the mails inner variable content is broken if it is some HTML.

In the code the email variable content is systemically escaped in this function : 

```php
function sanitizeEmailBody($textMail, $antiXss): string
{
    $textMailClean = $antiXss->xss_clean($textMail);
    return htmlspecialchars($textMailClean, ENT_QUOTES, 'UTF-8');
}
```

Some emails `$textMail` is just some text so the issue is not visible. But with some emails, as the one to reset google auth TOTP the  `$textMail` is some html, so it will appear broken in the mail client.

> The issue was introduced in this commit : https://github.com/nilsteampassnet/TeamPass/commit/5d26774682023c40c70aa7925f83f8a993bf53ec in the 3.1.2.69 version.

Here is a screenshot of the issue : 
![image](https://github.com/user-attachments/assets/6629fe60-72da-4bb4-90e8-d668ec5b13c2)
As you can see the email template from `emailBody()` function is correctly displayed but not the inner content from `$textMail`

In this PR i fixes the issue by adding a condition in the `sanitizeEmailBody()` function to escape the content only in the case of a malicious XSS injection is detected.
