### PR TITLE
Fix  4316 - Error in the character encoding in “User Definition”

### DIFF
--- a/sources/users.queries.php
+++ b/sources/users.queries.php
@@ -1357,8 +1357,8 @@ if (null !== $post_type) {
 
                 $arrData['error'] = false;
                 $arrData['login'] = $rowUser['login'];
-                $arrData['name'] = empty($rowUser['name']) === false && $rowUser['name'] !== NULL ? html_entity_decode($rowUser['name'], ENT_QUOTES, 'UTF-8') : '';
-                $arrData['lastname'] = empty($rowUser['lastname']) === false && $rowUser['lastname'] !== NULL ? html_entity_decode($rowUser['lastname'], ENT_QUOTES, 'UTF-8') : '';
+                $arrData['name'] = !empty($rowUser['name']) === false && $rowUser['name'] !== NULL ? htmlspecialchars(strip_tags(html_entity_decode($rowUser['name'], ENT_QUOTES | ENT_HTML5, 'UTF-8')), ENT_QUOTES, 'UTF-8') : '';
+                $arrData['lastname'] = !empty($rowUser['lastname']) === false && $rowUser['lastname'] !== NULL ? htmlspecialchars(strip_tags(html_entity_decode($rowUser['lastname'], ENT_QUOTES | ENT_HTML5, 'UTF-8')), ENT_QUOTES, 'UTF-8') : '';
                 $arrData['email'] = $rowUser['email'];
                 $arrData['function'] = $functionsList;
                 $arrData['managedby'] = $managedBy;

--- a/sources/users.queries.php
+++ b/sources/users.queries.php
@@ -1357,8 +1357,8 @@ if (null !== $post_type) {
 
                 $arrData['error'] = false;
                 $arrData['login'] = $rowUser['login'];
-                $arrData['name'] = empty($rowUser['name']) === false && $rowUser['name'] !== NULL ? htmlspecialchars_decode($rowUser['name'], ENT_QUOTES) : '';
-                $arrData['lastname'] = empty($rowUser['lastname']) === false && $rowUser['lastname'] !== NULL ? htmlspecialchars_decode($rowUser['lastname'], ENT_QUOTES) : '';
+                $arrData['name'] = empty($rowUser['name']) === false && $rowUser['name'] !== NULL ? html_entity_decode($rowUser['name'], ENT_QUOTES, 'UTF-8') : '';
+                $arrData['lastname'] = empty($rowUser['lastname']) === false && $rowUser['lastname'] !== NULL ? html_entity_decode($rowUser['lastname'], ENT_QUOTES, 'UTF-8') : '';
                 $arrData['email'] = $rowUser['email'];
                 $arrData['function'] = $functionsList;
                 $arrData['managedby'] = $managedBy;


### PR DESCRIPTION
Corrects vowel characters with accents or special characters in the first and last names of users when editing their data.

Error documented in #4316
https://github.com/nilsteampassnet/TeamPass/issues/4316