### PR TITLE
Add support of generic OAuth2 provider in addition to MS Azure, auto-login and fix security issue.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -108,7 +108,7 @@
         },
         {
             "type": "path",
-            "url": "includes/libraries/teampassclasses/azureauthcontroller",
+            "url": "includes/libraries/teampassclasses/oauth2controller",
             "options": {
                 "symlink": false
             }
@@ -146,7 +146,7 @@
         "teampassclasses/language": "dev-master",
         "teampassclasses/ldapextra": "dev-master",
         "teampassclasses/passwordmanager": "dev-master",
-        "teampassclasses/azureauthcontroller": "dev-master",
+        "teampassclasses/oauth2controller": "dev-master",
         "teampassclasses/configmanager": "dev-master",
         "teampassclasses/emailservice": "dev-master",
         "illuminate/contracts": "^10.32",

--- a/composer.lock
+++ b/composer.lock
@@ -5851,11 +5851,11 @@
             "time": "2024-07-26T12:30:32+00:00"
         },
         {
-            "name": "teampassclasses/azureauthcontroller",
+            "name": "teampassclasses/oauth2controller",
             "version": "dev-master",
             "dist": {
                 "type": "path",
-                "url": "includes/libraries/teampassclasses/azureauthcontroller",
+                "url": "includes/libraries/teampassclasses/oauth2controller",
                 "reference": "5948d5854bf9c775d9dd94810d91f8f07078f76b"
             },
             "require": {
@@ -5864,7 +5864,7 @@
             "type": "library",
             "autoload": {
                 "psr-4": {
-                    "TeampassClasses\\AzureAuthController\\": "src/"
+                    "TeampassClasses\\OAuth2Controller\\": "src/"
                 }
             },
             "license": [
@@ -6738,7 +6738,7 @@
         "teampassclasses/language": 20,
         "teampassclasses/ldapextra": 20,
         "teampassclasses/passwordmanager": 20,
-        "teampassclasses/azureauthcontroller": 20,
+        "teampassclasses/oauth2controller": 20,
         "teampassclasses/configmanager": 20,
         "teampassclasses/emailservice": 20,
         "passwordlib/passwordlib": 15

--- a/includes/core/load.js.php
+++ b/includes/core/load.js.php
@@ -213,8 +213,20 @@ $request = SymfonyRequest::createFromGlobals();
 
                             // Show form
                             $('#dialog-ldap-user-change-password').removeClass('hidden');
+
+                            if (data.queryResults.auth_type === 'oauth2') {
+                                // LDAP or local account to OAuth2 account
+                                var info_message = '<?php echo $lang->get('oauth2_need_user_old_password');?>';
+                                $('#new-password-field').hide();
+                                $('#dialog-ldap-user-change-password-current').val(store.get('teampassUser').pwd);
+                            } else {
+                                // LDAP password updated
+                                var info_message = '<?php echo $lang->get('ldap_user_has_changed_his_password');?>';
+                            }
+
+                            // Display info tip
                             $('#dialog-ldap-user-change-password-info')
-                                .html('<i class="icon fa-solid fa-info mr-2"></i><?php echo $lang->get('ldap_user_has_changed_his_password');?>')
+                                .html('<i class="icon fa-solid fa-info mr-2"></i>' + info_message)
                                 .removeClass('hidden');
                         } else if (typeof data.queryResults !== 'undefined' && data.queryResults.keys_recovery_time === null && store.get('teampassUser').user_admin === 0) {
                             // User has not yet recovered his keys

--- a/includes/core/login.js.php
+++ b/includes/core/login.js.php
@@ -76,6 +76,8 @@ declare(strict_types=1);
 
         // Manage case of oauth2 login
         var userOauth2Info = <?php echo empty($userOauth2InfoJson) ? 'null' : $userOauth2InfoJson; ?>;
+        var autoLogin = parseInt(<?php echo $SETTINGS['oauth2_auto_login'] ?? 0; ?>);
+        var loginForm = parseInt(<?php echo str_contains($session->get('user-initial_url') ?? '', 'loginForm') ? 1 : 0; ?>);
         // Case of oauth2 login
         if (userOauth2Info !== null && userOauth2Info['oauth2TokenUsed'] === false) {
             // disable token
@@ -100,6 +102,9 @@ declare(strict_types=1);
                 console.log("We have an oauth2 login");
             }
 
+            // Hide login form to avoid confusion.
+            $('.login-box').hide();
+
             // launch identification process inside Teampass.
             launchIdentify(false, "", "", false);
         } else {
@@ -107,6 +112,11 @@ declare(strict_types=1);
             store.set(
                 'userOauth2Info', ''
             );
+
+            // Auto login with OAuth2 provider
+            if (autoLogin === 1 && loginForm === 0) {
+                launchIdentify(false, '<?php isset($nextUrl) === true ? $nextUrl : ''; ?>', false, true);
+            }
         }
 
         // Prepare iCheck format for checkboxes

--- a/includes/core/login.js.php
+++ b/includes/core/login.js.php
@@ -88,6 +88,7 @@ declare(strict_types=1);
                 const hash = CryptoJS.SHA256(userId);
                 return hash.toString(CryptoJS.enc.Hex).substring(0, 16);
             }
+            $("#login").val(userOauth2Info['login']);
             $("#pw").val(hashUserId(userOauth2Info['id']));
             
             // store userOauth2Info   

--- a/includes/core/login.oauth2.php
+++ b/includes/core/login.oauth2.php
@@ -29,7 +29,7 @@ declare(strict_types=1);
  * @see       https://www.teampass.net
  */
 
-use TeampassClasses\AzureAuthController\AzureAuthController;
+use TeampassClasses\OAuth2Controller\OAuth2Controller;
 
 session_start();
 require_once __DIR__. '/../../includes/config/include.php';
@@ -39,7 +39,7 @@ require_once __DIR__.'/../../sources/main.functions.php';
 loadClasses();
 
 // Création d'une instance du contrôleur
-$azureAuth = new AzureAuthController($SETTINGS);
+$OAuth2 = new OAuth2Controller($SETTINGS);
 
 // Redirection vers Azure pour l'authentification
-$azureAuth->redirect();
+$OAuth2->redirect();

--- a/includes/core/login.php
+++ b/includes/core/login.php
@@ -31,8 +31,7 @@ declare(strict_types=1);
 
 use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
 use TeampassClasses\Language\Language;
-use TeampassClasses\AzureAuthController\AzureAuthController;
-
+use TeampassClasses\OAuth2Controller\OAuth2Controller;
 // Automatic redirection
 $nextUrl = '';
 if (strpos($server['request_uri'], '?') > 0) {
@@ -62,10 +61,10 @@ if (isset($_GET['code']) === true && isset($_GET['state']) === true && $get['pos
     if (WIP === true) error_log('---- OAUTH2 START ----');
 
     // Création d'une instance du contrôleur
-    $azureAuth = new AzureAuthController($SETTINGS);
+    $OAuth2 = new OAuth2Controller($SETTINGS);
 
     // Traitement de la réponse de callback Azure
-    $userInfo = $azureAuth->callback();
+    $userInfo = $OAuth2->callback();
 
     if ($userInfo['error'] === false) {
         // Si aucune erreur, stocker les informations utilisateur dans la session PHP

--- a/includes/core/logout.php
+++ b/includes/core/logout.php
@@ -113,6 +113,6 @@ $session->set('key', SessionManager::getCookieValue('PHPSESSID'));
     }
     
     setTimeout(function() {
-        document.location.href="../../index.php"
+        document.location.href="../../index.php?page=items&loginForm"
     }, 1);
 </script>

--- a/includes/language/english.php
+++ b/includes/language/english.php
@@ -37,6 +37,7 @@ return array(
     'user_exists_but_not_oauth2' => 'User has to authenticate using Entra/Azure AD',
     'user_not_allowed_to_auth_to_teampass_app' => 'User is not allowed to authenticate with Teampass application',
     'user_is_not_auth_with_oauth2' => 'User should not authenticate with Entra/Azure AD',
+    'oauth2_need_user_old_password' => 'For the first SSO connection, please provide your previous password',
     'tenant_id' => 'Tenant ID',
     'items_page_split_view_mode' => 'Show item details in page split view mode',
     'show_item_data' => 'Show item data in items list',

--- a/includes/language/french.php
+++ b/includes/language/french.php
@@ -1192,5 +1192,6 @@ return array(
     'user_exists_but_not_oauth2' => 'Vous devez vous authentifier avec votre compte Azure/Entra AD',
     'user_not_allowed_to_auth_to_teampass_app' => 'Vous n&apos;êtes pas autoriser à vous authentifier à l&apos;application Teampass',
     'user_is_not_auth_with_oauth2' => 'Vous ne pouvez pas vous authentifier avec un compte Entra/Azure AD',
+    'oauth2_need_user_old_password' => 'Pour la première connexion en SSO, merci de fournir votre précédent mot de passe.',
 
 );

--- a/includes/libraries/teampassclasses/oauth2controller/composer.json
+++ b/includes/libraries/teampassclasses/oauth2controller/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "teampassclasses/azureauthcontroller",
+    "name": "teampassclasses/oauth2controller",
     "description": "Provide Azure Auth.",
     "type": "library",
     "license": "GPL-3.0-only",
@@ -18,7 +18,7 @@
     },
     "autoload": {
         "psr-4": {
-            "TeampassClasses\\AzureAuthController\\": "src/"
+            "TeampassClasses\\OAuth2Controller\\": "src/"
         }
     }
 }

--- a/index.php
+++ b/index.php
@@ -798,7 +798,7 @@ if ((null === $session->get('user-validite_pw') || empty($session->get('user-val
                                     </div>
                                     <input type="password" class="form-control" id="dialog-ldap-user-change-password-old">
                                 </div>
-                                <div class="input-group mb-3">
+                                <div class="input-group mb-3" id="new-password-field">
                                     <div class="input-group-prepend">
                                         <span class="input-group-text"><?php echo $lang->get('provide_your_current_password'); ?></span>
                                     </div>

--- a/pages/oauth.php
+++ b/pages/oauth.php
@@ -135,6 +135,18 @@ $ldap_type = $SETTINGS['ldap_type'] ?? '';
                                 </div>
                             </div>
 
+                            <div class='row mb-2'>
+                                <div class='col-10'>
+                                    <?php echo $lang->get('settings_oauth_auto_login'); ?>
+                                    <small id='passwordHelpBlock' class='form-text text-muted'>
+                                        <?php echo $lang->get('settings_oauth_auto_login_tip'); ?>
+                                    </small>
+                                </div>
+                                <div class='col-2'>
+                                    <div class='toggle toggle-modern' id='oauth2_auto_login' data-toggle-on='<?php echo isset($SETTINGS['oauth2_auto_login']) === true && (int) $SETTINGS['oauth2_auto_login'] === 1 ? 'true' : 'false'; ?>'></div><input type='hidden' id='oauth2_auto_login_input' value='<?php echo isset($SETTINGS['oauth2_auto_login']) && (int) $SETTINGS['oauth2_auto_login'] === 1 ? 1 : 0; ?>'>
+                                </div>
+                            </div>
+
                             <div class='row mb-2 tr-ldap'>
                                 <div class='col-5'>
                                     <?php echo $lang->get('app_name'); ?>

--- a/pages/oauth.php
+++ b/pages/oauth.php
@@ -35,7 +35,7 @@ use TeampassClasses\Language\Language;
 use TeampassClasses\NestedTree\NestedTree;
 use TeampassClasses\PerformChecks\PerformChecks;
 use TeampassClasses\ConfigManager\ConfigManager;
-use TeampassClasses\AzureAuthController\AzureAuthController;
+use TeampassClasses\OAuth2Controller\OAuth2Controller;
 
 // Load functions
 require_once __DIR__.'/../sources/main.functions.php';

--- a/sources/identify.php
+++ b/sources/identify.php
@@ -2384,10 +2384,18 @@ function shouldUserAuthWithOauth2(
     string $username
 ): array
 {
+    // Security issue without this return if an user auth_type == oauth2 and
+    // oauth2 disabled : we can login as a valid user by using hashUserId(username)
+    // as password in the login the form.
+    if ((int) $SETTINGS['oauth2_enabled'] !== 1) {
+        return [
+            'error' => true,
+            'message' => 'user_not_allowed_to_auth_to_teampass_app',
+        ];
+    }
+
     // Prepare Oauth2 connection if set up
-    if ((int) $SETTINGS['oauth2_enabled'] === 1
-        && $username !== 'admin'
-    ) {
+    if ($username !== 'admin') {
         // User has started to auth with oauth2
         if ((bool) $userInfo['oauth2_login_ongoing'] === true) {
             // Case where user exists in Teampass but not allowed to auth with Oauth2        
@@ -2478,9 +2486,7 @@ function createOauth2User(
             'userPasswordVerified' => true,
         ];
     
-    } elseif ((int) $SETTINGS['oauth2_enabled'] === 1
-        && isset($userInfo['id']) === true && empty($userInfo['id']) === false
-    ) {
+    } elseif (isset($userInfo['id']) === true && empty($userInfo['id']) === false) {
         // CHeck if user should use oauth2
         $ret = shouldUserAuthWithOauth2(
             $SETTINGS,

--- a/sources/identify.php
+++ b/sources/identify.php
@@ -47,8 +47,7 @@ use RobThree\Auth\TwoFactorAuth;
 use TeampassClasses\LdapExtra\LdapExtra;
 use TeampassClasses\LdapExtra\OpenLdapExtra;
 use TeampassClasses\LdapExtra\ActiveDirectoryExtra;
-use TeampassClasses\AzureAuthController\AzureAuthController;
-
+use TeampassClasses\OAuth2Controller\OAuth2Controller;
 // Load functions
 require_once 'main.functions.php';
 
@@ -219,55 +218,10 @@ if ($post_type === 'identify_user') {
     //
 
     // Création d'une instance du contrôleur
-    $azureAuth = new AzureAuthController($SETTINGS);
+    $OAuth2 = new OAuth2Controller($SETTINGS);
 
     // Redirection vers Azure pour l'authentification
-    $azureAuth->redirect();
-
-/*
-    $provider = new TheNetworg\OAuth2\Client\Provider\Azure([
-        'clientId'                => $SETTINGS['oauth2_azure_clientId'],
-        'clientSecret'            => $SETTINGS['oauth2_azure_clientSecret'],
-        'redirectUri'             => $SETTINGS['oauth2_azure_redirectUri'],
-        'urlAuthorize'            => $SETTINGS['oauth2_azure_urlAuthorize'],
-        'urlAccessToken'          => $SETTINGS['oauth2_azure_urlAccessToken'],
-        'urlResourceOwnerDetails' => $SETTINGS['oauth2_azure_urlResourceOwnerDetails'],
-        'scopes'                  => explode(",", $SETTINGS['oauth2_azure_scopes']),
-        'defaultEndPointVersion' => '2.0'
-    ]);
-    $provider->defaultEndPointVersion = TheNetworg\OAuth2\Client\Provider\Azure::ENDPOINT_VERSION_2_0;
-    $baseGraphUri = $provider->getRootMicrosoftGraphUri(null);
-    $provider->scope = 'openid profile email offline_access ' . $baseGraphUri . '/User.Read';
-    if (isset($_GET['code']) && isset($_SESSION['OAuth2.state']) && isset($_GET['state'])) {
-        if ($_GET['state'] == $_SESSION['OAuth2.state']) {
-            unset($_SESSION['OAuth2.state']);
-    
-            $token = $provider->getAccessToken('authorization_code', [
-                'scope' => $provider->scope,
-                'code' => $_GET['code'],
-            ]);
-    
-            // Verify token
-            // Save it to local server session data
-            
-            return $token->getToken();
-        } else {
-            echo 'Invalid state';
-    
-            return null;
-        }
-    } else {
-        $authorizationUrl = $provider->getAuthorizationUrl(['scope' => $provider->scope]);
-
-        $_SESSION['OAuth2.state'] = $provider->getState();
-
-        header('Location: ' . $authorizationUrl);
-
-        exit;
-
-        return $token->getToken();
-    }
-*/
+    $OAuth2->redirect();
 
     // Encrypt data to return
     echo json_encode([

--- a/sources/main.functions.php
+++ b/sources/main.functions.php
@@ -4249,7 +4249,6 @@ function handleUserRecoveryKeysDownload(int $userId, array $SETTINGS):string
 
     if (DB::count() > 0) {
         $now = (int) time();
-error_log('password: '.$session->get('user-password'));
         // Prepare file content
         $export_value = file_get_contents(__DIR__."/../includes/core/teampass_ascii.txt")."\n".
             "Generation date: ".date($SETTINGS['date_format'] . ' ' . $SETTINGS['time_format'], $now)."\n\n".

--- a/sources/oauth.php
+++ b/sources/oauth.php
@@ -1,5 +1,5 @@
 <?php
-use TeampassClasses\AzureAuthController\AzureAuthController;
+use TeampassClasses\OAuth2Controller\OAuth2Controller;
 session_start();
 require_once __DIR__. '/../includes/config/include.php';
 require_once __DIR__.'/../sources/main.functions.php';
@@ -11,7 +11,7 @@ loadClasses();
 // MDP  teampass.admin  Goh@u939!879
 
 // Création d'une instance du contrôleur
-$azureAuth = new AzureAuthController($SETTINGS);
+$OAuth2 = new OAuth2Controller($SETTINGS);
 
 // Redirection vers Azure pour l'authentification
-$azureAuth->redirect();
+$OAuth2->redirect();

--- a/vendor/composer/autoload_classmap.php
+++ b/vendor/composer/autoload_classmap.php
@@ -2033,7 +2033,7 @@ return array(
     'TCPDF_IMPORT' => $vendorDir . '/tecnickcom/tcpdf/tcpdf_import.php',
     'TCPDF_PARSER' => $vendorDir . '/tecnickcom/tcpdf/tcpdf_parser.php',
     'TCPDF_STATIC' => $vendorDir . '/tecnickcom/tcpdf/include/tcpdf_static.php',
-    'TeampassClasses\\AzureAuthController\\AzureAuthController' => $vendorDir . '/teampassclasses/azureauthcontroller/src/AzureAuthController.php',
+    'TeampassClasses\\OAuth2Controller\\OAuth2Controller' => $vendorDir . '/teampassclasses/OAuth2Controller/src/OAuth2Controller.php',
     'TeampassClasses\\ConfigManager\\ConfigManager' => $vendorDir . '/teampassclasses/configmanager/src/ConfigManager.php',
     'TeampassClasses\\EmailService\\EmailService' => $vendorDir . '/teampassclasses/emailservice/src/EmailService.php',
     'TeampassClasses\\EmailService\\EmailSettings' => $vendorDir . '/teampassclasses/emailservice/src/EmailSettings.php',

--- a/vendor/composer/autoload_psr4.php
+++ b/vendor/composer/autoload_psr4.php
@@ -22,7 +22,7 @@ return array(
     'TeampassClasses\\Encryption\\' => array($vendorDir . '/teampassclasses/encryption/src'),
     'TeampassClasses\\EmailService\\' => array($vendorDir . '/teampassclasses/emailservice/src'),
     'TeampassClasses\\ConfigManager\\' => array($vendorDir . '/teampassclasses/configmanager/src'),
-    'TeampassClasses\\AzureAuthController\\' => array($vendorDir . '/teampassclasses/azureauthcontroller/src'),
+    'TeampassClasses\\OAuth2Controller\\' => array($vendorDir . '/teampassclasses/oauth2authcontroller/src'),
     'Symfony\\Polyfill\\Php83\\' => array($vendorDir . '/symfony/polyfill-php83'),
     'Symfony\\Polyfill\\Php81\\' => array($vendorDir . '/symfony/polyfill-php81'),
     'Symfony\\Polyfill\\Php80\\' => array($vendorDir . '/symfony/polyfill-php80'),

--- a/vendor/composer/autoload_static.php
+++ b/vendor/composer/autoload_static.php
@@ -59,7 +59,7 @@ class ComposerStaticInite3f3ee27f81ca21f7bd7499d7b935c11
             'TeampassClasses\\Encryption\\' => 27,
             'TeampassClasses\\EmailService\\' => 29,
             'TeampassClasses\\ConfigManager\\' => 30,
-            'TeampassClasses\\AzureAuthController\\' => 36,
+            'TeampassClasses\\Oauth2AuthController\\' => 36,
         ),
         'S' => 
         array (
@@ -241,9 +241,9 @@ class ComposerStaticInite3f3ee27f81ca21f7bd7499d7b935c11
         array (
             0 => __DIR__ . '/..' . '/teampassclasses/configmanager/src',
         ),
-        'TeampassClasses\\AzureAuthController\\' => 
+        'TeampassClasses\\OAuth2Controller\\' => 
         array (
-            0 => __DIR__ . '/..' . '/teampassclasses/azureauthcontroller/src',
+            0 => __DIR__ . '/..' . '/teampassclasses/oauth2controller/src',
         ),
         'Symfony\\Polyfill\\Php83\\' => 
         array (
@@ -2619,7 +2619,7 @@ class ComposerStaticInite3f3ee27f81ca21f7bd7499d7b935c11
         'TCPDF_IMPORT' => __DIR__ . '/..' . '/tecnickcom/tcpdf/tcpdf_import.php',
         'TCPDF_PARSER' => __DIR__ . '/..' . '/tecnickcom/tcpdf/tcpdf_parser.php',
         'TCPDF_STATIC' => __DIR__ . '/..' . '/tecnickcom/tcpdf/include/tcpdf_static.php',
-        'TeampassClasses\\AzureAuthController\\AzureAuthController' => __DIR__ . '/..' . '/teampassclasses/azureauthcontroller/src/AzureAuthController.php',
+        'TeampassClasses\\OAuth2Controller\\OAuth2Controller' => __DIR__ . '/..' . '/teampassclasses/oauth2controller/src/OAuth2Controller.php',
         'TeampassClasses\\ConfigManager\\ConfigManager' => __DIR__ . '/..' . '/teampassclasses/configmanager/src/ConfigManager.php',
         'TeampassClasses\\EmailService\\EmailService' => __DIR__ . '/..' . '/teampassclasses/emailservice/src/EmailService.php',
         'TeampassClasses\\EmailService\\EmailSettings' => __DIR__ . '/..' . '/teampassclasses/emailservice/src/EmailSettings.php',

--- a/vendor/composer/installed.json
+++ b/vendor/composer/installed.json
@@ -6102,12 +6102,12 @@
             "install-path": "../symfony/translation"
         },
         {
-            "name": "teampassclasses/azureauthcontroller",
+            "name": "teampassclasses/oauth2controller",
             "version": "dev-master",
             "version_normalized": "dev-master",
             "dist": {
                 "type": "path",
-                "url": "includes/libraries/teampassclasses/azureauthcontroller",
+                "url": "includes/libraries/teampassclasses/oauth2controller",
                 "reference": "5948d5854bf9c775d9dd94810d91f8f07078f76b"
             },
             "require": {
@@ -6117,7 +6117,7 @@
             "installation-source": "dist",
             "autoload": {
                 "psr-4": {
-                    "TeampassClasses\\AzureAuthController\\": "src/"
+                    "TeampassClasses\\OAuth2Controller\\": "src/"
                 }
             },
             "license": [
@@ -6138,7 +6138,7 @@
                 "symlink": false,
                 "relative": true
             },
-            "install-path": "../teampassclasses/azureauthcontroller"
+            "install-path": "../teampassclasses/oauth2controller"
         },
         {
             "name": "teampassclasses/configmanager",

--- a/vendor/composer/installed.php
+++ b/vendor/composer/installed.php
@@ -877,12 +877,12 @@
                 0 => '2.3|3.0',
             ),
         ),
-        'teampassclasses/azureauthcontroller' => array(
+        'teampassclasses/oauth2controller' => array(
             'pretty_version' => 'dev-master',
             'version' => 'dev-master',
             'reference' => '5948d5854bf9c775d9dd94810d91f8f07078f76b',
             'type' => 'library',
-            'install_path' => __DIR__ . '/../teampassclasses/azureauthcontroller',
+            'install_path' => __DIR__ . '/../teampassclasses/oauth2controller',
             'aliases' => array(),
             'dev_requirement' => false,
         ),

--- a/vendor/teampassclasses/oauth2controller/composer.json
+++ b/vendor/teampassclasses/oauth2controller/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "teampassclasses/azureauthcontroller",
+    "name": "teampassclasses/oauth2controller",
     "description": "Provide Azure Auth.",
     "type": "library",
     "license": "GPL-3.0-only",
@@ -18,7 +18,7 @@
     },
     "autoload": {
         "psr-4": {
-            "TeampassClasses\\AzureAuthController\\": "src/"
+            "TeampassClasses\\OAuth2Controller\\": "src/"
         }
     }
 }

--- a/vendor/teampassclasses/oauth2controller/src/OAuth2Controller.php
+++ b/vendor/teampassclasses/oauth2controller/src/OAuth2Controller.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace TeampassClasses\AzureAuthController;
+namespace TeampassClasses\OAuth2Controller;
 
 /**
  * Teampass - a collaborative passwords manager.
@@ -30,17 +30,18 @@ namespace TeampassClasses\AzureAuthController;
  */
 
 use TheNetworg\OAuth2\Client\Provider\Azure;
-//use League\OAuth2\Client\Token\AccessToken;
+use League\OAuth2\Client\Provider\GenericProvider;
+
 
 /*** INFO - .htaccess modification ***
  * RewriteEngine On
- * RewriteRule ^login/azure$ /path/to/AzureAuthController.php?method=redirect [L]
- * RewriteRule ^login/azure/callback$ /path/to/AzureAuthController.php?method=callback [L]
+ * RewriteRule ^login/azure$ /path/to/OAuth2Controller.php?method=redirect [L]
+ * RewriteRule ^login/azure/callback$ /path/to/OAuth2Controller.php?method=callback [L]
 
  */
 use Exception;
 
-class AzureAuthController
+class OAuth2Controller
 {
     protected $provider;
     protected $settings;
@@ -50,29 +51,46 @@ class AzureAuthController
         // Initialize the settings property
         $this->settings = $settings;
         
-        // Multi-tenant is not allowed
-        if (empty($settings['oauth2_tenant_id']) || $settings['oauth2_tenant_id'] === 'common') {
-            throw new Exception('Invalid tenant_id provided. Multi-tenant access is not allowed.');
-        }
+        // MS Azure
+        if (str_contains($settings['oauth2_client_endpoint'], 'login.microsoftonline.com')) {
 
-        // Using the v2.0 endpoint
-        $this->provider = new Azure([
-            'clientId'                => $settings['oauth2_client_id'],
-            'clientSecret'            => $settings['oauth2_client_secret'],
-            'tenant'                  => $settings['oauth2_tenant_id'],
-            'redirectUri'             => $settings['cpassman_url'].'/index.php?post_type=oauth2',
-            'urlAuthorize'            => 'https://login.microsoftonline.com/' . $settings['oauth2_tenant_id'] . '/oauth2/v2.0/authorize', // Using the v2.0 endpoint
-            'urlAccessToken'          => 'https://login.microsoftonline.com/' . $settings['oauth2_tenant_id'] . '/oauth2/v2.0/token',     // v2.0 endpoint for the token
-            'urlResourceOwnerDetails' => 'https://graph.microsoft.com/v1.0/me',  // Endpoint to get user info
-            'scopes'                  => explode(",", $settings['oauth2_client_scopes']),  // Scopes are defined in the settings
-            'defaultEndPointVersion'  => '2.0',  // Endpoint version
-        ]);
+            // Multi-tenant is not allowed
+            if (empty($settings['oauth2_tenant_id']) || $settings['oauth2_tenant_id'] === 'common') {
+                throw new Exception('Invalid tenant_id provided. Multi-tenant access is not allowed.');
+            }
+
+            // Using the v2.0 endpoint
+            $this->provider = new Azure([
+                'clientId'                => $settings['oauth2_client_id'],
+                'clientSecret'            => $settings['oauth2_client_secret'],
+                'tenant'                  => $settings['oauth2_tenant_id'],
+                'redirectUri'             => $settings['cpassman_url'].'/index.php?post_type=oauth2',
+                'urlAuthorize'            => 'https://login.microsoftonline.com/' . $settings['oauth2_tenant_id'] . '/oauth2/v2.0/authorize', // Using the v2.0 endpoint
+                'urlAccessToken'          => 'https://login.microsoftonline.com/' . $settings['oauth2_tenant_id'] . '/oauth2/v2.0/token',     // v2.0 endpoint for the token
+                'urlResourceOwnerDetails' => 'https://graph.microsoft.com/v1.0/me',  // Endpoint to get user info
+                'scopes'                  => explode(",", $settings['oauth2_client_scopes']),  // Scopes are defined in the settings
+                'defaultEndPointVersion'  => '2.0',  // Endpoint version
+            ]);
+
+        // Generic Oauth2 provider
+        } else {
+
+            $this->provider = new GenericProvider([
+                'clientId'                => $settings['oauth2_client_id'],
+                'clientSecret'            => $settings['oauth2_client_secret'],
+                'redirectUri'             => $settings['cpassman_url'].'/index.php?post_type=oauth2',
+                'urlAuthorize'            => $settings['oauth2_client_endpoint'],
+                'urlAccessToken'          => $settings['oauth2_client_token'],
+                'urlResourceOwnerDetails' => $settings['oauth2_client_urlResourceOwnerDetails'],
+                'scopes'                  => explode(",", $settings['oauth2_client_scopes']),
+            ]);
+        }
     }
 
     public function redirect()
     {
         // Force a unique tenant by refusing any other configuration
-        if ($this->settings['oauth2_tenant_id'] === 'common') {
+        if ($this->provider instanceof Azure && $this->settings['oauth2_tenant_id'] === 'common') {
             throw new Exception('Multi-tenant access is not allowed. Tenant must be specified.');
         }
 
@@ -102,25 +120,35 @@ class AzureAuthController
                 'code' => $_GET['code']
             ]);
 
-            // Retrieve user information via Microsoft Graph
-            $graphUrl = 'https://graph.microsoft.com/v1.0/me';
-            $response = $this->provider->getAuthenticatedRequest('GET', $graphUrl, $token->getToken());
-            $user = $this->provider->getParsedResponse($response);
-
-            // Retrieve the groups the user belongs to
-            $groupsUrl = 'https://graph.microsoft.com/v1.0/me/memberOf';
-            $groupsResponse = $this->provider->getAuthenticatedRequest('GET', $groupsUrl, $token->getToken());
-            $groups = $this->provider->getParsedResponse($groupsResponse);
-            
-            // Extract only the IDs and names of the groups if available
-            $userGroups = [];
-            if (isset($groups['value']) && is_array($groups['value'])) {
-                foreach ($groups['value'] as $group) {
-                    $userGroups[] = [
-                        'id' => $group['id'] ?? null,
-                        'displayName' => $group['displayName'] ?? null,
-                    ];
+            if ($this->provider instanceof Azure) {
+                // Retrieve user information via Microsoft Graph
+                $graphUrl = 'https://graph.microsoft.com/v1.0/me';
+                $response = $this->provider->getAuthenticatedRequest('GET', $graphUrl, $token->getToken());
+                $user = $this->provider->getParsedResponse($response);
+    
+                // Retrieve the groups the user belongs to
+                $groupsUrl = 'https://graph.microsoft.com/v1.0/me/memberOf';
+                $groupsResponse = $this->provider->getAuthenticatedRequest('GET', $groupsUrl, $token->getToken());
+                $groups = $this->provider->getParsedResponse($groupsResponse);
+                
+                // Extract only the IDs and names of the groups if available
+                $userGroups = [];
+                if (isset($groups['value']) && is_array($groups['value'])) {
+                    foreach ($groups['value'] as $group) {
+                        $userGroups[] = [
+                            'id' => $group['id'] ?? null,
+                            'displayName' => $group['displayName'] ?? null,
+                        ];
+                    }
                 }
+            } else {
+                // Get user infos
+                $resourceOwner = $this->provider->getResourceOwner($token);
+                $user = $resourceOwner->toArray();
+                $userGroups = $user['realm_access']['roles'];
+                $user['userPrincipalName'] = $user['preferred_username'];
+                $user['givenname'] = $user['given_name'];
+                $user['surname'] = $user['family_name'];
             }
 
             // Return user information


### PR DESCRIPTION
I am able to login with my account with a standard oauth2 provider after updating my account auth type (need to restore my keys after login):
```sql
UPDATE users SET auth_type = 'oauth2' WHERE login = 'corentin';
```

With the second commit, we can enable sso auto login. Bypass autologin with URL index.php?page=items&loginForm or logout button.

This "password" seems to be insecure but I don't know if we can do anything really better:
```php
            // manage cryto ID
            function hashUserId(userId) {
                const hash = CryptoJS.SHA256(userId);
                return hash.toString(CryptoJS.enc.Hex).substring(0, 16);
            }
```

There is still a step to migrate from a password (ldap or local) account to an SSO account.
