### PR TITLE
fix jsUrl parameter error

### DIFF
--- a/install/install.queries.php
+++ b/install/install.queries.php
@@ -1561,9 +1561,9 @@ if (isset($_SESSION[\'settings\'][\'timezone\']) === true) {
                     }
                     unlink($csrfp_file); // delete existing csrfp.config file
                     copy($csrfp_file_sample, $csrfp_file); // make a copy of csrfp.config.sample file
-                    $inputData['data'] = file_get_contents($csrfp_file);
-                    $newdata = str_replace('"CSRFP_TOKEN" => ""', '"CSRFP_TOKEN" => "' . bin2hex(openssl_random_pseudo_bytes(25)) . '"', $inputData['data']);
-                    $jsUrl = $data_sent['url_path'] . '/includes/libraries/csrfp/js/csrfprotector.js';
+                    $data = file_get_contents($csrfp_file);
+                    $newdata = str_replace('"CSRFP_TOKEN" => ""', '"CSRFP_TOKEN" => "' . bin2hex(openssl_random_pseudo_bytes(25)) . '"', $data);
+                    $jsUrl = $inputData['data']['url_path'] . '/includes/libraries/csrfp/js/csrfprotector.js';
                     $newdata = str_replace('"jsUrl" => ""', '"jsUrl" => "' . $jsUrl . '"', $newdata);
                     file_put_contents('../includes/libraries/csrfp/libs/csrfp.config.php', $newdata);
 

--- a/install/install.queries.php
+++ b/install/install.queries.php
@@ -1563,7 +1563,7 @@ if (isset($_SESSION[\'settings\'][\'timezone\']) === true) {
                     copy($csrfp_file_sample, $csrfp_file); // make a copy of csrfp.config.sample file
                     $data = file_get_contents($csrfp_file);
                     $newdata = str_replace('"CSRFP_TOKEN" => ""', '"CSRFP_TOKEN" => "' . bin2hex(openssl_random_pseudo_bytes(25)) . '"', $data);
-                    $jsUrl = $inputData['data']['url_path'] . '/includes/libraries/csrfp/js/csrfprotector.js';
+                    $jsUrl = './includes/libraries/csrfp/js/csrfprotector.js';
                     $newdata = str_replace('"jsUrl" => ""', '"jsUrl" => "' . $jsUrl . '"', $newdata);
                     file_put_contents('../includes/libraries/csrfp/libs/csrfp.config.php', $newdata);
 


### PR DESCRIPTION
Fix missing url_path in jsUrl parameter in csrfp.config.php file.

![404](https://github.com/user-attachments/assets/92cfc013-8247-434d-a626-9b74c75d438c)


![image](https://github.com/user-attachments/assets/89732ae6-a75f-47df-a825-5bfff870fc8d)
