### PR TITLE
Use random encryption key instead and reset session id on login.

### DIFF
--- a/includes/core/login.js.php
+++ b/includes/core/login.js.php
@@ -808,7 +808,7 @@ declare(strict_types=1);
                 
                 if (debugJavascript === true) {
                     console.info('Identification answer:')
-                    console.log('SESSION KEY is: <?php echo $session->get('key'); ?>');
+                    console.log('SESSION KEY is: ' + data.session_key);
                     console.log(data);
                 }
                 

--- a/includes/core/logout.php
+++ b/includes/core/logout.php
@@ -86,7 +86,6 @@ if (empty($user_id) === false) {
 
 // erase session table
 $session->invalidate();
-$session->set('key', SessionManager::getCookieValue('PHPSESSID'));
 
 ?>
 <script type="text/javascript" src="../../plugins/store.js/dist/store.everything.min.js"></script>

--- a/index.php
+++ b/index.php
@@ -79,12 +79,11 @@ require_once __DIR__.'/sources/main.functions.php';
 // init
 loadClasses();
 $session = SessionManager::getSession();
-$session->set('key', SessionManager::getCookieValue('PHPSESSID'));
-// PHPSESSID isn't sent on first query.
-if ($session->get('key') == null) {
-    header('Refresh: 0');
-    exit;
-}
+
+// Random encryption key
+if ($session->get('key') === null)
+    $session->set('key', generateQuickPassword(30, false));
+
 $request = SymfonyRequest::createFromGlobals();
 $configManager = new ConfigManager(__DIR__, $request->getRequestUri());
 $SETTINGS = $configManager->getAllSettings();

--- a/sources/main.functions.php
+++ b/sources/main.functions.php
@@ -1258,6 +1258,7 @@ function utf8Converter(array $array): array
 function prepareExchangedData($data, string $type, ?string $key = null)
 {
     $session = SessionManager::getSession();
+    $key = empty($key) ? $session->get('key') : $key;
     
     // Perform
     if ($type === 'encode' && is_array($data) === true) {
@@ -1271,7 +1272,7 @@ function prepareExchangedData($data, string $type, ?string $key = null)
         if ($session->get('encryptClientServer') === 1) {
             $data = Encryption::encrypt(
                 $data,
-                $session->get('key')
+                $key
             );
         }
 
@@ -1282,7 +1283,7 @@ function prepareExchangedData($data, string $type, ?string $key = null)
         if ($session->get('encryptClientServer') === 1) {
             $data = (string) Encryption::decrypt(
                 (string) $data,
-                $session->get('key')
+                $key
             );
         } else {
             // Double html encoding received


### PR DESCRIPTION
Using the PHPSESSID cookie value as encryption key removes the benefit of the "httpOnly" cookie flag.
Good practice is to change the session id after successful authentication.