### PR TITLE
Fix invisible new created folder in personal space and avoid double jstree selection on creation.

### DIFF
--- a/pages/items.js.php
+++ b/pages/items.js.php
@@ -1923,6 +1923,9 @@ $var['hidden_asterisk'] = '<i class="fa-solid fa-asterisk mr-2"></i><i class="fa
                     // Refresh list of folders
                     refreshVisibleFolders(true);
                     if ($('#form-folder-add').data('action') === 'add') {
+                        // select new folder on jstree
+                        $('#jstree').jstree('deselect_all');
+                        $('#jstree').jstree('select_node', '#li_' + data.newId);
                         // Refresh tree
                         refreshTree(data.newId, true);
                         // Refresh list of items inside the folder

--- a/sources/folders.class.php
+++ b/sources/folders.class.php
@@ -321,7 +321,9 @@ class FolderManager
         $tree = new NestedTree(prefixTable('nested_tree'), 'id', 'parent_id', 'title');
         $tree->rebuild();
         
-        SessionManager::addRemoveFromSessionArray('user-accessible_folders', [$newId], 'add');
+        // Update session visible flolders
+        $sess_key = $isPersonal ? 'user-personal_folders' : 'user-accessible_folders';
+        SessionManager::addRemoveFromSessionArray($sess_key, [$newId], 'add');
 
         if ($user_is_admin === 0) {
             $this->updateUserFolderCache($tree, $title, $parent_id, $isPersonal, $user_id, $newId);


### PR DESCRIPTION
Fix for: 
- New created folder in personal space is invisible until the cache_tree_build job completes.
- Multiple jstree selection on folder creation:
![image](https://github.com/user-attachments/assets/81e7cb76-dd4d-4b8c-9da4-889fa671a723)
