### PR TITLE
Fix role visibility display issue.

### DIFF
--- a/install/upgrade_run_3.1.php
+++ b/install/upgrade_run_3.1.php
@@ -588,8 +588,14 @@ if (file_exists($configFilePath)) {
     }    
 }
 
-
 //---<END 3.1.2
+
+
+//--->BEGIN 3.1.3
+
+// Remove from roles_values folders without any access
+$deleteQuery = "DELETE FROM `" . $pre . "roles_values` WHERE type = ''";
+mysqli_query($db_link, $deleteQuery);
 
 //---------------------------------------------------------------------
 

--- a/sources/roles.queries.php
+++ b/sources/roles.queries.php
@@ -222,15 +222,17 @@ if (null !== $post_type) {
                     $post_roleId
                 );
 
-                //Store in DB
-                DB::insert(
-                    prefixTable('roles_values'),
-                    array(
-                        'folder_id' => $folderId,
-                        'role_id' => $post_roleId,
-                        'type' => $post_access,
-                    )
-                );
+                //Store in DB if "access" is not empty (no access to folder)
+                if (!empty($post_access)) {
+                    DB::insert(
+                        prefixTable('roles_values'),
+                        array(
+                            'folder_id' => $folderId,
+                            'role_id' => $post_roleId,
+                            'type' => $post_access,
+                        )
+                    );
+                }
 
                 // Manage descendants
                 if ((int) $post_propagate === 1) {
@@ -244,15 +246,17 @@ if (null !== $post_type) {
                             $post_roleId
                         );
 
-                        //Store in DB
-                        DB::insert(
-                            prefixTable('roles_values'),
-                            array(
-                                'folder_id' => $node->id,
-                                'role_id' => $post_roleId,
-                                'type' => $post_access,
-                            )
-                        );
+                        //Store in DB if "access" is not empty (no access to folder)        
+                        if (!empty($post_access)) {
+                            DB::insert(
+                                prefixTable('roles_values'),
+                                array(
+                                    'folder_id' => $node->id,
+                                    'role_id' => $post_roleId,
+                                    'type' => $post_access,
+                                )
+                            );
+                        }
                     }
                 }
             }


### PR DESCRIPTION
My user role:
![image](https://github.com/user-attachments/assets/d6151087-67e4-469e-ba1b-87ea02213515)

Add visibility on role:
![image](https://github.com/user-attachments/assets/b1337b47-8ec6-4d81-9e8d-9cc1795f13c5)

Remove visibility and folder disappear successfully:
![image](https://github.com/user-attachments/assets/b5b7aa5f-65b9-425e-9170-6e42f78825b5)

However I still see `'test` role with another user that has access to this folder:
![image](https://github.com/user-attachments/assets/671a7720-9c00-418c-bdec-b9e944588e3e)

This issue occur when 'type' field is empty:
```sql
mysql> SELECT * FROM teampass_roles_values WHERE type = "";
+--------------+---------+-----------+------+
| increment_id | role_id | folder_id | type |
+--------------+---------+-----------+------+
|            3 |       1 |         3 |      |
|            5 |       1 |         5 |      |
|          443 |       1 |       455 |      |
|          456 |       8 |        95 |      |
+--------------+---------+-----------+------+
4 rows in set (0.00 sec)
```