### PR TITLE
Fix settings last modification.

### DIFF
--- a/includes/libraries/teampassclasses/configmanager/src/ConfigManager.php
+++ b/includes/libraries/teampassclasses/configmanager/src/ConfigManager.php
@@ -30,6 +30,7 @@ namespace TeampassClasses\ConfigManager;
 
 use TeampassClasses\SessionManager\SessionManager;
 use DB;
+
 class ConfigManager
 {
     private $settings;
@@ -131,7 +132,7 @@ class ConfigManager
         require_once __DIR__.'/../../../sergeytsalkov/meekrodb/db.class.php';
 
         $maxTimestamp = DB::queryFirstField(
-            'SELECT MAX(GREATEST(created_at, updated_at)) AS timestamp
+            'SELECT GREATEST(MAX(created_at), MAX(updated_at)) AS timestamp
             FROM ' . prefixTable('misc') . '
             WHERE type = %s',
             'admin'

--- a/sources/admin.queries.php
+++ b/sources/admin.queries.php
@@ -2125,10 +2125,6 @@ switch ($post_type) {
                 $post_field
             );
 
-            // Update session settings
-            $SETTINGS[$post_field] = $post_value;
-            $session->set('teampass-settings', $SETTINGS);
-
             // in case of stats enabled, update the actual time
             if ($post_field === 'send_stats') {
                 // Check if previous time exists, if not them insert this value in DB

--- a/vendor/teampassclasses/configmanager/src/ConfigManager.php
+++ b/vendor/teampassclasses/configmanager/src/ConfigManager.php
@@ -132,7 +132,7 @@ class ConfigManager
         require_once __DIR__.'/../../../sergeytsalkov/meekrodb/db.class.php';
 
         $maxTimestamp = DB::queryFirstField(
-            'SELECT MAX(GREATEST(created_at, updated_at)) AS timestamp
+            'SELECT GREATEST(MAX(created_at), MAX(updated_at)) AS timestamp
             FROM ' . prefixTable('misc') . '
             WHERE type = %s',
             'admin'


### PR DESCRIPTION
Better than #4385 that only update session of user which updated setting and not others.

`GREATEST(MAX(created_at), MAX(updated_at))` seems have a better result than `MAX(GREATEST(created_at, updated_at))`.

```sql
mysql> SELECT GREATEST(MAX(created_at), MAX(updated_at)) AS timestamp FROM teampass_misc WHERE type = 'admin';
+------------+
| timestamp  |
+------------+
| 1727940012 |
+------------+
1 row in set (0,00 sec)

mysql> SELECT MAX(GREATEST(created_at, updated_at)) AS timestamp FROM teampass_misc WHERE type = 'admin';
+------------+
| timestamp  |
+------------+
| 1727939791 |
+------------+
1 row in set (0,00 sec)
```