### PR TITLE
Fix issue #4422: Resolve edit errors on previously CSV-imported items

### DIFF
--- a/pages/items.js.php
+++ b/pages/items.js.php
@@ -5463,8 +5463,7 @@ $var['hidden_asterisk'] = '<i class="fa-solid fa-asterisk mr-2"></i><i class="fa
                 // Show restrictions with Badges
                 var html_restrictions = '';
                 $.each(store.get('teampassItem').id_restricted_to, function(i, value) {
-                    html_restrictions +=https://github.com/rcruz-pntlb/TeamPass/edit/bugfix/4422-fix-item-edit-after-csv-import/pages/items.js.php
-                        '<span class="badge badge-info mr-2 mb-1"><i class="fa-solid fa-group fa-sm mr-1"></i>' +
+                    html_restrictions +='<span class="badge badge-info mr-2 mb-1"><i class="fa-solid fa-group fa-sm mr-1"></i>' +
                         data.users_list.find(x => x.id === parseInt(value)).name + '</span>';
                 });
                 /*BEGIN modification for issue #4422 bugfix/4422-fix-item-edit-after-csv-import

--- a/pages/items.js.php
+++ b/pages/items.js.php
@@ -5469,14 +5469,7 @@ $var['hidden_asterisk'] = '<i class="fa-solid fa-asterisk mr-2"></i><i class="fa
                 /*BEGIN modification for issue #4422 bugfix/4422-fix-item-edit-after-csv-import
                   original post: https://github.com/nilsteampassnet/TeamPass/issues/4422
                     @Author:     rcruz@pintaluba.com
-                    @Date:       10/29/2024
-
-                --REPLACES ORIGINAL CODE--
-                $.each(store.get('teampassItem').id_restricted_to_roles, function(i, value) {
-                    html_restrictions +=
-                        '<span class="badge badge-info mr-2 mb-1"><i class="fa-solid fa-group fa-sm mr-1"></i>' +
-                        data.roles_list.find(x => x.id === parseInt(value)).title + '</span>';
-                });                                                
+                    @Date:       10/29/2024                                            
                 */
                 $.each(store.get('teampassItem').id_restricted_to_roles, function(i, value) {                   
                     const role = data.roles_list.find(x => x.id === parseInt(value));

--- a/pages/items.js.php
+++ b/pages/items.js.php
@@ -5463,15 +5463,28 @@ $var['hidden_asterisk'] = '<i class="fa-solid fa-asterisk mr-2"></i><i class="fa
                 // Show restrictions with Badges
                 var html_restrictions = '';
                 $.each(store.get('teampassItem').id_restricted_to, function(i, value) {
-                    html_restrictions +=
+                    html_restrictions +=https://github.com/rcruz-pntlb/TeamPass/edit/bugfix/4422-fix-item-edit-after-csv-import/pages/items.js.php
                         '<span class="badge badge-info mr-2 mb-1"><i class="fa-solid fa-group fa-sm mr-1"></i>' +
                         data.users_list.find(x => x.id === parseInt(value)).name + '</span>';
                 });
+                /*BEGIN modification for issue #4422 bugfix/4422-fix-item-edit-after-csv-import
+                  original post: https://github.com/nilsteampassnet/TeamPass/issues/4422
+                    @Author:     rcruz@pintaluba.com
+                    @Date:       10/29/2024
+
+                --REPLACES ORIGINAL CODE--
                 $.each(store.get('teampassItem').id_restricted_to_roles, function(i, value) {
                     html_restrictions +=
                         '<span class="badge badge-info mr-2 mb-1"><i class="fa-solid fa-group fa-sm mr-1"></i>' +
                         data.roles_list.find(x => x.id === parseInt(value)).title + '</span>';
+                });                                                
+                */
+                $.each(store.get('teampassItem').id_restricted_to_roles, function(i, value) {                   
+                    const role = data.roles_list.find(x => x.id === parseInt(value));
+                    html_restrictions += (role ? '<span class="badge badge-info mr-2 mb-1"><i class="fa-solid fa-group fa-sm mr-1"></i>' + role.title  + '</span>' : '');
                 });
+                /*END modification for issue #4422 bugfix/4422-fix-item-edit-after-csv-import*/
+                        
                 if (html_restrictions === '') {
                     $('#card-item-restrictedto').html('<?php echo $lang->get('no_special_restriction'); ?>');
                 } else {

--- a/pages/items.js.php
+++ b/pages/items.js.php
@@ -5465,17 +5465,12 @@ $var['hidden_asterisk'] = '<i class="fa-solid fa-asterisk mr-2"></i><i class="fa
                 $.each(store.get('teampassItem').id_restricted_to, function(i, value) {
                     html_restrictions +='<span class="badge badge-info mr-2 mb-1"><i class="fa-solid fa-group fa-sm mr-1"></i>' +
                         data.users_list.find(x => x.id === parseInt(value)).name + '</span>';
-                });
-                /*BEGIN modification for issue #4422 bugfix/4422-fix-item-edit-after-csv-import
-                  original post: https://github.com/nilsteampassnet/TeamPass/issues/4422
-                    @Author:     rcruz@pintaluba.com
-                    @Date:       10/29/2024                                            
-                */
+                }); 
+                        
                 $.each(store.get('teampassItem').id_restricted_to_roles, function(i, value) {                   
                     const role = data.roles_list.find(x => x.id === parseInt(value));
                     html_restrictions += (role ? '<span class="badge badge-info mr-2 mb-1"><i class="fa-solid fa-group fa-sm mr-1"></i>' + role.title  + '</span>' : '');
-                });
-                /*END modification for issue #4422 bugfix/4422-fix-item-edit-after-csv-import*/
+                });     
                         
                 if (html_restrictions === '') {
                     $('#card-item-restrictedto').html('<?php echo $lang->get('no_special_restriction'); ?>');


### PR DESCRIPTION
This pull request addresses a bug where items, after being imported via CSV, could not be edited correctly. The issue was due to missing role validation in the HTML rendering process, and it specifically affects the `pages/items.js.php` script.

Changes include:
- Added a role existence check before adding HTML badge elements.
- Refactored the HTML generation loop to ensure robustness if roles are missing in `data.roles_list`.
- Fixed a minor error in the code that was not detected in the previous commit.

Original issue: https://github.com/nilsteampassnet/TeamPass/issues/4422
