### PR TITLE
fix missing characters when exporting pdf

### DIFF
--- a/sources/export.queries.php
+++ b/sources/export.queries.php
@@ -632,7 +632,7 @@ if (null !== $post_type) {
                     if ($prev_path !== $record['path']) {
                         $html_table .= '
                             <tr>
-                                <td colspan="6">'.$record['path'].'</td>
+                                <td colspan="6">'.htmlspecialchars($record['path']).'</td>
                             </tr>';
                     }
                     $prev_path = $record['path'];
@@ -640,12 +640,12 @@ if (null !== $post_type) {
                     // build
                     $html_table .= '
                     <tr>
-                        <td>'.$record['label'].'</td>
-                        <td>'.$record['login'].'</td>
-                        <td>'.$record['pw'].'</td>
-                        <td>'.$record['url'].'</td>
-                        <td>'.$record['description'].'</td>
-                        <td>'.$record['email'].'</td>
+                        <td>'.htmlspecialchars($record['label']).'</td>
+                        <td>'.htmlspecialchars($record['login']).'</td>
+                        <td>'.htmlspecialchars($record['pw']).'</td>
+                        <td>'.htmlspecialchars($record['url']).'</td>
+                        <td>'.htmlspecialchars($record['description']).'</td>
+                        <td>'.htmlspecialchars($record['email']).'</td>
                     </tr>';
                 }
                 $html_table .= '


### PR DESCRIPTION
When the password contains characters such as <,>, because of the html encoding problem, the password display in the exported PDF file is incomplete.