### PR TITLE
Fixed an issue when displaying the password after updating it.

### DIFF
--- a/pages/items.js.php
+++ b/pages/items.js.php
@@ -2577,6 +2577,9 @@ $var['hidden_asterisk'] = '<i class="fa-solid fa-asterisk mr-2"></i><i class="fa
             $('#form-item-password').attr('type', 'password');
         })
         .mousedown(function() {
+            // Allow $('#form-item .form-item-control').on('change') to be fired
+            $('#form-item .form-item-control').blur();
+            // Display cleartext password
             $('#form-item-password').attr('type', 'text');
         });
     $('.btn-no-click')


### PR DESCRIPTION
Currently, if I only change the password and click the button to display it without clicking outside the password field, I cannot validate the form (no changes made).