### PR TITLE
Install improvements

### DIFF
--- a/install/install.js
+++ b/install/install.js
@@ -20,12 +20,6 @@ $(function() {
         $("#step").val($(this).attr("target_id"));
         document.upgrade.submit();
     });
-
-    // no paste
-    $("#admin_pwd").bind("paste",function(e) {
-        alert("Paste option is disabled !!");
-        e.preventDefault();
-    });
 });
 
 function aesEncrypt(text)
@@ -347,10 +341,6 @@ function GotoNextStep()
         $("#step_result").html("");
         $("#step_name").html($("#menu_step"+nextStep).html());
         $("#step_content").html($("#text_step"+nextStep).html());
-        $('#admin_pwd').live("paste",function(e) {
-            alert("Paste option is disabled !!");
-            e.preventDefault();
-        });
         $("#admin_pwd").live("keypress", function(e){
             var key = e.charCode || e.keyCode || 0;
             // allow backspace, tab, delete, arrows, letters, numbers and keypad numbers ONLY

--- a/install/install.js
+++ b/install/install.js
@@ -131,7 +131,7 @@ function checkPage()
     // STEP 6
         jsonValues = {"url_path":sanitizeString($("#hid_url_path").val())};
         dataToUse = JSON.stringify(jsonValues);
-        tasks = [ "file*settings.php","install*init", "file*security", "file*settings.php", "file*csrfp-token", "install*cleanup", "install*cronJob"];
+        tasks = ["file*settings.php","install*init", "file*security", "file*settings.php", "file*csrfp-token", "install*cleanup", "install*cronJob"];
         multiple = true;
     }
 

--- a/install/install.queries.php
+++ b/install/install.queries.php
@@ -1461,7 +1461,7 @@ if (null !== $inputData['type']) {
                             KEY `ITEM` (`item_id`)
                             ) CHARSET=utf8;"
                         );
-                    } else if ($inputData['task'] === 'items_otp') {
+                    } else if ($inputData['task'] === 'auth_failures') {
                         $mysqli_result = mysqli_query(
                             $dbTmp,
                             "CREATE TABLE IF NOT EXISTS `" . $var['tbl_prefix'] . "auth_failures` (

--- a/install/install.queries.php
+++ b/install/install.queries.php
@@ -1568,11 +1568,6 @@ if (isset($_SESSION[\'settings\'][\'timezone\']) === true) {
                     );
                     fclose($file_handler);
 
-                    // NOw remove old file
-                    if (file_exists(__DIR__.'/../includes/config/'.SECUREFILE)) {
-                        unlink(__DIR__.'/../includes/config/'.SECUREFILE);
-                    }
-
                     // Create TP USER
                     require_once '../includes/config/include.php';
                     $tmp = mysqli_num_rows(mysqli_query($dbTmp, "SELECT * FROM `" . $var['tbl_prefix'] . "users` WHERE id = '" . TP_USER_ID . "'"));
@@ -1685,12 +1680,18 @@ if (isset($_SESSION[\'settings\'][\'timezone\']) === true) {
                                 
                                 $crontabRepository->addJob($crontabJob);
                                 $crontabRepository->persist();
+
+                                // Now remove old file
+                                if (file_exists(__DIR__.'/../includes/config/'.SECUREFILE)) {
+                                    unlink(__DIR__.'/../includes/config/'.SECUREFILE);
+                                }
                             }
                         } catch (Exception $e) {
                             // do nothing
                         }
                     } else {
                         echo '[{"error" : "Cannot find PHP binary location. Please add a cronjob manually (see documentation).", "result":"", "index" : "' . $inputData['index'] . '", "multiple" : "' . $inputData['multiple'] . '"}]';
+                        break;
                     }
                     echo '[{"error" : "", "index" : "' . $inputData['index'] . '", "multiple" : "' . $inputData['multiple'] . '"}]';
                 }

--- a/install/upgrade.php
+++ b/install/upgrade.php
@@ -332,7 +332,7 @@ if (!isset($_GET['step']) && !isset($post_step)) {
                         
                         <div class="form-group">
                             <label>Password</label>
-                            <input type="text" class="form-control" name="db_pw" id="db_pw" class="ui-widget" value="'.DB_PASSWD_CLEAR.'">
+                            <input type="password" class="form-control" name="db_pw" id="db_pw" class="ui-widget" value="'.DB_PASSWD_CLEAR.'">
                         </div>
                         
                         <div class="form-group">

--- a/sources/identify.php
+++ b/sources/identify.php
@@ -2110,24 +2110,6 @@ function identifyDoInitialChecks(
     $oauth2Enabled = $SETTINGS['oauth2_enabled'] ?? false;
     $lang = new Language($session->get('user-language') ?? 'english');
 
-    // Manage Maintenance mode
-    try {
-        $checks->isMaintenanceModeEnabled(
-            $SETTINGS['maintenance_mode'],
-            $userInfo['admin']
-        );
-    } catch (Exception $e) {
-        return [
-            'error' => true,
-            'skip_anti_bruteforce' => true,
-            'array' => [
-                'value' => '',
-                'error' => 'maintenance_mode_enabled',
-                'message' => '',
-            ]
-        ];
-    }
-
     // Brute force management
     try {
         $checks->isTooManyPasswordAttempts($username, getClientIpServer());
@@ -2159,6 +2141,24 @@ function identifyDoInitialChecks(
         ];
     }
 
+    // Manage Maintenance mode
+    try {
+        $checks->isMaintenanceModeEnabled(
+            $SETTINGS['maintenance_mode'],
+            $userInfo['admin']
+        );
+    } catch (Exception $e) {
+        return [
+            'error' => true,
+            'skip_anti_bruteforce' => true,
+            'array' => [
+                'value' => '',
+                'error' => 'maintenance_mode_enabled',
+                'message' => '',
+            ]
+        ];
+    }
+    
     // user should use MFA?
     $userInfo['mfa_auth_requested_roles'] = mfa_auth_requested_roles(
         (string) $userInfo['fonction_id'],


### PR DESCRIPTION
- Preventing pasting the password encourages using weak passwords.
- The table auth_failures was not created during initial installation.
- Remove old securefile on the latest task to avoid 500 errors.
- Hide database password.
- Fix error with anti bruteforce that deny access to administrators when maintenance mode is enabled.

There is still a 500 error that I have not been able to correct:
![image](https://github.com/user-attachments/assets/a679157c-cb4f-4963-a63e-5ac4abe5021a)
The installation seems to be completed correctly and I don't have any error logs... Maybe you will have an idea how to fix it?
