### PR TITLE
Fixed an issue that moved the item to another folder when editing it.

### DIFF
--- a/pages/items.js.php
+++ b/pages/items.js.php
@@ -766,6 +766,7 @@ $var['hidden_asterisk'] = '<i class="fa-solid fa-asterisk mr-2"></i><i class="fa
             // > END <
             //
         } else if ($(this).data('item-action') === 'edit') {
+            const item_tree_id = store.get('teampassItem').tree_id;
             if (debugJavascript === true) console.info('SHOW EDIT ITEM');
             // Reset item
             store.update(
@@ -790,7 +791,7 @@ $var['hidden_asterisk'] = '<i class="fa-solid fa-asterisk mr-2"></i><i class="fa
             }
 
             $.when(
-                getPrivilegesOnItem(selectedFolderId, 1)
+                getPrivilegesOnItem(item_tree_id, 1)
             ).then(function(retData) {
                 console.log('getPrivilegesOnItem 2')
                 console.log(retData)
@@ -838,7 +839,7 @@ $var['hidden_asterisk'] = '<i class="fa-solid fa-asterisk mr-2"></i><i class="fa
                 $('#form-item').removeClass('was-validated');
 
                 // Now manage edtion
-                showItemEditForm(selectedFolderId);
+                showItemEditForm(item_tree_id);
             });
 
             //
@@ -4842,6 +4843,7 @@ $var['hidden_asterisk'] = '<i class="fa-solid fa-asterisk mr-2"></i><i class="fa
                         'teampassItem',
                         function(teampassItem) {
                             teampassItem.id = parseInt(data.id),
+                            teampassItem.tree_id = parseInt(data.folder),
                             teampassItem.folderId = parseInt(data.folder),
                             teampassItem.timestamp = data.timestamp,
                             teampassItem.user_can_modify = data.user_can_modify,


### PR DESCRIPTION
Using a new storage variable tree_id in the edit form which is updated only by `Details()`.
This ensures that editing an item will not move it to the current folder.
