### PR TITLE
Items are restricted

### DIFF
--- a/includes/config/include.php
+++ b/includes/config/include.php
@@ -28,7 +28,7 @@
 
 define('TP_VERSION', '3.1.3');
 define("UPGRADE_MIN_DATE", "1732981987");
-define('TP_VERSION_MINOR', '1');
+define('TP_VERSION_MINOR', '2');
 define('TP_TOOL_NAME', 'Teampass');
 define('TP_ONE_DAY_SECONDS', 86400);
 define('TP_ONE_WEEK_SECONDS', 604800);

--- a/sources/items.queries.php
+++ b/sources/items.queries.php
@@ -4352,7 +4352,7 @@ switch ($inputData['type']) {
                             $right = 20;
                         } elseif ((20 <= (int) $accessLevel) && ((int) $accessLevel < 30)) {
                             $right = 60;
-                        } elseif ((int) $accessLevel === 30) {
+                        } elseif ((int) $accessLevel >= 30) {
                             $right = 70;
                         } else {
                             $right = 10;


### PR DESCRIPTION
Fix for #4495
Condition at L4355 was wrong as item with $accessLevel for a user higher to 30 indicates that user can RWDU the item. As a consequence, the related right is 70.