### PR TITLE
Fix the problem of abnormal values of item key and created at in item attributes

### DIFF
--- a/sources/import.queries.php
+++ b/sources/import.queries.php
@@ -377,6 +377,8 @@ switch (filter_input(INPUT_POST, 'type', FILTER_SANITIZE_FULL_SPECIAL_CHARS)) {
                     'login' => empty($item['login']) === true ? '' : substr($item['login'], 0, 200),
                     'anyone_can_modify' => $post_edit_all,
                     'encryption_type' => 'teampass_aes',
+                    'item_key' => uniqidReal(50),
+                    'created_at' => time(),
                 )
             );
             $newId = DB::insertId();

--- a/sources/import.queries.php
+++ b/sources/import.queries.php
@@ -818,6 +818,8 @@ switch (filter_input(INPUT_POST, 'type', FILTER_SANITIZE_FULL_SPECIAL_CHARS)) {
                     'inactif' => 0,
                     'restricted_to' => '',
                     'perso' => $post_folders[$item['parentFolderId']]['isPF'] === true ? 1 : 0,
+                    'item_key' => uniqidReal(50),
+                    'created_at' => time(),
                 )
             );
             $newId = DB::insertId();

--- a/sources/items.queries.php
+++ b/sources/items.queries.php
@@ -2251,8 +2251,9 @@ switch ($inputData['type']) {
 
             // generate the query to update the new record with the previous values
             $aSet = array();
-            $aSet['created_at'] = time();
             foreach ($originalRecord as $key => $value) {
+                $aSet['item_key'] = uniqidReal(50);
+                $aSet['created_at'] = time();
                 if ($key === 'id_tree') {
                     $aSet['id_tree'] = $post_dest_id;
                 } elseif ($key === 'label') {


### PR DESCRIPTION
Fix the problem that when importing items via csv, the value of item_key is -1 and the value of created_at is null, make sure the item_key is unique, when it is -1, no abnormality is found in the process of using it to avoid unknown problems, fix it.

When copying an item, the item_key and created_at of the newly generated item still use the attributes of the copied item.