### PR TITLE
Fix items tasks error

### DIFF
--- a/sources/logs.datatables.php
+++ b/sources/logs.datatables.php
@@ -863,10 +863,11 @@ if (isset($params['action']) && $params['action'] === 'connections') {
     );
 
     // Prepare the SQL query
-    $sql = 'SELECT p.increment_id, p.created_at, p.updated_at, p.process_type, p.is_in_progress
-    FROM '.prefixTable('background_tasks').' AS p 
-    LEFT JOIN '.prefixTable('users').' AS u ON %l
-    WHERE %l ORDER BY %l %l LIMIT %i, %i';
+    $sql = 'SELECT p.increment_id, p.created_at, p.updated_at, p.process_type,
+                p.is_in_progress, p.arguments
+            FROM '.prefixTable('background_tasks').' AS p 
+            LEFT JOIN '.prefixTable('users').' AS u ON %l
+            WHERE %l ORDER BY %l %l LIMIT %i, %i';
     $params = ['u.id = json_extract(p.arguments, "$[0]")',$sWhere, $orderColumn, $orderDirection, $sLimitStart, $sLimitLength];
 
     // Get the records

--- a/sources/main.functions.php
+++ b/sources/main.functions.php
@@ -2365,6 +2365,9 @@ function doDataDecryption(string $data, string $key): string
  */
 function encryptUserObjectKey(string $key, string $publicKey): string
 {
+    // Empty password
+    if (empty($key)) return '';
+
     // Sanitize
     $antiXss = new AntiXSS();
     $publicKey = $antiXss->xss_clean($publicKey);

--- a/sources/main.functions.php
+++ b/sources/main.functions.php
@@ -2634,12 +2634,12 @@ function storeUsersShareKey(
         // Create sharekey for each user
         $user_ids = [OTV_USER_ID, SSH_USER_ID, API_USER_ID];
         if ($all_users_except_id !== -1) {
-            array_push($user_ids, $all_users_except_id . '"');
+            array_push($user_ids, (int) $all_users_except_id);
         }
         $users = DB::query(
             'SELECT id, public_key
             FROM ' . prefixTable('users') . '
-            WHERE id NOT IN (%li)
+            WHERE id NOT IN %li
             AND public_key != ""',
             $user_ids
         );


### PR DESCRIPTION
The scheduler is stuck on tasks that handle sharekeys creation:
- Fix SQL query:
```
#0 /var/www/teampass/vendor/sergeytsalkov/meekrodb/db.class.php(890): MeekroDB->queryHelper(Array, Array)
#1 /var/www/teampass/vendor/sergeytsalkov/meekrodb/db.class.php(116): MeekroDB->query('SELECT id, publ...', Array)
#2 /var/www/teampass/sources/main.functions.php(2640): DB::__callStatic('query', Array)
```
- Improve task recursion to avoid high CPU load.
- Error on item creation with empty password since #4412 (`if ($encrypted === false) {` -> `if (empty($encrypted)) {`).
- Error on tasks page (missing field arguments in SQL query).