### PR TITLE
Vulnerability creating admin user with a normal account

### DIFF
--- a/includes/config/include.php
+++ b/includes/config/include.php
@@ -28,7 +28,7 @@
 
 define('TP_VERSION', '3.1.2');
 define("UPGRADE_MIN_DATE", "1727110744");
-define('TP_VERSION_MINOR', '114');
+define('TP_VERSION_MINOR', '115');
 define('TP_TOOL_NAME', 'Teampass');
 define('TP_ONE_DAY_SECONDS', 86400);
 define('TP_ONE_WEEK_SECONDS', 604800);

--- a/includes/tables_integrity.json
+++ b/includes/tables_integrity.json
@@ -1,7 +1,7 @@
 [
     {
         "table_name": "api",
-        "structure_hash": "59deba4080818d00e2f678fb078568e83d93e7916b03aa76d3cc2d907b8e201c"
+        "structure_hash": "c81c5fd8428425dd343d72d34cc753cd79535cdbb01dd0b72d7b2ca7426d9a9d"
     },
     {
         "table_name": "automatic_del",
@@ -9,15 +9,15 @@
     },
     {
         "table_name": "background_subtasks",
-        "structure_hash": "7606da91e97d161ad950c6e13665366dddc0826a56752209aed7f24fb8f9d9fb"
+        "structure_hash": "edb00a0558c7f9e03fa848456c6445ee4fc58754d649312e9022a015511abe70"
     },
     {
         "table_name": "background_tasks",
-        "structure_hash": "79a62efdee7707b95762fece4b2981229a155dedede422a44e4410270ad0c869"
+        "structure_hash": "c5f2a8b304dec6998459eeb566a41d5d23468cb9ab45e70fe19d6d1cf5a9be6e"
     },
     {
         "table_name": "background_tasks_logs",
-        "structure_hash": "5b885ec26fdf2bb38ef63969be47ea2ca773f3f40be61e2afffa738cc3c73795"
+        "structure_hash": "0f61780d6c72a4d7511f84f80ed7f2d85b422716da572609f329252cd730b285"
     },
     {
         "table_name": "cache",
@@ -101,7 +101,7 @@
     },
     {
         "table_name": "log_system",
-        "structure_hash": "966e6fd89b125f152be3f2d0113a95466ad770989bae9b73d8129820c9777281"
+        "structure_hash": "a69db25d9f3baa4c2cc7d9daafbb5eca717cddaf636b421b63036f79a1ae6e6e"
     },
     {
         "table_name": "misc",
@@ -109,7 +109,7 @@
     },
     {
         "table_name": "nested_tree",
-        "structure_hash": "036f54632a73c02cf603a3f94a7fb2c8a786f5df05e338c138c926887aa3b8b6"
+        "structure_hash": "43c41856e67406da11202578e7275cb7927d8a8cad833999e5588128ebba6ea6"
     },
     {
         "table_name": "notification",
@@ -161,7 +161,7 @@
     },
     {
         "table_name": "sharekeys_fields",
-        "structure_hash": "4c43d87852d7b9dbc58bc1337245f20074d7c8f6e59d7cce1ae75d5dad22582b"
+        "structure_hash": "b5caa08ad0132073e509b6bbfc1bbf7692a8acf06c239df1f00cd89efd2bb857"
     },
     {
         "table_name": "sharekeys_files",
@@ -169,7 +169,7 @@
     },
     {
         "table_name": "sharekeys_items",
-        "structure_hash": "b8822736b5b1c13a2ab46a2d39304901920c9b93adf792dd751d7283761e5670"
+        "structure_hash": "11a176592b7c1756c3488c0bd0fcf5812e2db5b16d12f3683b8be99196aa4504"
     },
     {
         "table_name": "sharekeys_logs",
@@ -201,7 +201,7 @@
     },
     {
         "table_name": "users",
-        "structure_hash": "9066dfea1645af9d990e53eeeb0f09c6b29de4ce2cadd759572b84e86135dbce"
+        "structure_hash": "c93885f6b5e10e7c6cc5deb47330098b710b59456ad1978e8f9173a09b46c40b"
     },
     {
         "table_name": "version_control",

--- a/sources/users.queries.php
+++ b/sources/users.queries.php
@@ -124,6 +124,18 @@ if (null !== $post_type) {
                 break;
             }
 
+            // Check if current user can add a new user
+            if ((int) $session->get('user-admin') === 0 && (int) $session->get('user-can_manage_all_users') === 0 && (int) $session->get('user-manager') === 0) {
+                echo prepareExchangedData(
+                    array(
+                        'error' => true,
+                        'message' => $lang->get('error_not_allowed_to'),
+                    ),
+                    'encode'
+                );
+                break;
+            }
+
             // decrypt and retrieve data in JSON format
             $dataReceived = prepareExchangedData(
                 $post_data,
@@ -133,7 +145,6 @@ if (null !== $post_type) {
             // Prepare variables
             $login = filter_var($dataReceived['login'], FILTER_SANITIZE_FULL_SPECIAL_CHARS);
             $email = filter_var($dataReceived['email'], FILTER_SANITIZE_EMAIL);
-            $password = '';//filter_var($dataReceived['pw'], FILTER_SANITIZE_FULL_SPECIAL_CHARS);
             $lastname = filter_var($dataReceived['lastname'], FILTER_SANITIZE_FULL_SPECIAL_CHARS);
             $name = filter_var($dataReceived['name'], FILTER_SANITIZE_FULL_SPECIAL_CHARS);
             $is_admin = filter_var($dataReceived['admin'], FILTER_SANITIZE_NUMBER_INT);
@@ -172,7 +183,7 @@ if (null !== $post_type) {
 
             if (DB::count() === 0) {
                 // check if admin role is set. If yes then check if originator is allowed
-                if ($dataReceived['admin'] === true && (int) $session->get('user-admin') !== 1) {
+                if ((int) $dataReceived['admin'] === 1 && (int) $session->get('user-admin') !== 1) {
                     echo prepareExchangedData(
                         array(
                             'error' => true,


### PR DESCRIPTION
Fixing a vulnerability where it could be possible to create an admin user with a normal user account

> By specifying the value 1 in the admin 昀椀eld rather than true , this allows to bypass a 昀椀lter preventing
account creation.
The following command makes it easier to exploit the vulnerability, using the script developed for this
purpose:
python3 teampass_poc.py request --uri '/sources/users.queries.php' --data '{"login":
"bacadduser","name": "bac","lastname": "adduser","email": "bacadduser@akai.labs","admin":
1,"manager": false,"hr": false,"read_only": false,"personal_folder":
false,"new_folder_role_domain": false,"domain": "","isAdministratedByRole": "0","groups":
["1"],"allowed_flds": [],"forbidden_flds": [],"action_on_user": "","form-create-root-folder":
false,"mfa_enabled": false}' --key "<encryption key or cookie>" --type 'add_new_user'