### PR TITLE
Fix users encoding #4316

### DIFF
--- a/includes/core/login.js.php
+++ b/includes/core/login.js.php
@@ -31,7 +31,7 @@ declare(strict_types=1);
 
 ?>
 <script type="text/javascript">
-    var debugJavascript = true;
+    var debugJavascript = false;
 
     // On page load
     $(function() {

--- a/pages/users.js.php
+++ b/pages/users.js.php
@@ -819,10 +819,10 @@ if ($checkUserAccess->checkSession() === false || $checkUserAccess->userAccessPa
 
                     if (data.error === false) {
                         // Prefil with user data
-                        $('#form-login').val(data.login);
-                        $('#form-email').val(data.email);
-                        $('#form-name').val(data.name);
-                        $('#form-lastname').val(data.lastname);
+                        $('#form-login').val($('<div>').html(data.login).text());
+                        $('#form-email').val($('<div>').html(data.email).text());
+                        $('#form-name').val($('<div>').html(data.name).text());
+                        $('#form-lastname').val($('<div>').html(data.lastname).text());
                         $('#form-create-root-folder').iCheck(data.can_create_root_folder === 1 ? 'check' : 'uncheck');
                         $('#form-create-personal-folder').iCheck(data.personal_folder === 1 ? 'check' : 'uncheck');
                         $('#form-create-mfa-enabled').iCheck(data.mfa_enabled === 1 ? 'check' : 'uncheck');

--- a/sources/users.datatable.php
+++ b/sources/users.datatable.php
@@ -275,10 +275,10 @@ foreach ($rows as $record) {
                 ).
                 ((in_array($record['id'], [OTV_USER_ID, TP_USER_ID, SSH_USER_ID, API_USER_ID]) === false && (int) $record['pw_passwordlib'] === 1) ? '<i class=\"fa-solid fa-person-walking-luggage infotip ml-1\" style=\"color:Tomato\" title=\"Old password encryption. Shall login to initialize.\"></i>' : '');
         }
-        
+
         $sOutput .= '["<span data-id=\"'.$record['id'].'\" data-fullname=\"'.
-            addslashes(str_replace("'", '&lsquo;', empty($record['name']) === false ? $record['name'] : '')).' '.
-            addslashes(str_replace("'", '&lsquo;', empty($record['lastname']) === false ? $record['lastname'] : '')).
+            (empty($record['name']) === false ? htmlentities($record['name'], ENT_QUOTES|ENT_SUBSTITUTE|ENT_DISALLOWED) : '').' '.
+            (empty($record['lastname']) === false ? htmlentities($record['lastname'], ENT_QUOTES|ENT_SUBSTITUTE|ENT_DISALLOWED) : '').
             '\" data-auth-type=\"'.$record['auth_type'].'\" data-special=\"'.$record['special'].'\" data-mfa-enabled=\"'.$record['mfa_enabled'].'\" data-otp-provided=\"'.(isset($record['otp_provided']) === true ? $record['otp_provided'] : '').'\"></span>", ';
         //col2
         $sOutput .= '"'.
@@ -350,5 +350,4 @@ if (count($rows) > 0) {
     $sOutput .= '[]';
 }
 
-//echo ($sOutput).'}';
-echo $antiXss->xss_clean($sOutput.'}');
+echo ($sOutput).'}';

--- a/sources/users.queries.php
+++ b/sources/users.queries.php
@@ -1357,8 +1357,8 @@ if (null !== $post_type) {
 
                 $arrData['error'] = false;
                 $arrData['login'] = $rowUser['login'];
-                $arrData['name'] = empty($rowUser['name']) === false && $rowUser['name'] !== NULL ? htmlspecialchars_decode($rowUser['name'], ENT_QUOTES) : '';
-                $arrData['lastname'] = empty($rowUser['lastname']) === false && $rowUser['lastname'] !== NULL ? htmlspecialchars_decode($rowUser['lastname'], ENT_QUOTES) : '';
+                $arrData['name'] = empty($rowUser['name']) === false && $rowUser['name'] !== NULL ? $rowUser['name'] : '';
+                $arrData['lastname'] = empty($rowUser['lastname']) === false && $rowUser['lastname'] !== NULL ? $rowUser['lastname'] : '';
                 $arrData['email'] = $rowUser['email'];
                 $arrData['function'] = $functionsList;
                 $arrData['managedby'] = $managedBy;


### PR DESCRIPTION
- Safely remove html encoding by using virtual div element (data strings are always html safe):
```js
$('#form-login').val($('<div>').html(data.login).text());
```

- Fix issue where $antiXss->xss_clean resolve html encodings:
![image](https://github.com/user-attachments/assets/90a1675b-038b-43a0-88ca-1d22df72d179)

- Remove insecure htmlspecialchars_decode.

All fields seems to be secure:
![image](https://github.com/user-attachments/assets/e782040c-c830-459b-9d89-aff84d6b88b4)
