### PR TITLE
Add email field to admin account setup #4382

### DIFF
--- a/install/install.js
+++ b/install/install.js
@@ -97,6 +97,8 @@ function checkPage()
         }
     } else if (step === "4") {
     // STEP 4
+
+        // Password checks
         if ($("#admin_pwd").val() === "") {
             alertify
                 .error('<i class="fas fa-ban mr-2"></i>You must define a password for Administrator account.', 10)
@@ -112,13 +114,26 @@ function checkPage()
                 .error('<i class="fas fa-ban mr-2"></i>Administrator passwords are not similar.', 10)
                 .dismissOthers();
             return false;
-        } else{
-            $("#hid_db_pre").val($("#tbl_prefix").val());
-            jsonValues = {"tbl_prefix":sanitizeString($("#tbl_prefix").val()), "sk_path":sanitizeString($("#sk_path").val()), "admin_pwd":sanitizeString($("#admin_pwd").val()), "send_stats":""};
-            dataToUse = JSON.stringify(jsonValues);
-            tasks = ["misc*preparation"];
-            multiple = "";
         }
+        
+        // Email checks
+        if ($("#admin_email").val() === "") {
+            alertify
+                .error('<i class="fas fa-ban mr-2"></i>You must define an email for Administrator account.', 10)
+                .dismissOthers();
+            return false;
+        } else if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test($("#admin_email").val())) {
+            alertify
+                .error('<i class="fas fa-ban mr-2"></i>Administrator email is not valid.', 10)
+                .dismissOthers();
+            return false;
+        }
+
+        $("#hid_db_pre").val($("#tbl_prefix").val());
+        jsonValues = {"tbl_prefix":sanitizeString($("#tbl_prefix").val()), "sk_path":sanitizeString($("#sk_path").val()), "admin_pwd":sanitizeString($("#admin_pwd").val()), "admin_email":sanitizeString($("#admin_email").val()), "send_stats":""};
+        dataToUse = JSON.stringify(jsonValues);
+        tasks = ["misc*preparation"];
+        multiple = "";
     } else if (step === "5") {
     // STEP 5
         dataToUse = "";

--- a/install/install.php
+++ b/install/install.php
@@ -308,12 +308,17 @@ define('MIN_PHP_VERSION', 8.1);
 					<div class="form-group">
 						<label>Teampass Administrator password</label>
 						<input type="password" class="form-control" id="admin_pwd" class="ui-widget" value=""><span id="res4_check10"></span>
-					</div
+					</div>
 					
 					<div class="form-group">
 						<label>Confirm Administrator password</label>
 						<input type="password" class="form-control" id="admin_pwd_confirm" class="ui-widget" value=""><span id="res4_check11"></span>
-					</div
+					</div>
+					
+					<div class="form-group">
+						<label>Administrator email</label>
+						<input type="text" class="form-control" id="admin_email" class="ui-widget" value=""><span id="res4_check12"></span>
+					</div>
 				</div>
 			</div>
 		</div>


### PR DESCRIPTION
I verified that the admin user creation query already had the "admin_email" field defined. [Here](https://github.com/nilsteampassnet/TeamPass/blob/bdd3fd9af5f6016ec6fbd07294d59ac3ecb560d4/install/install.queries.php#L842)

So I just did the html and js.