### PR TITLE
fix: fix user email incorrect format

### DIFF
--- a/sources/main.functions.php
+++ b/sources/main.functions.php
@@ -4318,7 +4318,6 @@ function sendMailToUser(
     // Sanitize inputs
     $post_receipt = filter_var($post_receipt, FILTER_SANITIZE_EMAIL);
     $post_subject = htmlspecialchars($post_subject, ENT_QUOTES, 'UTF-8');
-    $post_body = htmlspecialchars($post_body, ENT_QUOTES, 'UTF-8');
 
     if (count($post_replace) > 0) {
         $post_body = str_replace(


### PR DESCRIPTION
sendMailToUser function gets email body in $post_body variable and unconditionally applies htmlspecialchars to it, which escapes html tags. It maybe unneeded as later sendMailToUser passes email body to $emailService->sendMail method which performs XSS check through sanitizeEmailBody method and applies htmlspecialchars if needed.