### PR TITLE
Profile fixes

### DIFF
--- a/pages/profile.php
+++ b/pages/profile.php
@@ -399,15 +399,16 @@ foreach ($session->get('user-roles_array') as $role) {
                                         <label class="col-sm-10 control-label"><?php echo $lang->get('timezone_selection');?></label>
                                         <div class="col-sm-10">
                                             <select class="form-control" id="profile-user-timezone">
-                                                <?php
-                                                foreach ($zones as $key => $zone) {
-                                                    echo '
-                                                <option value="' . $key . '"',
-                                                    $session->has('user-timezone') && $session->get('user-timezone') === $key ? ' selected' :
-                                                    (($session->has('user-timezone') && $session->get('user-timezone') === 'not_defined') && isset($SETTINGS['timezone']) && $SETTINGS['timezone'] === $key ? ' selected' : ''),
-                                                '>' . $zone . '</option>';
-                                                }
-                                                ?>
+                                                <?php foreach ($zones as $key => $zone): ?>
+                                                    <option value="<?php echo $key; ?>"<?php 
+                                                        if ($session->has('user-timezone'))
+                                                            if($session->get('user-timezone') === $key)
+                                                                echo ' selected';
+                                                            elseif ($session->get('user-timezone') === 'not_defined')
+                                                                if (isset($SETTINGS['timezone']) && $SETTINGS['timezone'] === $key)
+                                                                    echo ' selected';
+                                                    ?>><?php echo $zone; ?></option>
+                                                <?php endforeach; ?>
                                             </select>
                                         </div>
                                     </div>

--- a/pages/profile.php
+++ b/pages/profile.php
@@ -396,16 +396,15 @@ foreach ($session->get('user-roles_array') as $role) {
                                     </div>
 
                                     <div class="form-group">
-                                        <label class="col-sm-10 control-label"><?php echo $lang->get('timezone_selection'); ?></label>
+                                        <label class="col-sm-10 control-label"><?php echo $lang->get('timezone_selection');?></label>
                                         <div class="col-sm-10">
                                             <select class="form-control" id="profile-user-timezone">
                                                 <?php
                                                 foreach ($zones as $key => $zone) {
                                                     echo '
                                                 <option value="' . $key . '"',
-                                                    $session->has('user-timezone') && $session->get('user-timezone') && null !== $session->get('user-timezone') && $session->get('user-timezone') === $key ?
-                                                    ' selected' :
-                                                    (isset($SETTINGS['timezone']) === true && $SETTINGS['timezone'] === $key ? ' selected' : ''),
+                                                    $session->has('user-timezone') && $session->get('user-timezone') === $key ? ' selected' :
+                                                    (($session->has('user-timezone') && $session->get('user-timezone') === 'not_defined') && isset($SETTINGS['timezone']) && $SETTINGS['timezone'] === $key ? ' selected' : ''),
                                                 '>' . $zone . '</option>';
                                                 }
                                                 ?>

--- a/sources/users.queries.php
+++ b/sources/users.queries.php
@@ -2210,7 +2210,7 @@ if (null !== $post_type) {
                 );
 
                 // Prevent LFI.
-                $inputData['language'] = preg_replace('/[^a-z]/', "", $inputData['language']);
+                $inputData['language'] = preg_replace('/[^a-z_]/', "", $inputData['language']);
 
                 // Force english if non-existent language.
                 if (!file_exists(__DIR__."/../includes/language/".$inputData['language'].".php")) {


### PR DESCRIPTION
- **Fixed update user language, when underline is a character in language selector**
  - When the language "Portuguese (Brazil)" was selected, the prevent LFI regular expression removed the underline character, so whenever the user chose this language they ended up receiving English as a fallback.

    ```php
    echo $inputData['language']; // portuguese_br
    
    // Prevent LFI.
    $inputData['language'] = preg_replace('/[^a-z]/', "", $inputData['language']);
    
    echo $inputData['language']; // portuguesebr
    ```

- **Fixes timezone selection display in profile**
  - The way the logic was before, the system timezone was always selected. When selecting "America/Maceio" timezone in the profile and saving, the next time it was displayed, "UTC" appeared again. It was necessary to choose the preferred timezone whenever making any edit.