### PR TITLE
Change password expiration calculation rules

### DIFF
--- a/sources/items.queries.php
+++ b/sources/items.queries.php
@@ -4225,7 +4225,12 @@ switch ($inputData['type']) {
             // List all ITEMS
             if ($folderIsPf === false) {
                 $where->add('i.inactif=%i', 0);
-                $where->add('l.date=%l', '(SELECT date FROM ' . prefixTable('log_items') . " WHERE action IN ('at_creation', 'at_modification') AND id_item=i.id ORDER BY date DESC LIMIT 1)");
+                $sql_e='(SELECT date FROM ' . prefixTable('log_items') 
+                    . " WHERE action = 'at_creation' AND id_item=i.id " 
+                    . 'union all SELECT date FROM '. prefixTable('log_items') 
+                    . " WHERE action = 'at_modification' AND raison = 'at_pw'
+                    AND id_item=i.id ORDER BY date DESC LIMIT 1)";
+                $where->add('l.date=%l', $sql_e);
                 if (empty($limited_to_items) === false) {
                     $where->add('i.id IN %ls', explode(',', $limited_to_items));
                 }


### PR DESCRIPTION
Modify the password expiration calculation rule, converge the calculation rule, when modifying other attributes of the item, it will not affect the expiration time, when modifying the password, update the expiration time.