### PR TITLE
wrong LDAP option setting name preventing LDAP bind to occur

### DIFF
--- a/sources/main.functions.php
+++ b/sources/main.functions.php
@@ -2751,7 +2751,7 @@ function ldapCheckUserPassword(string $login, string $password, array $SETTINGS)
         // Custom LDAP Options
         'options' => [
             // See: http://php.net/ldap_set_option
-            LDAP_OPT_X_TLS_REQUIRE_CERT => (isset($SETTINGS['ldap_tls_certiface_check']) ? $SETTINGS['ldap_tls_certiface_check'] : LDAP_OPT_X_TLS_HARD),
+            LDAP_OPT_X_TLS_REQUIRE_CERT => (isset($SETTINGS['ldap_tls_certifacte_check']) ? $SETTINGS['ldap_tls_certifacte_check'] : LDAP_OPT_X_TLS_HARD),
         ],
     ];
     

--- a/vendor/teampassclasses/ldapextra/src/LdapExtra.php
+++ b/vendor/teampassclasses/ldapextra/src/LdapExtra.php
@@ -56,7 +56,7 @@ class LdapExtra
             'timeout' => 5,
             'follow_referrals' => false,
             'options' => [
-                LDAP_OPT_X_TLS_REQUIRE_CERT => isset($this->settings['ldap_tls_certiface_check']) ? $this->settings['ldap_tls_certiface_check'] : LDAP_OPT_X_TLS_HARD,
+                LDAP_OPT_X_TLS_REQUIRE_CERT => isset($this->settings['ldap_tls_certifacte_check']) ? $this->settings['ldap_tls_certifacte_check'] : LDAP_OPT_X_TLS_HARD,
             ],
         ];
 


### PR DESCRIPTION
It took me hours to detect that very simple typo as I assumed right away that the setting was correctly retrieved from DB.
Consequently the LDAP_OPT_X_TLS_REQUIRE_CERT option was being set with 'blank' which then transform to '1' when passing to set_ldap_option.
