### PR TITLE
Completes the implementation of the encryptClientServer parameter .

### DIFF
--- a/includes/js/functions.js
+++ b/includes/js/functions.js
@@ -183,7 +183,7 @@ function prepareExchangedData(data, type, key, fileName = '', functionName = '')
         }
     } else if (type === 'encode') {
         if (parseInt($('#encryptClientServer').val()) === 0) {
-            return stripHtml(data);
+            return data;
         } else {
             let encryption = new Encryption();
             return encryption.encrypt(data, key);
@@ -201,22 +201,6 @@ function isJsonString(str) {
     }
     return true;
 }
-
-
-/**
- * Returns the text from a HTML string
- * 
- * @param {string} String The html string
- */
-function stripHtml(html) {
-    // Create a new div element
-    let temporalDivElement = document.createElement('div');
-    // Set the HTML content with the providen
-    temporalDivElement.innerHTML = html;
-    // Retrieve the text property of the element (cross-browser support)
-    return temporalDivElement.textContent || temporalDivElement.innerText || '';
-}
-
 
 /**
  * 

--- a/index.php
+++ b/index.php
@@ -89,6 +89,7 @@ $request = SymfonyRequest::createFromGlobals();
 $configManager = new ConfigManager(__DIR__, $request->getRequestUri());
 $SETTINGS = $configManager->getAllSettings();
 $antiXss = new AntiXSS();
+$session->set('encryptClientServer', (int) $SETTINGS['encryptClientServer'] ?? 1);
 
 // Quick major version check -> upgrade needed?
 if (isset($SETTINGS['teampass_version']) === true && version_compare(TP_VERSION, $SETTINGS['teampass_version']) > 0) {
@@ -1304,6 +1305,7 @@ if ((null === $session->get('user-validite_pw') || empty($session->get('user-val
     <!-- functions -->
     <script type="text/javascript" src="includes/js/functions.js?v=<?php echo TP_VERSION; ?>"></script>
     <script type="text/javascript" src="includes/js/CreateRandomString.js?v=<?php echo TP_VERSION; ?>"></script>
+    <input type="hidden" id="encryptClientServer" value="<?php echo $SETTINGS['encryptClientServer'] ?? 1; ?>" />
 
     </body>
 

--- a/sources/main.functions.php
+++ b/sources/main.functions.php
@@ -1258,24 +1258,36 @@ function prepareExchangedData($data, string $type, ?string $key = null)
     
     // Perform
     if ($type === 'encode' && is_array($data) === true) {
-        // Now encode
-        return Encryption::encrypt(
-            json_encode(
-                $data,
-                JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP
-            ),
-            $session->get('key')
+        // json encoding
+        $data = json_encode(
+            $data,
+            JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP
         );
+
+        // Now encrypt
+        if ($session->get('encryptClientServer') === 1) {
+            $data = Encryption::encrypt(
+                $data,
+                $session->get('key')
+            );
+        }
+
+        return $data;
     }
     if ($type === 'decode' && is_array($data) === false) {
-        // check if key exists
-        return json_decode(
-            (string) Encryption::decrypt(
+        // Decrypt if needed
+        if ($session->get('encryptClientServer') === 1) {
+            $data = (string) Encryption::decrypt(
                 (string) $data,
                 $session->get('key')
-            ),
-            true
-        );
+            );
+        } else {
+            // Double html encoding received
+            $data = html_entity_decode(html_entity_decode($data));
+        }
+
+        // Return data array
+        return json_decode($data, true);
     }
     return '';
 }


### PR DESCRIPTION
It is very useful to be able to disable client/server communication encryption for debugging or using an application firewall.
The `encryptClientServer` parameter was already present in the `tp.config.php`, and the JavaScript part was already prepared.

It should be noted that the encryption seems unnecessary since it is symmetric, and the key is present throughout all communications:
- Anyone with a tool like Wireshark can read the encrypted content as well as the private key in the same request.
- It significantly slows down the application: Teampass is much more responsive without this encryption.
- An administrator concerned about the security of exchanges will systematically use TLS.

During my tests I noticed that the stripHtml function is vulnerable to XSS injection since it creates unsafe elements in the DOM.
As there was no consistency in using it, I removed its call and definition.