### PR TITLE
Displaying error toast if fetch user fails

### DIFF
--- a/includes/language/english.php
+++ b/includes/language/english.php
@@ -130,6 +130,7 @@ return array(
     'allowed_to_delete' => 'Allowed to delete',
     'error_folder_not_allowed_for_this_user' => 'Folder is not allowed for this user',
     'users_api_access_info' => 'Users can access the API with same access rights as in Teampass.',
+    'users_fetch_error' => 'Something went wrong fetching users',
     'error_otp_secret' => 'Enable to decode the OTP secret, is the secret correct?',
     'tasks_log_retention_delay_in_days' => 'Tasks log retention delay (in days)',
     'tasks_log_table_size' => 'Tasks log table size',

--- a/pages/users.js.php
+++ b/pages/users.js.php
@@ -117,6 +117,7 @@ if ($checkUserAccess->checkSession() === false || $checkUserAccess->userAccessPa
             e.preventDefault();
         });
 
+    var loadingToast = null;
 
     //Launch the datatables pluggin
     var oTable = $('#table-users').DataTable({
@@ -136,6 +137,10 @@ if ($checkUserAccess->checkSession() === false || $checkUserAccess->userAccessPa
             url: '<?php echo $SETTINGS['cpassman_url']; ?>/sources/users.datatable.php',
             data: function(d) {
                 d.display_warnings = $('#warnings_display').is(':checked');
+            },
+            error: function(d) {
+                loadingToast.remove();
+                toastr.error(<?php echo $lang->get('fetch_users_error'); ?>, '', {timeOut: 5000, progressBar: true, extendedCloseButton: true});
             }
         },
         'language': {
@@ -198,7 +203,7 @@ if ($checkUserAccess->checkSession() === false || $checkUserAccess->userAccessPa
             }
         ],
         'preDrawCallback': function() {
-            toastr.info(
+            loadingToast = toastr.info(
                 '<?php echo $lang->get('loading'); ?> ... <i class="fa-solid fa-circle-notch fa-spin fa-2x"></i><span class="close-toastr-progress"></span>',
                 ''
             );


### PR DESCRIPTION
I used the latest version yesterday. Fetching users from admin fails but the Loading toast remains. This hides the Loading and shows a generic error.