### PR TITLE
Enforce password log on copy or shown action.

### DIFF
--- a/includes/core/load.js.php
+++ b/includes/core/load.js.php
@@ -2082,4 +2082,69 @@ $request = SymfonyRequest::createFromGlobals();
         const hash = CryptoJS.SHA256(userId);
         return hash.toString(CryptoJS.enc.Hex).substring(0, 16);
     }
+
+    /**
+     * Get item password to show or copy it in clipboard.
+     * 
+     * @param {string} action - Log action (ex: at_password_shown).
+     * @param {string} id_type - 'item_key' or 'item_id'.
+     * @param {number|string} id_value - The item key or id.
+     * 
+     * @returns {string} - The item cleartext password if user has access.
+     */
+    function getItemPassword(action, id_type, id_value) {
+        let item_password = '';
+        
+        // Get password from server
+        $.ajax({
+            type: "POST",
+            async: false,
+            url: 'sources/items.queries.php',
+            data: 'type=get_item_password&action=' + action + '&' + id_type +
+                  '=' + id_value + '&key=<?php echo $session->get('key'); ?>',
+            dataType: "",
+            success: function(data) {
+                //decrypt data
+                try {
+                    data = prepareExchangedData(data, "decode", "<?php echo $session->get('key'); ?>");
+                } catch (e) {
+                    // error
+                    toastr.remove();
+                    toastr.warning(
+                        '<?php echo $lang->get('no_item_to_display'); ?>'
+                    );
+                    return false;
+                }
+
+                // No access
+                if (data.password_error !== '') {
+                    toastr.remove();
+                    toastr.error(
+                        data.password_error,
+                        '<?php echo $lang->get('caution'); ?>', {
+                            timeOut: 5000,
+                            progressBar: true
+                        }
+                    );
+                    return false;
+                }
+
+                const password = simplePurifier(atob(data.password), false, false, false, false).utf8Decode();
+                if (password === '') {
+                    toastr.info(
+                        '<?php echo $lang->get('password_is_empty'); ?>',
+                        '', {
+                            timeOut: 2000,
+                            positionClass: 'toast-bottom-right',
+                            progressBar: true
+                        }
+                    );
+                }
+
+                item_password = password;
+            }
+        });
+
+        return item_password;
+    }
 </script>

