### PR TITLE
Fix multiple roles permission conflicts

### DIFF
--- a/sources/items.queries.php
+++ b/sources/items.queries.php
@@ -7328,16 +7328,22 @@ function getRoleBasedAccess($session, int $treeId): array
         $roles, 
         $treeId
     );
+    // Values ​​to be checked
     $check_value = 'W';
+    // Values ​​to be deleted
     $delete_value = 'R';
+    
+    // Check if $check_value exists
     if (in_array($check_value, $accessTypes)) {
-        // Find the index of $delete_value in the array
-        $key = array_search($delete_value, $accessTypes);
-        
-        // If the value is found, delete
-        if ($key !== false) {
-            unset($accessTypes[$key]);
+        // Use the foreach loop to delete all matches
+        foreach ($accessTypes as $key => $value) {
+            if ($value === $delete_value) {
+                // Delete matching values
+                unset($accessTypes[$key]);  
+            }
         }
+        // Reindex array
+        $accessTypes = array_values($accessTypes);
     }
     // Determine access rights based on the retrieved types
     foreach ($accessTypes as $access) {

--- a/sources/items.queries.php
+++ b/sources/items.queries.php
@@ -7324,7 +7324,7 @@ function getRoleBasedAccess($session, int $treeId): array
 
     // Query the access rights for the given roles and folder
     $accessTypes = DB::queryFirstColumn(
-        'SELECT type FROM ' . prefixTable('roles_values') . ' WHERE role_id IN %ls AND folder_id = %i', 
+        'SELECT DISTINCT type FROM ' . prefixTable('roles_values') . ' WHERE role_id IN %ls AND folder_id = %i', 
         $roles, 
         $treeId
     );
@@ -7335,15 +7335,13 @@ function getRoleBasedAccess($session, int $treeId): array
     
     // Check if $check_value exists
     if (in_array($check_value, $accessTypes)) {
-        // Use the foreach loop to delete all matches
-        foreach ($accessTypes as $key => $value) {
-            if ($value === $delete_value) {
-                // Delete matching values
-                unset($accessTypes[$key]);  
-            }
+        // Find the index of $delete_value in the array
+        $key = array_search($delete_value, $accessTypes);
+
+        // If the value is found, delete
+        if ($key !== false) {
+            unset($accessTypes[$key]);
         }
-        // Reindex array
-        $accessTypes = array_values($accessTypes);
     }
     // Determine access rights based on the retrieved types
     foreach ($accessTypes as $access) {

--- a/sources/items.queries.php
+++ b/sources/items.queries.php
@@ -7328,7 +7328,17 @@ function getRoleBasedAccess($session, int $treeId): array
         $roles, 
         $treeId
     );
-
+    $check_value = 'W';
+    $delete_value = 'R';
+    if (in_array($check_value, $accessTypes)) {
+        // Find the index of $delete_value in the array
+        $key = array_search($delete_value, $accessTypes);
+        
+        // If the value is found, delete
+        if ($key !== false) {
+            unset($accessTypes[$key]);
+        }
+    }
     // Determine access rights based on the retrieved types
     foreach ($accessTypes as $access) {
         switch ($access) {

--- a/sources/main.functions.php
+++ b/sources/main.functions.php
@@ -807,7 +807,7 @@ function cacheTableRefresh(): void
                     'perso' => $record['perso'],
                     'restricted_to' => isset($record['restricted_to']) && ! empty($record['restricted_to']) ? $record['restricted_to'] : '0',
                     'login' => $record['login'] ?? '',
-                    'folder' => implode(' > ', $folder),
+                    'folder' => implode(' » ', $folder),
                     'author' => $record['id_user'],
                     'renewal_period' => $resNT['renewal_period'] ?? '0',
                     'timestamp' => $record['date'],


### PR DESCRIPTION
When a user has multiple roles for a folder, the permissions are deduplicated, and when both read and write permissions are available, the write permissions will be retained.