### PR TITLE
Fix typo in translation files: 'deasaster' -> 'disaster'

### DIFF
--- a/includes/language/bulgarian.php
+++ b/includes/language/bulgarian.php
@@ -1144,7 +1144,7 @@ return array(
     'public_key' => 'Public key',
     'private_key' => 'Private key',
     'download_recovery_keys' => 'Download your recovery keys',
-    'download_recovery_keys_confirmation' => 'You are about to download your recovery keys. Please store them in a safe place as they should be mandatory in case of deasaster.',
+    'download_recovery_keys_confirmation' => 'You are about to download your recovery keys. Please store them in a safe place as they should be mandatory in case of disaster.',
     'recovery_keys_download_date' => 'Recovery keys download date',
     'keys_not_recovered' => 'Public and Private keys not stored',
     'keys_not_recovered_explanation' => 'In order to prevent against any passwords lost, you should store safely your personal Teampass keys',

--- a/includes/language/catalan.php
+++ b/includes/language/catalan.php
@@ -1144,7 +1144,7 @@ return array(
     'public_key' => 'Public key',
     'private_key' => 'Private key',
     'download_recovery_keys' => 'Download your recovery keys',
-    'download_recovery_keys_confirmation' => 'You are about to download your recovery keys. Please store them in a safe place as they should be mandatory in case of deasaster.',
+    'download_recovery_keys_confirmation' => 'You are about to download your recovery keys. Please store them in a safe place as they should be mandatory in case of disaster.',
     'recovery_keys_download_date' => 'Recovery keys download date',
     'keys_not_recovered' => 'Public and Private keys not stored',
     'keys_not_recovered_explanation' => 'In order to prevent against any passwords lost, you should store safely your personal Teampass keys',

--- a/includes/language/chinese.php
+++ b/includes/language/chinese.php
@@ -1144,7 +1144,7 @@ return array(
     'public_key' => 'Public key',
     'private_key' => 'Private key',
     'download_recovery_keys' => 'Download your recovery keys',
-    'download_recovery_keys_confirmation' => 'You are about to download your recovery keys. Please store them in a safe place as they should be mandatory in case of deasaster.',
+    'download_recovery_keys_confirmation' => 'You are about to download your recovery keys. Please store them in a safe place as they should be mandatory in case of disaster.',
     'recovery_keys_download_date' => 'Recovery keys download date',
     'keys_not_recovered' => 'Public and Private keys not stored',
     'keys_not_recovered_explanation' => 'In order to prevent against any passwords lost, you should store safely your personal Teampass keys',

--- a/includes/language/czech.php
+++ b/includes/language/czech.php
@@ -1144,7 +1144,7 @@ return array(
     'public_key' => 'Public key',
     'private_key' => 'Private key',
     'download_recovery_keys' => 'Download your recovery keys',
-    'download_recovery_keys_confirmation' => 'You are about to download your recovery keys. Please store them in a safe place as they should be mandatory in case of deasaster.',
+    'download_recovery_keys_confirmation' => 'You are about to download your recovery keys. Please store them in a safe place as they should be mandatory in case of disaster.',
     'recovery_keys_download_date' => 'Recovery keys download date',
     'keys_not_recovered' => 'Public and Private keys not stored',
     'keys_not_recovered_explanation' => 'In order to prevent against any passwords lost, you should store safely your personal Teampass keys',

--- a/includes/language/dutch.php
+++ b/includes/language/dutch.php
@@ -1144,7 +1144,7 @@ return array(
     'public_key' => 'Public key',
     'private_key' => 'Private key',
     'download_recovery_keys' => 'Download your recovery keys',
-    'download_recovery_keys_confirmation' => 'You are about to download your recovery keys. Please store them in a safe place as they should be mandatory in case of deasaster.',
+    'download_recovery_keys_confirmation' => 'You are about to download your recovery keys. Please store them in a safe place as they should be mandatory in case of disaster.',
     'recovery_keys_download_date' => 'Recovery keys download date',
     'keys_not_recovered' => 'Public and Private keys not stored',
     'keys_not_recovered_explanation' => 'In order to prevent against any passwords lost, you should store safely your personal Teampass keys',

--- a/includes/language/english.php
+++ b/includes/language/english.php
@@ -113,7 +113,7 @@ return array(
     'public_key' => 'Public key',
     'private_key' => 'Private key',
     'download_recovery_keys' => 'Download your recovery keys',
-    'download_recovery_keys_confirmation' => 'You are about to download your recovery keys. Please store them in a safe place as they should be mandatory in case of deasaster.',
+    'download_recovery_keys_confirmation' => 'You are about to download your recovery keys. Please store them in a safe place as they should be mandatory in case of disaster.',
     'recovery_keys_download_date' => 'Recovery keys download date',
     'keys_not_recovered' => 'Public and Private keys not stored',
     'keys_not_recovered_explanation' => 'In order to prevent against any passwords lost, you should store safely your personal Teampass keys',

--- a/includes/language/estonian.php
+++ b/includes/language/estonian.php
@@ -1144,7 +1144,7 @@ return array(
     'public_key' => 'Public key',
     'private_key' => 'Private key',
     'download_recovery_keys' => 'Download your recovery keys',
-    'download_recovery_keys_confirmation' => 'You are about to download your recovery keys. Please store them in a safe place as they should be mandatory in case of deasaster.',
+    'download_recovery_keys_confirmation' => 'You are about to download your recovery keys. Please store them in a safe place as they should be mandatory in case of disaster.',
     'recovery_keys_download_date' => 'Recovery keys download date',
     'keys_not_recovered' => 'Public and Private keys not stored',
     'keys_not_recovered_explanation' => 'In order to prevent against any passwords lost, you should store safely your personal Teampass keys',

--- a/includes/language/greek.php
+++ b/includes/language/greek.php
@@ -1144,7 +1144,7 @@ return array(
     'public_key' => 'Public key',
     'private_key' => 'Private key',
     'download_recovery_keys' => 'Download your recovery keys',
-    'download_recovery_keys_confirmation' => 'You are about to download your recovery keys. Please store them in a safe place as they should be mandatory in case of deasaster.',
+    'download_recovery_keys_confirmation' => 'You are about to download your recovery keys. Please store them in a safe place as they should be mandatory in case of disaster.',
     'recovery_keys_download_date' => 'Recovery keys download date',
     'keys_not_recovered' => 'Public and Private keys not stored',
     'keys_not_recovered_explanation' => 'In order to prevent against any passwords lost, you should store safely your personal Teampass keys',

--- a/includes/language/hungarian.php
+++ b/includes/language/hungarian.php
@@ -1144,7 +1144,7 @@ return array(
     'public_key' => 'Public key',
     'private_key' => 'Private key',
     'download_recovery_keys' => 'Download your recovery keys',
-    'download_recovery_keys_confirmation' => 'You are about to download your recovery keys. Please store them in a safe place as they should be mandatory in case of deasaster.',
+    'download_recovery_keys_confirmation' => 'You are about to download your recovery keys. Please store them in a safe place as they should be mandatory in case of disaster.',
     'recovery_keys_download_date' => 'Recovery keys download date',
     'keys_not_recovered' => 'Public and Private keys not stored',
     'keys_not_recovered_explanation' => 'In order to prevent against any passwords lost, you should store safely your personal Teampass keys',

--- a/includes/language/italian.php
+++ b/includes/language/italian.php
@@ -1144,7 +1144,7 @@ return array(
     'public_key' => 'Public key',
     'private_key' => 'Private key',
     'download_recovery_keys' => 'Download your recovery keys',
-    'download_recovery_keys_confirmation' => 'You are about to download your recovery keys. Please store them in a safe place as they should be mandatory in case of deasaster.',
+    'download_recovery_keys_confirmation' => 'You are about to download your recovery keys. Please store them in a safe place as they should be mandatory in case of disaster.',
     'recovery_keys_download_date' => 'Recovery keys download date',
     'keys_not_recovered' => 'Public and Private keys not stored',
     'keys_not_recovered_explanation' => 'In order to prevent against any passwords lost, you should store safely your personal Teampass keys',

--- a/includes/language/japanese.php
+++ b/includes/language/japanese.php
@@ -1144,7 +1144,7 @@ return array(
     'public_key' => 'Public key',
     'private_key' => 'Private key',
     'download_recovery_keys' => 'Download your recovery keys',
-    'download_recovery_keys_confirmation' => 'You are about to download your recovery keys. Please store them in a safe place as they should be mandatory in case of deasaster.',
+    'download_recovery_keys_confirmation' => 'You are about to download your recovery keys. Please store them in a safe place as they should be mandatory in case of disaster.',
     'recovery_keys_download_date' => 'Recovery keys download date',
     'keys_not_recovered' => 'Public and Private keys not stored',
     'keys_not_recovered_explanation' => 'In order to prevent against any passwords lost, you should store safely your personal Teampass keys',

--- a/includes/language/norwegian.php
+++ b/includes/language/norwegian.php
@@ -1144,7 +1144,7 @@ return array(
     'public_key' => 'Public key',
     'private_key' => 'Private key',
     'download_recovery_keys' => 'Download your recovery keys',
-    'download_recovery_keys_confirmation' => 'You are about to download your recovery keys. Please store them in a safe place as they should be mandatory in case of deasaster.',
+    'download_recovery_keys_confirmation' => 'You are about to download your recovery keys. Please store them in a safe place as they should be mandatory in case of disaster.',
     'recovery_keys_download_date' => 'Recovery keys download date',
     'keys_not_recovered' => 'Public and Private keys not stored',
     'keys_not_recovered_explanation' => 'In order to prevent against any passwords lost, you should store safely your personal Teampass keys',

--- a/includes/language/portuguese.php
+++ b/includes/language/portuguese.php
@@ -1144,7 +1144,7 @@ return array(
     'public_key' => 'Public key',
     'private_key' => 'Private key',
     'download_recovery_keys' => 'Download your recovery keys',
-    'download_recovery_keys_confirmation' => 'You are about to download your recovery keys. Please store them in a safe place as they should be mandatory in case of deasaster.',
+    'download_recovery_keys_confirmation' => 'You are about to download your recovery keys. Please store them in a safe place as they should be mandatory in case of disaster.',
     'recovery_keys_download_date' => 'Recovery keys download date',
     'keys_not_recovered' => 'Public and Private keys not stored',
     'keys_not_recovered_explanation' => 'In order to prevent against any passwords lost, you should store safely your personal Teampass keys',

--- a/includes/language/romanian.php
+++ b/includes/language/romanian.php
@@ -1144,7 +1144,7 @@ return array(
     'public_key' => 'Public key',
     'private_key' => 'Private key',
     'download_recovery_keys' => 'Download your recovery keys',
-    'download_recovery_keys_confirmation' => 'You are about to download your recovery keys. Please store them in a safe place as they should be mandatory in case of deasaster.',
+    'download_recovery_keys_confirmation' => 'You are about to download your recovery keys. Please store them in a safe place as they should be mandatory in case of disaster.',
     'recovery_keys_download_date' => 'Recovery keys download date',
     'keys_not_recovered' => 'Public and Private keys not stored',
     'keys_not_recovered_explanation' => 'In order to prevent against any passwords lost, you should store safely your personal Teampass keys',

--- a/includes/language/russian.php
+++ b/includes/language/russian.php
@@ -1144,7 +1144,7 @@ return array(
     'public_key' => 'Public key',
     'private_key' => 'Private key',
     'download_recovery_keys' => 'Download your recovery keys',
-    'download_recovery_keys_confirmation' => 'You are about to download your recovery keys. Please store them in a safe place as they should be mandatory in case of deasaster.',
+    'download_recovery_keys_confirmation' => 'You are about to download your recovery keys. Please store them in a safe place as they should be mandatory in case of disaster.',
     'recovery_keys_download_date' => 'Recovery keys download date',
     'keys_not_recovered' => 'Public and Private keys not stored',
     'keys_not_recovered_explanation' => 'In order to prevent against any passwords lost, you should store safely your personal Teampass keys',

--- a/includes/language/swedish.php
+++ b/includes/language/swedish.php
@@ -1144,7 +1144,7 @@ return array(
     'public_key' => 'Public key',
     'private_key' => 'Private key',
     'download_recovery_keys' => 'Download your recovery keys',
-    'download_recovery_keys_confirmation' => 'You are about to download your recovery keys. Please store them in a safe place as they should be mandatory in case of deasaster.',
+    'download_recovery_keys_confirmation' => 'You are about to download your recovery keys. Please store them in a safe place as they should be mandatory in case of disaster.',
     'recovery_keys_download_date' => 'Recovery keys download date',
     'keys_not_recovered' => 'Public and Private keys not stored',
     'keys_not_recovered_explanation' => 'In order to prevent against any passwords lost, you should store safely your personal Teampass keys',

--- a/includes/language/turkish.php
+++ b/includes/language/turkish.php
@@ -1144,7 +1144,7 @@ return array(
     'public_key' => 'Public key',
     'private_key' => 'Private key',
     'download_recovery_keys' => 'Download your recovery keys',
-    'download_recovery_keys_confirmation' => 'You are about to download your recovery keys. Please store them in a safe place as they should be mandatory in case of deasaster.',
+    'download_recovery_keys_confirmation' => 'You are about to download your recovery keys. Please store them in a safe place as they should be mandatory in case of disaster.',
     'recovery_keys_download_date' => 'Recovery keys download date',
     'keys_not_recovered' => 'Public and Private keys not stored',
     'keys_not_recovered_explanation' => 'In order to prevent against any passwords lost, you should store safely your personal Teampass keys',

--- a/includes/language/ukrainian.php
+++ b/includes/language/ukrainian.php
@@ -1144,7 +1144,7 @@ return array(
     'public_key' => 'Public key',
     'private_key' => 'Private key',
     'download_recovery_keys' => 'Download your recovery keys',
-    'download_recovery_keys_confirmation' => 'You are about to download your recovery keys. Please store them in a safe place as they should be mandatory in case of deasaster.',
+    'download_recovery_keys_confirmation' => 'You are about to download your recovery keys. Please store them in a safe place as they should be mandatory in case of disaster.',
     'recovery_keys_download_date' => 'Recovery keys download date',
     'keys_not_recovered' => 'Public and Private keys not stored',
     'keys_not_recovered_explanation' => 'In order to prevent against any passwords lost, you should store safely your personal Teampass keys',

--- a/includes/language/vietnamese.php
+++ b/includes/language/vietnamese.php
@@ -1144,7 +1144,7 @@ return array(
     'public_key' => 'Public key',
     'private_key' => 'Private key',
     'download_recovery_keys' => 'Download your recovery keys',
-    'download_recovery_keys_confirmation' => 'You are about to download your recovery keys. Please store them in a safe place as they should be mandatory in case of deasaster.',
+    'download_recovery_keys_confirmation' => 'You are about to download your recovery keys. Please store them in a safe place as they should be mandatory in case of disaster.',
     'recovery_keys_download_date' => 'Recovery keys download date',
     'keys_not_recovered' => 'Public and Private keys not stored',
     'keys_not_recovered_explanation' => 'In order to prevent against any passwords lost, you should store safely your personal Teampass keys',


### PR DESCRIPTION
Fixes a simple typo in the translation files -- 'deasaster' is not the correct spelling of 'disaster' in English.