### PR TITLE
Update AzureAuthController.php and ActiveDirectoryExtra.php

### DIFF
--- a/vendor/teampassclasses/azureauthcontroller/src/AzureAuthController.php
+++ b/vendor/teampassclasses/azureauthcontroller/src/AzureAuthController.php
@@ -47,6 +47,9 @@ class AzureAuthController
 
     public function __construct(array $settings)
     {
+        // Initialize the settings property
+        $this->settings = $settings;
+        
         // Multi-tenant is not allowed
         if (empty($settings['oauth2_tenant_id']) || $settings['oauth2_tenant_id'] === 'common') {
             throw new Exception('Invalid tenant_id provided. Multi-tenant access is not allowed.');

--- a/vendor/teampassclasses/ldapextra/src/ActiveDirectoryExtra.php
+++ b/vendor/teampassclasses/ldapextra/src/ActiveDirectoryExtra.php
@@ -32,7 +32,7 @@ namespace TeampassClasses\LdapExtra;
 use LdapRecord\Models\ActiveDirectory\Group as BaseGroup ;
 use LdapRecord\Connection;
 use LdapRecord\Container;
-use LdapRecord\Models\OpenLDAP\User;
+use LdapRecord\Models\ActiveDirectory\User;
 
 class ActiveDirectoryExtra extends BaseGroup 
 {


### PR DESCRIPTION
The class AzureAuthController declares a protected property $settings but never initializes it within the constructor. This throws the following PHP errors:

`[16-Sep-2024 16:34:58] WARNING: [pool www] child 56 said into stderr: "NOTICE: PHP message: PHP Warning:  Trying to access array offset on value of type null in /var/www/html/vendor/teampassclasses/azureauthcontroller/src/AzureAuthController.php on line 72"
[16-Sep-2024 16:34:58] WARNING: [pool www] child 56 said into stderr: "NOTICE: PHP message: PHP Stack trace:"
[16-Sep-2024 16:34:58] WARNING: [pool www] child 56 said into stderr: "NOTICE: PHP message: PHP   1. {main}() /var/www/html/includes/core/login.oauth2.php:0"
[16-Sep-2024 16:34:58] WARNING: [pool www] child 56 said into stderr: "NOTICE: PHP message: PHP   2. TeampassClasses\AzureAuthController\AzureAuthController->redirect() /var/www/html/includes/core/login.oauth2.php:45"`





Also, ActiveDirectoryExtra.php fix OpenLDAP to ActiveDirectory per #4319 #4080 