### PR TITLE
Fix file overwrite when older file exists with same md5 checksum.

### DIFF
--- a/sources/main.functions.php
+++ b/sources/main.functions.php
@@ -2466,7 +2466,7 @@ function encryptFile(string $fileInName, string $fileInPath): array
 
     // Save new file
     // deepcode ignore InsecureHash: is simply used to get a unique name
-    $hash = md5($plaintext);
+    $hash = uniqid('', true);
     $fileOut = $fileInPath . '/' . TP_FILE_PREFIX . $hash;
     file_put_contents($fileOut, $ciphertext);
     unlink($fileInPath . '/' . $fileInName);


### PR DESCRIPTION
This will fix #4402.