### PR TITLE
Speedup copy/delete folder and copy item actions.

### DIFF
--- a/pages/items.js.php
+++ b/pages/items.js.php
@@ -1598,6 +1598,11 @@ $var['hidden_asterisk'] = '<i class="fa-solid fa-asterisk mr-2"></i><i class="fa
                             timeOut: 1000
                         }
                     );
+
+                    // Select folder of new item in jstree
+                    $('#jstree').jstree('deselect_all');
+                    $('#jstree').jstree('select_node', '#li_' + $('#form-item-copy-destination').val());
+
                     // Refresh tree
                     refreshTree(parseInt($('#form-item-copy-destination').val()), true);
                     // Load list of items
@@ -1611,7 +1616,7 @@ $var['hidden_asterisk'] = '<i class="fa-solid fa-asterisk mr-2"></i><i class="fa
                     );
                     
                     // Close
-                    $('#folder-tree-container').removeClass('hidden');
+                    $('#folders-tree-card').removeClass('hidden');
                     $('.form-item-copy').addClass('hidden');
                 } else {
                     // ERROR
@@ -3220,6 +3225,11 @@ $var['hidden_asterisk'] = '<i class="fa-solid fa-asterisk mr-2"></i><i class="fa
                                         key: '<?php echo $session->get('key'); ?>'
                                     }
                                 );
+
+                                // Select new folder of item in jstree
+                                $('#jstree').jstree('deselect_all');
+                                $('#jstree').jstree('select_node', '#li_' + $('#form-item-folder').val());
+
                             } else if ($('#form-item-button-save').data('action') === 'new_item') {
                                 window.location.href = './index.php?page=items&group='+$('#form-item-folder').val()+'&id='+data.item_id;
                                 return;

--- a/sources/folders.queries.php
+++ b/sources/folders.queries.php
@@ -754,7 +754,7 @@ if (null !== $post_type) {
                                     'id = %i',
                                     $item['id']
                                 );
-                                
+
                                 // log
                                 logItems(
                                     $SETTINGS,
@@ -772,51 +772,6 @@ if (null !== $post_type) {
 
                                 //Update CACHE table
                                 updateCacheTable('delete_value',(int) $item['id']);
-/*
-                                // --> build json tree  
-                                // update cache_tree
-                                $cache_tree = DB::queryfirstrow(
-                                    'SELECT increment_id, folders, visible_folders
-                                    FROM ' . prefixTable('cache_tree').' WHERE user_id = %i',
-                                    (int) $session->get('user-id')
-                                );
-                                if (DB::count()>0) {
-                                    // remove id from folders
-                                    if (empty($cache_tree['folders']) === false && is_null($cache_tree['folders']) === false) {
-                                        $a_folders = json_decode($cache_tree['folders'], true);
-                                        $key = array_search($item['id'], $a_folders, true);
-                                        if ($key !== false) {
-                                            unset($a_folders[$key]);
-                                        }
-                                    } else {
-                                        $a_folders = [];
-                                    }
-
-                                    // remove id from visible_folders
-                                    if (empty($cache_tree['visible_folders']) === false && is_null($cache_tree['visible_folders']) === false) {
-                                        $a_visible_folders = json_decode($cache_tree['visible_folders'], true);
-                                        foreach ($a_visible_folders as $i => $v) {
-                                            if ($v['id'] == $item['id']) {
-                                                unset($a_visible_folders[$i]);
-                                            }
-                                        }
-                                    } else {
-                                        $a_visible_folders = [];
-                                    }
-
-                                    DB::update(
-                                        prefixTable('cache_tree'),
-                                        array(
-                                            'folders' => json_encode($a_folders),
-                                            'visible_folders' => json_encode($a_visible_folders),
-                                            'timestamp' => time(),
-                                        ),
-                                        'increment_id = %i',
-                                        (int) $cache_tree['increment_id']
-                                    );
-                                }
-                                // <-- end - build json tree
-                                */
                             }
 
                             //Actualize the variable
@@ -825,7 +780,7 @@ if (null !== $post_type) {
                     }
                 }
             }
-            
+
             // Add new task for building user cache tree
             if ((int) $session->get('user-admin') !== 1) {
                 DB::insert(
@@ -848,7 +803,7 @@ if (null !== $post_type) {
             foreach ($folderForDel as $fol) {
                 DB::delete(prefixTable('nested_tree'), 'id = %i', $fol);
             }
-            
+
             // Update timestamp
             DB::update(
                 prefixTable('misc'),
@@ -860,16 +815,12 @@ if (null !== $post_type) {
                 'timestamp',
                 'last_folder_change'
             );
-            
+
             // Commit transaction
             DB::commit();
-            
+
             //rebuild tree
             $tree->rebuild();
-            
-            // reload cache table
-            include_once $SETTINGS['cpassman_dir'] . '/sources/main.functions.php';
-            updateCacheTable('reload', null);
 
             echo prepareExchangedData(
                 array(
@@ -1348,16 +1299,15 @@ if (null !== $post_type) {
                             'at_copy',
                             $session->get('user-login')
                         );
+
+                        // Add item to cache table
+                        updateCacheTable('add_value', (int) $newItemId);
                     }
                 }
             }
 
             // rebuild tree
             $tree->rebuild();
-
-            // reload cache table
-            include_once $SETTINGS['cpassman_dir'] . '/sources/main.functions.php';
-            updateCacheTable('reload', NULL);
 
             // Update timestamp
             DB::update(

--- a/sources/items.queries.php
+++ b/sources/items.queries.php
@@ -2469,9 +2469,6 @@ switch ($inputData['type']) {
                 'at_copy',
                 $session->get('user-login')
             );
-            // reload cache table
-            include_once $SETTINGS['cpassman_dir'] . '/sources/main.functions.php';
-            updateCacheTable('reload', null);
 
             echo (string) prepareExchangedData(
                 array(
@@ -2481,6 +2478,9 @@ switch ($inputData['type']) {
                 ),
                 'encode'
             );
+
+            // Add new item to cache table.
+            updateCacheTable('add_value', (int) $newItemId);
         } else {
             // no item
             echo (string) prepareExchangedData(


### PR DESCRIPTION
`updateCacheTable('reload', null);` has a huge time cost.
This instruction should never be run outside the scheduler.

updateCacheTable add_value and delete_value on delete/copy folder should be enough.

Fix some case where selection is incorrect in the jstree.