### PR TITLE
Highlight selected/favorites items and reverse default limited-search value

### DIFF
--- a/includes/language/french.php
+++ b/includes/language/french.php
@@ -261,7 +261,7 @@ return array(
     'expected_complexity_level' => 'Niveau de complexité requis',
     'your_attention_is_required' => 'Merci de votre attention',
     'favorite' => 'Favori',
-    'unfavorite' => 'Non favori',
+    'unfavorite' => 'Retirer favori',
     'you_need_to_select_at_least_one_folder' => 'Vous devez sélectionner au moins un répertoire',
     'no_value_defined_please_fix' => 'Aucune valeur définie ! Vous devriez le faire.',
     'apply' => 'Appliquer',

--- a/pages/items.js.php
+++ b/pages/items.js.php
@@ -368,7 +368,7 @@ $var['hidden_asterisk'] = '<i class="fa-solid fa-asterisk mr-2"></i><i class="fa
     });
 
     // Prepare some UI elements
-    $('#limited-search').prop('checked', false);
+    $('#limited-search').prop('checked', '<?php echo $SETTINGS['limited_search_default']; ?>');
 
     $(document).on('blur', '#form-item-icon', function() {
         $('#form-item-icon-show').html('<i class="fas '+$(this).val()+'"></i>');
@@ -3316,7 +3316,7 @@ $var['hidden_asterisk'] = '<i class="fa-solid fa-asterisk mr-2"></i><i class="fa
 
     // Warn in case of limited search
     $(document).on('click', '#limited-search', function() {
-        if ($(this).is(":checked") === true) {
+        if ($(this).is(":checked") != "<?php echo $SETTINGS['limited_search_default']; ?>") {
             $('#find_items').css({
                 "background-color": "#f56954"
             });

--- a/pages/items.js.php
+++ b/pages/items.js.php
@@ -122,6 +122,7 @@ $var['hidden_asterisk'] = '<i class="fa-solid fa-asterisk mr-2"></i><i class="fa
             personalSaltkeyRequired: 0,
             uploadedFileId: '',
             tempScrollTop: 0,
+            highlightSelected: parseInt(<?php echo $SETTINGS['highlight_selected']; ?>),
             highlightFavorites: parseInt(<?php echo $SETTINGS['highlight_favorites']; ?>)
         }
     );
@@ -278,7 +279,9 @@ $var['hidden_asterisk'] = '<i class="fa-solid fa-asterisk mr-2"></i><i class="fa
             'teampassApplication', {
                 selectedFolder: parseInt(queryDict['group']),
                 itemsListFolderId: parseInt(queryDict['group']),
-                selectedItem: parseInt(queryDict['id'])
+                selectedItem: parseInt(queryDict['id']),
+                highlightSelected: parseInt(<?php echo $SETTINGS['highlight_selected']; ?>),
+                highlightFavorites: parseInt(<?php echo $SETTINGS['highlight_favorites']; ?>)
             }
         );
         store.update(
@@ -2230,6 +2233,11 @@ $var['hidden_asterisk'] = '<i class="fa-solid fa-asterisk mr-2"></i><i class="fa
                     $('#folder-tree-container').addClass('col-md-5').removeClass('col-md-3').removeClass('hidden');
                     $('#items-list-container').addClass('col-md-7').removeClass('col-md-4').removeClass('hidden');
                     $('#items-details-container').addClass('hidden');
+
+                    // Remove selected item highlighting in list
+                    if (store.get('teampassApplication').highlightSelected === 1) {
+                        $('.list-item-row .list-item-description').removeClass('bg-black');
+                    }
 
                 } else {
                     // Hide all
@@ -4826,6 +4834,12 @@ $var['hidden_asterisk'] = '<i class="fa-solid fa-asterisk mr-2"></i><i class="fa
                         // Prepare Views
                         $('.item-details-card, #item-details-card-categories').removeClass('hidden');
                         $('.form-item').addClass('hidden');
+
+                        // Highlight selected item in list
+                        if (store.get('teampassApplication').highlightSelected === 1) {
+                            $('.list-item-row .list-item-description').removeClass('bg-black');
+                            $('#list-item-row_' + data.id + ' .list-item-description').addClass('bg-black');
+                        }
 
                         // show split mode or not
                         if (store.get('teampassUser').split_view_mode === 1) {

--- a/pages/items.js.php
+++ b/pages/items.js.php
@@ -122,6 +122,7 @@ $var['hidden_asterisk'] = '<i class="fa-solid fa-asterisk mr-2"></i><i class="fa
             personalSaltkeyRequired: 0,
             uploadedFileId: '',
             tempScrollTop: 0,
+            highlightFavorites: parseInt(<?php echo $SETTINGS['highlight_favorites']; ?>)
         }
     );
 
@@ -2504,10 +2505,22 @@ $var['hidden_asterisk'] = '<i class="fa-solid fa-asterisk mr-2"></i><i class="fa
                         //change quick icon
                         if (elem.data('item-favourited') === 0) {
                             $(elem)
-                                .html('<span class="fa-stack fa-clickable item-favourite pointer infotip mr-2" title="<?php echo $lang->get('unfavorite'); ?>" data-item-id="' + elem.item_id + '" data-item-favourited="1"><i class="fa-solid fa-circle fa-stack-2x"></i><i class="fa-solid fa-star fa-stack-1x fa-inverse text-warning"></i></span>');
+                                .html('<span class="fa-stack fa-clickable item-favourite pointer infotip mr-2" title="<?php echo $lang->get('unfavorite'); ?>" data-item-id="' + data.item_id + '" data-item-favourited="1"><i class="fa-solid fa-circle fa-stack-2x"></i><i class="fa-solid fa-star fa-stack-1x fa-inverse text-warning"></i></span>');
+
+                            // Remove highlighting
+                            if (store.get('teampassApplication').highlightFavorites === 1) {
+                                $('#list-item-row_' + data.item_id).addClass('bg-yellow');
+                                $('#list-item-row_' + data.item_id + ' .item-favorite-star').addClass('fa-star mr-1');
+                            }
                         } else {
                             $(elem)
-                                .html('<span class="fa-stack fa-clickable item-favourite pointer infotip mr-2" title="<?php echo $lang->get('favorite'); ?>" data-item-id="' + elem.item_id + '" data-item-favourited="0"><i class="fa-solid fa-circle fa-stack-2x"></i><i class="fa-solid fa-star fa-stack-1x fa-inverse"></i></span>');
+                                .html('<span class="fa-stack fa-clickable item-favourite pointer infotip mr-2" title="<?php echo $lang->get('favorite'); ?>" data-item-id="' + data.item_id + '" data-item-favourited="0"><i class="fa-solid fa-circle fa-stack-2x"></i><i class="fa-solid fa-star fa-stack-1x fa-inverse"></i></span>');
+                            
+                            // Add highlighting
+                            if (store.get('teampassApplication').highlightFavorites === 1) {
+                                $('#list-item-row_' + data.item_id).removeClass('bg-yellow');
+                                $('#list-item-row_' + data.item_id + ' .item-favorite-star').removeClass('fa-star mr-1');
+                            }
                         }
 
                         toastr.remove();
@@ -4282,7 +4295,7 @@ $var['hidden_asterisk'] = '<i class="fa-solid fa-asterisk mr-2"></i><i class="fa
                 }
 
                 $('#teampass_items_list').append(
-                    '<tr class="list-item-row' + (value.canMove === 1 ? ' is-draggable' : '') + '" id="list-item-row_' + value.item_id + '" data-item-key="' + value.item_key + '" data-item-edition="' + value.open_edit + '" data-item-id="' + value.item_id + '" data-item-sk="' + value.sk + '" data-item-expired="' + value.expired + '" data-item-rights="' + value.rights + '" data-item-display="' + value.display + '" data-item-open-edit="' + value.open_edit + '" data-item-tree-id="' + value.tree_id + '" data-is-search-result="' + value.is_result_of_search + '" data-label="' + escape(value.label) + '">' +
+                    '<tr class="list-item-row' + (value.canMove === 1 ? ' is-draggable' : '') + ((store.get('teampassApplication').highlightFavorites === 1 && value.is_favourited === 1) ? ' bg-yellow' : '') + '" id="list-item-row_' + value.item_id + '" data-item-key="' + value.item_key + '" data-item-edition="' + value.open_edit + '" data-item-id="' + value.item_id + '" data-item-sk="' + value.sk + '" data-item-expired="' + value.expired + '" data-item-rights="' + value.rights + '" data-item-display="' + value.display + '" data-item-open-edit="' + value.open_edit + '" data-item-tree-id="' + value.tree_id + '" data-is-search-result="' + value.is_result_of_search + '" data-label="' + escape(value.label) + '">' +
                     '<td class="list-item-description" style="width: 100%;">' +
                     // Show user a grippy bar to move item
                     (value.canMove === 1  ? '<i class="fa-solid fa-ellipsis-v mr-2 dragndrop"></i>' : '') + //&& value.is_result_of_search === 0
@@ -4296,7 +4309,7 @@ $var['hidden_asterisk'] = '<i class="fa-solid fa-asterisk mr-2"></i><i class="fa
                     (value.fa_icon !== '' ? '<i class="'+value.fa_icon+' mr-1"></i>' : '') +
                     // Prepare item info
                     '<span class="list-item-clicktoshow' + (value.rights === 10 ? '' : ' pointer') + '" data-item-id="' + value.item_id + '" data-item-key="' + value.item_key + '">' +
-                    '<span class="list-item-row-description' + (value.rights === 10 ? ' font-weight-light' : '') + '">' + value.label + '</span>' + (value.rights === 10 ? '' : description) +
+                    '<span class="list-item-row-description' + (value.rights === 10 ? ' font-weight-light' : '') + '"><i class="item-favorite-star fa-solid' + ((store.get('teampassApplication').highlightFavorites === 1 && value.is_favourited === 1) ? ' fa-star mr-1' : '') + '"></i>' + value.label + '</span>' + (value.rights === 10 ? '' : description) +
                     '</span>' +
                     '<span class="list-item-actions hidden">' +
                     (value.rights === 10 ?


### PR DESCRIPTION
With theses optional settings:
```php
    'limited_search_default' => '1',
    'highlight_selected' => '1',
    'highlight_favorites' => '1',
```

Allow to reverse the default search type (particularly useful on large instances):
![image](https://github.com/user-attachments/assets/2364a4b7-96e8-467a-897c-e74b6307b462)

Highlight selected item in list:
![image](https://github.com/user-attachments/assets/ddefe4b5-b7a8-4a3f-8e7e-95cb12fbb9b4)

Highlight favorites items in list:
![image](https://github.com/user-attachments/assets/f89ca5a5-d700-4167-a874-e925749ec09d)

Same in dark theme:
![image](https://github.com/user-attachments/assets/cbbe37dd-8fb3-4889-82c2-fa5d377ed723)
