### PR TITLE
Revert excessive filter on get_teampass_settings.

### DIFF
--- a/sources/main.queries.php
+++ b/sources/main.queries.php
@@ -769,16 +769,6 @@ function systemHandler(string $post_type, array|null|string $dataReceived, array
         */
         case 'get_teampass_settings'://action_system
 
-            // Only administrators can see this confidential informations.
-            if ((int) $session->get('user-admin') !== 1) {
-                return prepareExchangedData(
-                    array(
-                        'error' => false,
-                    ),
-                    'encode'
-                );
-            }
-
             // Encrypt data to return
             return prepareExchangedData(
                 array_intersect_key(


### PR DESCRIPTION
Users must access to `get_teampass_settings` and it is already filtered by `array_intersect_key`.

![image](https://github.com/user-attachments/assets/197026ff-5bd2-4b8f-8cf7-003c226191a2)