--- a/pages/items.js.php
+++ b/pages/items.js.php
@@ -383,14 +383,13 @@ $var['hidden_asterisk'] = '<i class="fa-solid fa-asterisk mr-2"></i><i class="fa
     $(document).on('click', '#card-item-pwd-show-button', function() {
         if ($(this).hasClass('pwd-shown') === false) {
             $(this).addClass('pwd-shown');
-            // Prepare data to show
-            // Is data crypted?
-            var data = unCryptData($('#hidden-item-pwd').val(), '<?php echo $session->get('key'); ?>');
-            if (data !== false && data !== undefined) {
-                $('#hidden-item-pwd').val(
-                    data.password
-                );
-            }
+
+            // Get item password from server
+            const item_pwd = getItemPassword(
+                'at_password_shown',
+                'item_id',
+                store.get('teampassItem').id
+            );
 
             // Change class and show spinner
             $('.pwd-show-spinner')
@@ -399,15 +398,8 @@ $var['hidden_asterisk'] = '<i class="fa-solid fa-asterisk mr-2"></i><i class="fa
 
             // display raw password
             $('#card-item-pwd')
-                .text($('#hidden-item-pwd').val())
+                .text(item_pwd)
                 .addClass('pointer_none');
-
-            // log password is shown
-            itemLog(
-                'at_password_shown',
-                store.get('teampassItem').id,
-                $('#card-item-label').text()
-            );
 
             // Autohide
             setTimeout(() => {
@@ -2581,34 +2573,24 @@ $var['hidden_asterisk'] = '<i class="fa-solid fa-asterisk mr-2"></i><i class="fa
             mouseStillDown = false;
             showPwdContinuous();
         });
-    var showPwdContinuous = function() {
-        if (mouseStillDown === true) {
-            // Prepare data to show
-            // Is data crypted?
-            var data = unCryptData($('#hidden-item-pwd').val(), '<?php echo $session->get('key'); ?>');
-            if (data !== false && data !== undefined) {
-                $('#hidden-item-pwd').val(
-                    data.password
-                );
-            }
 
-            $('#card-item-pwd')
-                .html(
-                    // XSS Filtering
-                    $('<span span style="cursor:none;">').text($('#hidden-item-pwd').val()).html()
-                );
+    const showPwdContinuous = function() {
+        if (mouseStillDown === true 
+            && !$('#card-item-pwd').hasClass('pwd-shown')) {
 
+            // Get item password from server
+            const item_pwd = getItemPassword(
+                'at_password_shown',
+                'item_id',
+                store.get('teampassItem').id
+            );
+
+            $('#card-item-pwd').text(item_pwd);
+            $('#card-item-pwd').addClass('pwd-shown');
+
+            // Auto hide password
             setTimeout('showPwdContinuous("card-item-pwd")', 50);
-            // log password is shown
-            if ($('#card-item-pwd').hasClass('pwd-shown') === false) {
-                itemLog(
-                    'at_password_shown',
-                    store.get('teampassItem').id,
-                    $('#card-item-label').text()
-                );
-                $('#card-item-pwd').addClass('pwd-shown');
-            }
-        } else {
+        } else if(mouseStillDown !== true) {
             $('#card-item-pwd')
                 .html('<?php echo $var['hidden_asterisk']; ?>')
                 .removeClass('pwd-shown');
@@ -3380,6 +3362,14 @@ $var['hidden_asterisk'] = '<i class="fa-solid fa-asterisk mr-2"></i><i class="fa
                 }
             );
         } else {
+            // Get password and fill the field.
+            const item_pwd = getItemPassword(
+                'at_password_shown_edit_form',
+                'item_id',
+                store.get('teampassItem').id
+            );
+            $('#form-item-password').val(item_pwd);
+
             $('#card-item-visibility').html(store.get('teampassItem').itemVisibility);
             $('#card-item-minimum-complexity').html(store.get('teampassItem').itemMinimumComplexity);
 
@@ -3980,57 +3970,18 @@ $var['hidden_asterisk'] = '<i class="fa-solid fa-asterisk mr-2"></i><i class="fa
                                 // Send query and get password
                                 var result = '',
                                     error = false;
-                                
-                                $.ajax({
-                                    type: "POST",
-                                    async: false,
-                                    url: 'sources/items.queries.php',
-                                    data: 'type=show_item_password&item_key=' + trigger.getAttribute('data-item-key') +
-                                        '&key=<?php echo $session->get('key'); ?>',
-                                    dataType: "",
-                                    success: function(data) {
-                                        //decrypt data
-                                        try {
-                                            data = prepareExchangedData(data, "decode", "<?php echo $session->get('key'); ?>");
-                                        } catch (e) {
-                                            // error
-                                            toastr.remove();
-                                            toastr.warning(
-                                                '<?php echo $lang->get('no_item_to_display'); ?>'
-                                            );
-                                            return false;
-                                        }
-                                        if (data.error === true) {
-                                            error = true;
-                                        } else {
-                                            if (data.password_error !== '') {
-                                                error = true;
-                                            } else {
-                                                result = simplePurifier(atob(data.password), false, false, false, false).utf8Decode();
-                                            }
-                                            if (result === '') {
-                                                toastr.info(
-                                                    '<?php echo $lang->get('password_is_empty'); ?>',
-                                                    '', {
-                                                        timeOut: 2000,
-                                                        positionClass: 'toast-bottom-right',
-                                                        progressBar: true
-                                                    }
-                                                );
-                                            }
-                                        }
-                                    }
-                                });
-                                return result;
+
+                                // Get item password from server
+                                const item_pwd = getItemPassword(
+                                    'at_password_copied',
+                                    'item_key',
+                                    trigger.getAttribute('data-item-key')
+                                );
+
+                                return item_pwd;
                             }
                         });
-                        clipboardForPassword.on('success', function(e) {
-                            itemLog(
-                                'at_password_copied',
-                                e.trigger.dataset.itemId,
-                                e.trigger.dataset.itemLabel
-                            );
-                            
+                        clipboardForPassword.on('success', function(e) {                            
                             // Warn user about clipboard clear
                             if (store.get('teampassSettings').clipboard_life_duration === undefined || parseInt(store.get('teampassSettings').clipboard_life_duration) === 0) {
                                 toastr.remove();
@@ -4832,11 +4783,6 @@ $var['hidden_asterisk'] = '<i class="fa-solid fa-asterisk mr-2"></i><i class="fa
                         $('#card-item-pwd').after('<i class="fa-solid fa-bell text-orange fa-shake ml-3 delete-after-usage infotip" title="'+data.pwd_encryption_error_message+'"></i>');
                     }
 
-                    // Uncrypt the pwd
-                    if (data.pw !== undefined) {
-                        data.pw = simplePurifier(atob(data.pw), false, false, false, false).utf8Decode();
-                    }
-
                     // Update hidden variables
                     store.update(
                         'teampassItem',
@@ -4899,7 +4845,7 @@ $var['hidden_asterisk'] = '<i class="fa-solid fa-asterisk mr-2"></i><i class="fa
                         $('.form-item').removeClass('hidden');
                         $('#folders-tree-card').addClass('hidden');
                     }
-                    $('#pwd-definition-size').val(data.pw.length);
+                    $('#pwd-definition-size').val(data.pw_length);
 
                     // Prepare card
                     const itemIcon = (data.fa_icon !== "") ? '<i class="'+data.fa_icon+' mr-1"></i>' : '';
@@ -4912,8 +4858,6 @@ $var['hidden_asterisk'] = '<i class="fa-solid fa-asterisk mr-2"></i><i class="fa
                         $('#card-item-description').removeClass('hidden');
                     }
                     $('#card-item-pwd').html('<?php echo $var['hidden_asterisk']; ?>');
-                    $('#hidden-item-pwd, #form-item-suggestion-password').val(data.pw);
-                    $('#form-item-password, #form-item-password-confirmation, #form-item-server-old-password').val(data.pw);
                     $('#card-item-login').html(data.login);
                     $('#form-item-login, #form-item-suggestion-login, #form-item-server-login').val(data.login);
 
@@ -5177,7 +5121,7 @@ $var['hidden_asterisk'] = '<i class="fa-solid fa-asterisk mr-2"></i><i class="fa
                     }
 
                     // Prepare clipboard - COPY PASSWORD
-                    if (data.pw !== '' && store.get('teampassItem').readyToUse === true) {
+                    if (data.pw_length > 0 && store.get('teampassItem').readyToUse === true) {
                         // Delete existing clipboard
                         if (clipboardForPasswordListItems) {
                             clipboardForPasswordListItems.destroy();
@@ -5185,16 +5129,17 @@ $var['hidden_asterisk'] = '<i class="fa-solid fa-asterisk mr-2"></i><i class="fa
                         // New clipboard
                         clipboardForPasswordListItems = new ClipboardJS('#card-item-pwd-button', {
                                 text: function() {
-                                    return (data.pw);
+                                    // Get item password from server
+                                    const item_pwd = getItemPassword(
+                                        'at_password_copied',
+                                        'item_id',
+                                        data.id
+                                    );
+
+                                    return item_pwd;
                                 }
                             })
                             .on('success', function(e) {
-                                itemLog(
-                                    'at_password_copied',
-                                    store.get('teampassItem').id,
-                                    $('#card-item-label').text()
-                                );
-
                                 // Warn user about clipboard clear
                                 if (store.get('teampassSettings').clipboard_life_duration === undefined || parseInt(store.get('teampassSettings').clipboard_life_duration) === 0) {
                                     toastr.remove();
@@ -6423,10 +6368,6 @@ $var['hidden_asterisk'] = '<i class="fa-solid fa-asterisk mr-2"></i><i class="fa
                 }
             }
         );
-    });
-
-    $('#item-button-password-copy').click(function() {
-        $('#form-item-password-confirmation').val($('#form-item-password').val());
     });
 
     /**

--- a/sources/items.queries.php
+++ b/sources/items.queries.php
@@ -152,6 +152,7 @@ $data = [
     'notifyType' => $request->request->filter('notify_type', '', FILTER_SANITIZE_SPECIAL_CHARS),
     'timestamp' => $request->request->filter('timestamp', '', FILTER_SANITIZE_SPECIAL_CHARS),
     'itemKey' => $request->request->filter('item_key', '', FILTER_SANITIZE_SPECIAL_CHARS),
+    'action' => $request->request->filter('action', '', FILTER_SANITIZE_SPECIAL_CHARS),
 ];
 
 $filters = [
@@ -176,6 +177,7 @@ $filters = [
     'notifyType' => 'trim|escape',
     'timestamp' => 'cast:integer',
     'itemKey' => 'trim|escape',
+    'action' => 'trim|escape',
 ];
 
 $inputData = dataSanitizer(
@@ -2836,7 +2838,7 @@ switch ($inputData['type']) {
             }
 
             $arrData['label'] = $dataItem['label'] === '' ? '' : $dataItem['label'];
-            $arrData['pw'] = $pw;
+            $arrData['pw_length'] = strlen($pw);
             $arrData['pw_decrypt_info'] = empty($pw) === true && $pwIsEmptyNormal === false ? 'error_no_sharekey_yet' : '';
             $arrData['email'] = empty($dataItem['email']) === true || $dataItem['email'] === null ? '' : $dataItem['email'];
             $arrData['url'] = empty($dataItem['url']) === true ? '' : $dataItem['url'];
@@ -4438,7 +4440,7 @@ switch ($inputData['type']) {
 
         break;
 
-    case 'show_item_password':
+    case 'get_item_password':
         // Check KEY
         if ($inputData['key'] !== $session->get('key')) {
             echo (string) prepareExchangedData(
@@ -4451,21 +4453,74 @@ switch ($inputData['type']) {
             break;
         }
 
-        // Run query
+        // Get item details and its sharekey
         $dataItem = DB::queryfirstrow(
-            'SELECT i.pw AS pw, s.share_key AS share_key
+            'SELECT i.pw AS pw, s.share_key AS share_key, i.id AS id,
+                    i.label AS label, i.id_tree AS id_tree
             FROM ' . prefixTable('items') . ' AS i
             INNER JOIN ' . prefixTable('sharekeys_items') . ' AS s ON (s.object_id = i.id)
-            WHERE user_id = %i AND i.item_key = %s',
+            WHERE user_id = %i AND (i.item_key = %s OR i.id = %i)',
             $session->get('user-id'),
-            $inputData['itemKey']
+            $inputData['itemKey'] ?? '',
+            $inputData['itemId'] ?? 0
         );
-        
-        // Uncrypt PW
+
+        // Check user access rights
         if (DB::count() === 0) {
-            // No share key found
-            $pw = '';
-        } else {
+            echo (string) prepareExchangedData(
+                [
+                    'error' => true,
+                    'password' => '',
+                    'password_error' => $lang->get('password_is_empty'),
+                ],
+                'encode'
+            );
+            break;
+        }
+
+        // Get user access rights
+        $userAccess = getCurrentAccessRights(
+            (int) $session->get('user-id'),
+            (int) $dataItem['id'],
+            (int) $dataItem['id_tree']
+        )['access'];
+
+        // List of allowed actions
+        $allowedActions = [
+            'at_password_copied',
+            'at_password_shown',
+            'at_password_shown_edit_form',
+        ];
+
+        // User not allowed to see this password or invalid action provided
+        if ($userAccess !== true
+            || empty($inputData['action'])
+            || !in_array($inputData['action'], $allowedActions, true)) {
+
+            echo (string) prepareExchangedData(
+                [
+                    'error' => true,
+                    'password' => '',
+                    'password_error' => $lang->get('not_allowed_to_see_pw'),
+                ],
+                'encode'
+            );
+            break;
+        }
+
+        // Log the action on password
+        logItems(
+            $SETTINGS,
+            (int) $dataItem['id'],
+            $dataItem['label'],
+            (int) $session->get('user-id'),
+            $inputData['action'], // Filtered by array of allowed values
+            $session->get('user-login')
+        );
+
+        // Uncrypt PW if sharekey is available (empty password otherwise)
+        $pw = '';
+        if (!empty($dataItem['share_key'])) {
             $pw = doDataDecryption(
                 $dataItem['pw'],
                 decryptUserObjectKey(
@@ -4473,14 +4528,6 @@ switch ($inputData['type']) {
                     $session->get('user-private_key')
                 )
             );
-            
-            $log = 'Used user ID: '.$session->get('user-id')."\n";
-            $log .= 'Used user Private key: '.$session->get('user-private_key')."\n";
-            $log .= '$currentUserKey: '.$dataItem['share_key']."\n";
-            $log .= 'itemKey: '.decryptUserObjectKey(
-                $dataItem['share_key'],
-                $session->get('user-private_key')
-            )."\n\n";
         }
 
         $returnValues = array(


### PR DESCRIPTION
- Remove item password from DOM to prevent unrecorded actions on passwords.
- Add generic function `getItemPassword()` to get item password client side.
- Use `getItemPassword()` every time the password is needed (copy, show, edit item).