### PR TITLE
Recreated the file with utf-8 encoding

### DIFF
--- a/includes/language/datatables.portuguese_br.txt
+++ b/includes/language/datatables.portuguese_br.txt
@@ -1,20 +1,20 @@
 {
     "sEmptyTable": "Nenhum registro encontrado",
-    "sInfo": "Mostrando de _START_ até _END_ de _TOTAL_ registros",
-    "sInfoEmpty": "Mostrando 0 até 0 de 0 registros",
+    "sInfo": "Mostrando de _START_ atÃ© _END_ de _TOTAL_ registros",
+    "sInfoEmpty": "Mostrando 0 atÃ© 0 de 0 registros",
     "sInfoFiltered": "(Filtrados de _MAX_ registros)",
     "sInfoPostFix": "",
     "sInfoThousands": ".",
-    "sLengthMenu": "_MENU_ resultados por página",
+    "sLengthMenu": "_MENU_ resultados por pÃ¡gina",
     "sLoadingRecords": "Carregando...",
     "sProcessing": "Processando...",
     "sZeroRecords": "Nenhum registro encontrado",
     "sSearch": "Pesquisar",
     "oPaginate": {
-        "sNext": "Próximo",
+        "sNext": "PrÃ³ximo",
         "sPrevious": "Anterior",
         "sFirst": "Primeiro",
-        "sLast": "Último"
+        "sLast": "Ãšltimo"
     },
     "oAria": {
         "sSortAscending": ": Ordenar colunas de forma ascendente",


### PR DESCRIPTION
The encoding of the file `datatables.portuguese_br.txt` was `iso-8859-1`, causing text to display with a "diamond question mark" character.

* Before
```bash
file -i teampass/includes/language/datatables.portuguese_br.txt 
teampass/includes/language/datatables.portuguese_br.txt: application/json; charset=iso-8859-1
```

* Recreated the file with `utf-8` encoding

```bash
file -i datatables.portuguese_br.txt
datatables.portuguese_br.txt: application/json; charset=utf-8
```