### PR TITLE
Improve teampass cron detection.

### DIFF
--- a/pages/admin.php
+++ b/pages/admin.php
@@ -28,9 +28,6 @@ declare(strict_types=1);
  * @license   GPL-3.0
  * @see       https://www.teampass.net
  */
-use TiBeN\CrontabManager\CrontabJob;
-use TiBeN\CrontabManager\CrontabAdapter;
-use TiBeN\CrontabManager\CrontabRepository;
 use TeampassClasses\SessionManager\SessionManager;
 use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
 use TeampassClasses\Language\Language;
@@ -199,9 +196,17 @@ if ($checkUserAccess->checkSession() === false || $checkUserAccess->userAccessPa
 
 // Instantiate the adapter and repository
 try {
-    $crontabRepository = new CrontabRepository(new CrontabAdapter());
-    $results = $crontabRepository->findJobByRegex('/Teampass\ scheduler/');
-    if (count($results) === 0) {
+    // Get last cron execution timestamp
+    $result = DB::query(
+        'SELECT valeur
+        FROM ' . prefixTable('misc') . '
+        WHERE type = %s AND intitule = %s and valeur >= %d',
+        'admin',
+        'last_cron_exec',
+        time() - 600 // max 10 minutes
+    );
+
+    if (DB::count() === 0) {
         ?>
                             <div class="callout callout-info alert-dismissible mt-3" role="alert">
                                 <h5><i class="fa-solid fa-info mr-2"></i><?php echo $lang->get('information'); ?></h5>

--- a/pages/tasks.php
+++ b/pages/tasks.php
@@ -28,9 +28,6 @@ declare(strict_types=1);
  * @license   GPL-3.0
  * @see       https://www.teampass.net
  */
-use TiBeN\CrontabManager\CrontabJob;
-use TiBeN\CrontabManager\CrontabAdapter;
-use TiBeN\CrontabManager\CrontabRepository;
 use TeampassClasses\SessionManager\SessionManager;
 use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
 use TeampassClasses\Language\Language;
@@ -126,9 +123,17 @@ header('Cache-Control: no-cache, no-store, must-revalidate');
 
 // Instantiate the adapter and repository
 try {
-    $crontabRepository = new CrontabRepository(new CrontabAdapter());
-    $results = $crontabRepository->findJobByRegex('/Teampass\ scheduler/');
-    if (count($results) === 0) {
+    // Get last cron execution timestamp
+    $result = DB::query(
+        'SELECT valeur
+        FROM ' . prefixTable('misc') . '
+        WHERE type = %s AND intitule = %s and valeur >= %d',
+        'admin',
+        'last_cron_exec',
+        time() - 600 // max 10 minutes
+    );
+
+    if (DB::count() === 0) {
         ?>
                                             <div class="callout callout-info alert-dismissible mt-3">
                                                 <h5><i class="fa-solid fa-info mr-2"></i><?php echo $lang->get('information'); ?></h5>

--- a/sources/scheduler.php
+++ b/sources/scheduler.php
@@ -46,6 +46,23 @@ $scheduler = new scheduler();
 $configManager = new ConfigManager();
 $SETTINGS = $configManager->getAllSettings();
 
+// Update row if exists
+$updated = DB::update(
+    prefixTable('misc'),
+    ['valeur' => time()],
+    'type = "admin" AND intitule = "last_cron_exec"'
+);
+
+// Insert row if not exists
+if ($updated === 0) {
+    DB::insert(
+        prefixTable('misc'), [
+        'type' => 'admin',
+        'intitule' => 'last_cron_exec',
+        'valeur' => time()
+    ]);
+}
+
 // Build the scheduler jobs
 // https://github.com/peppeocchi/php-cron-scheduler
 $scheduler->php(__DIR__.'/../scripts/background_tasks___userKeysCreation.php')->everyMinute($SETTINGS['user_keys_job_frequency'] ?? '1');


### PR DESCRIPTION
This change allows administrators to disable the exec() function without break teampass (disable_functions in php.ini).

This also avoids SELinux AVC in audit logs:
```
type=AVC msg=audit(1730880782.169:329): avc:  denied  { read } for  pid=10249 comm="unix_chkpwd" name="shadow" dev="dm-0" ino=16812627 scontext=system_u:system_r:httpd_t:s0 tcontext=system_u:object_r:shadow_t:s0 tclass=file permissive=1
type=AVC msg=audit(1730880782.169:329): avc:  denied  { open } for  pid=10249 comm="unix_chkpwd" path="/etc/shadow" dev="dm-0" ino=16812627 scontext=system_u:system_r:httpd_t:s0 tcontext=system_u:object_r:shadow_t:s0 tclass=file permissive=1
type=AVC msg=audit(1730880782.169:330): avc:  denied  { getattr } for  pid=10249 comm="unix_chkpwd" path="/etc/shadow" dev="dm-0" ino=16812627 scontext=system_u:system_r:httpd_t:s0 tcontext=system_u:object_r:shadow_t:s0 tclass=file permissive=1
type=AVC msg=audit(1730880782.170:331): avc:  denied  { nlmsg_relay } for  pid=10248 comm="crontab" scontext=system_u:system_r:httpd_t:s0 tcontext=system_u:system_r:httpd_t:s0 tclass=netlink_audit_socket permissive=1
type=AVC msg=audit(1730880782.170:331): avc:  denied  { audit_write } for  pid=10248 comm="crontab" capability=29  scontext=system_u:system_r:httpd_t:s0 tcontext=system_u:system_r:httpd_t:s0 tclass=capability permissive=1
type=AVC msg=audit(1730880782.170:334): avc:  denied  { open } for  pid=10248 comm="crontab" path="/var/spool/cron/httpd" dev="dm-0" ino=16971141 scontext=system_u:system_r:httpd_t:s0 tcontext=system_u:object_r:user_cron_spool_t:s0 tclass=file permissive=1
```