### PR TITLE
Fix user password expiration days error

### DIFF
--- a/sources/core.php
+++ b/sources/core.php
@@ -539,7 +539,7 @@ if (isset($SETTINGS['ldap_mode']) === true && (int) $SETTINGS['ldap_mode'] === 1
             $session->set('user-num_days_before_exp', 'infinite');
             $session->set('user-validite_pw', 1);
         } else {
-            $session->set('user-num_days_before_exp', $SETTINGS['pw_life_duration'] - round((mktime(0, 0, 0, (int) date('m'), (int) date('d'), (int) date('y')) - $session->get('user-last_pw_change')) / (24 * 60 * 60)));
+            $session->set('user-num_days_before_exp', (int) $SETTINGS['pw_life_duration'] - round((mktime(0, 0, 0, (int) date('m'), (int) date('d'), (int) date('y')) - (int) $session->get('user-last_pw_change')) / (24 * 60 * 60)));
             if ($session->get('user-num_days_before_exp') <= 0) {
                 $session->set('user-validite_pw', 0);
             } else {

--- a/sources/identify.php
+++ b/sources/identify.php
@@ -1157,15 +1157,22 @@ function checkUserPasswordValidity($userInfo, $numDaysBeforePwExpiration, $lastP
                 'user_force_relog' => 'infinite',
                 'numDaysBeforePwExpiration' => '',
             ];
+        } elseif ((int) $SETTINGS['pw_life_duration']  >0){
+            return [
+                'validite_pw' => $numDaysBeforePwExpiration <= 0 ? false : true,
+                'last_pw_change' => $userInfo['last_pw_change'],
+                'user_force_relog' => 'infinite',
+                'numDaysBeforePwExpiration' => $SETTINGS['pw_life_duration'] - round(
+                    (mktime(0, 0, 0, (int) date('m'), (int) date('d'), (int) date('y')) - $lastPwChange) / (24 * 60 * 60)),
+            ];
+        } else {
+            return [
+                'validite_pw' => false,
+                'last_pw_change' => '',
+                'user_force_relog' => '',
+                'numDaysBeforePwExpiration' => '',
+            ];
         }
-        
-        return [
-            'validite_pw' => $numDaysBeforePwExpiration <= 0 ? false : true,
-            'last_pw_change' => $userInfo['last_pw_change'],
-            'user_force_relog' => 'infinite',
-            'numDaysBeforePwExpiration' => $SETTINGS['pw_life_duration'] - round(
-                (mktime(0, 0, 0, (int) date('m'), (int) date('d'), (int) date('y')) - $lastPwChange) / (24 * 60 * 60)),
-        ];
     } else {
         return [
             'validite_pw' => false,


### PR DESCRIPTION
Missing judgment condition in code handling pw_life_duration>0

Fix type error in pw_life_duration and user-last_pw_change values

```
PHP Fatal error:  Uncaught TypeError: Unsupported operand types: int - string in /var/www/html/teampass/sources/core.php:542\nStack trace:\n#0 /var/www/html/teampass/index.php(110): require_once()\n#1 {main}\n  thrown in /var/www/html/teampass/sources/core.php on line 542
```