### PR TITLE
Fixing a vulnerability where a standard user could disable any user

### DIFF
--- a/includes/config/include.php
+++ b/includes/config/include.php
@@ -28,7 +28,7 @@
 
 define('TP_VERSION', '3.1.2');
 define("UPGRADE_MIN_DATE", "1727110744");
-define('TP_VERSION_MINOR', '115');
+define('TP_VERSION_MINOR', '116');
 define('TP_TOOL_NAME', 'Teampass');
 define('TP_ONE_DAY_SECONDS', 86400);
 define('TP_ONE_WEEK_SECONDS', 604800);

--- a/includes/tables_integrity.json
+++ b/includes/tables_integrity.json
@@ -17,7 +17,7 @@
     },
     {
         "table_name": "background_tasks_logs",
-        "structure_hash": "0f61780d6c72a4d7511f84f80ed7f2d85b422716da572609f329252cd730b285"
+        "structure_hash": "3fe2df7f32ad36a9c9534c4f03079547eda7fcf5bdf02358943f8ead6b55ef27"
     },
     {
         "table_name": "cache",
@@ -101,7 +101,7 @@
     },
     {
         "table_name": "log_system",
-        "structure_hash": "a69db25d9f3baa4c2cc7d9daafbb5eca717cddaf636b421b63036f79a1ae6e6e"
+        "structure_hash": "6332e45543704b860cfaf663e3aa766d250380f8b4102139e09d67f1010ad0b0"
     },
     {
         "table_name": "misc",
@@ -161,15 +161,15 @@
     },
     {
         "table_name": "sharekeys_fields",
-        "structure_hash": "b5caa08ad0132073e509b6bbfc1bbf7692a8acf06c239df1f00cd89efd2bb857"
+        "structure_hash": "7d6abf91104490eb1e5f78e5f8136c5e03ba48a774c0133e704c470453174f60"
     },
     {
         "table_name": "sharekeys_files",
-        "structure_hash": "bcae5ea668519654581f065b57a1f0991f4f1abd34ad19cf8d7405785eeeb594"
+        "structure_hash": "c4f4692b26fd4564e981ccf6e95f939557c030851fcd1c3ca3049d1fc1a445f0"
     },
     {
         "table_name": "sharekeys_items",
-        "structure_hash": "11a176592b7c1756c3488c0bd0fcf5812e2db5b16d12f3683b8be99196aa4504"
+        "structure_hash": "eacd859ad9395ac91e019834597b0135c64b9dbb8874ff3689e4abdd83e405d6"
     },
     {
         "table_name": "sharekeys_logs",

--- a/index.php
+++ b/index.php
@@ -257,7 +257,6 @@ $theme_navbar = $theme === 'dark' ? 'navbar-dark' : 'navbar-white navbar-light';
     <link rel="stylesheet" href="plugins/adminlte/css/adminlte.min.css?v=<?php echo TP_VERSION; ?>">
     <link rel="stylesheet" href="plugins/pace-progress/themes/corner-indicator.css?v=<?php echo TP_VERSION; ?>" type="text/css" />
     <link rel="stylesheet" href="plugins/select2/css/select2.min.css?v=<?php echo TP_VERSION; ?>" type="text/css" />
-    <!--<link rel="stylesheet" href="plugins/select2/css/select2-bootstrap.min.css?v=<?php echo TP_VERSION; ?>" type="text/css" />-->
     <link rel="stylesheet" href="plugins/select2/theme/select2-bootstrap4.min.css?v=<?php echo TP_VERSION; ?>" type="text/css" />
     <!-- Theme style -->
     <link rel="stylesheet" href="includes/css/teampass.css?v=<?php echo TP_VERSION; ?>">

--- a/sources/main.functions.php
+++ b/sources/main.functions.php
@@ -1021,7 +1021,8 @@ function getStatisticsData(array $SETTINGS): array
     );
     $counter_items_perso = DB::count();
         DB::query(
-        'SELECT id FROM ' . prefixTable('users') . ''
+        'SELECT id FROM ' . prefixTable('users') . ' WHERE login NOT IN (%s, %s, %s)',
+        'OTV', 'TP', 'API'
     );
     $counter_users = DB::count();
         DB::query(

--- a/sources/users.queries.php
+++ b/sources/users.queries.php
@@ -3065,6 +3065,21 @@ if (null !== $post_type) {
                 break;
             }
 
+            // Is this user allowed to do this?
+            if (
+                (int) $session->get('user-admin') !== 1
+                && (int) $session->get('user-can_manage_all_users') !== 1
+            ) {
+                echo prepareExchangedData(
+                    array(
+                        'error' => true,
+                        'message' => $lang->get('error_not_allowed_to'),
+                    ),
+                    'encode'
+                );
+                break;
+            }
+
             // decrypt and retrieve data in JSON format
             $dataReceived = prepareExchangedData(
                 $post_data,


### PR DESCRIPTION
Fixing a vulnerability where a standard user could disable any user 

> By querying the endpoint /sources/users.queries.php , all it takes is to specify the identi昀椀er of the user to be disabled, as well as a parameter ( disabled_status ) to de昀椀ne whether the target user should be disabled or enabled.
The JSON will take the following form:
{
"user_id": 10000021,
"disabled_status": 1
}
Here, the user_id 昀椀eld corresponds to the identi昀椀er of the target account. If the disabled_status 昀椀eld is set to 1 , the account will be disabled, and if it is set to 0 , the account will be enabled. 
Using the developed script, the following command can be executed:
python3 teampass_poc.py request --uri "/sources/users.queries.php" --data '{"user_id":
<target user id>,"disabled_status": 1}' --key "<encryption key or cookie>" --type "manage_user_disable_status" <target>

Fix for #4366
Small code cleaning