### PR TITLE
Fix error with wrong variable name on item creation.

### DIFF
--- a/sources/items.queries.php
+++ b/sources/items.queries.php
@@ -759,7 +759,7 @@ switch ($inputData['type']) {
                     // Get path
                     $path = geItemReadablePath(
                         (int) $inputData['folderId'],
-                        $label,
+                        $inputData['label'],
                         $SETTINGS
                     );
 


### PR DESCRIPTION
Fix for this error on item creation:
```log
[2024-09-17 15:24:05.515768] [proxy_fcgi:error] [R:ZumC9XzGBIxvQTSizQY64QAAAA4] AH01071: Got error 'PHP message: PHP Fatal error:  Uncaught TypeError: geItemReadablePath(): Argument #2 ($label) must be of type string, null given, called in /var/www/teampass/sources/items.queries.php on line 758 and defined in /var/www/teampass/sources/main.functions.php:1760\nStack trace:\n#0 /var/www/teampass/sources/items.queries.php(758): geItemReadablePath(1232, NULL, Array)\n#1 {main}\n  thrown in /var/www/teampass/sources/main.functions.php on line 1760'

```