### PR TITLE
Fix: Properly parse binary objectGUID for AD groups in LDAP sync

### DIFF
--- a/vendor/teampassclasses/ldapextra/src/ActiveDirectoryExtra.php
+++ b/vendor/teampassclasses/ldapextra/src/ActiveDirectoryExtra.php
@@ -38,10 +38,10 @@ class ActiveDirectoryExtra extends BaseGroup
 {
     public function getADGroups(Connection $connection, array $settings): array
     {
-        // Configure objectClasses based on settings
-        if (isset($settings['ldap_group_objectclasses_attibute']) === true) {
-            static::$objectClasses = explode(",",$settings['ldap_group_objectclasses_attibute']);
+        if (isset($settings['ldap_group_objectclasses_attibute'])) {
+            static::$objectClasses = explode(",", $settings['ldap_group_objectclasses_attibute']);
         }
+
         if (!$connection || !$connection->isConnected()) {
             return [
                 'error' => true,
@@ -49,28 +49,59 @@ class ActiveDirectoryExtra extends BaseGroup
                 'userGroups' => [],
             ];
         }
-        // prepare query
+
         $query = $connection->query();
 
-        // get all parameters to search
+        // Determine which GUID attribute is used
+        $guidAttr = strtolower(
+            (isset($settings['ldap_guid_attibute']) && !empty($settings['ldap_guid_attibute']))
+                ? $settings['ldap_guid_attibute']
+                : 'gidnumber'
+        );
+
+        // Always select CN and the chosen GUID attribute for the LDAP query
+        $selectAttrs = ['cn', $guidAttr];
+        $query->select($selectAttrs);
+
         foreach (static::$objectClasses as $objectClass) {
             $query->where('objectclass', '=', $objectClass);
         }
+
         try {
-            // perform query and get data
             $groups = $query->paginate();
 
             $groupsArr = [];
-            foreach($groups as $key => $group) {
-                $adGroupId = (int) $group[(isset($settings['ldap_guid_attibute']) === true && empty($settings['ldap_guid_attibute']) === false ? $settings['ldap_guid_attibute'] : 'gidnumber')][0];
+            foreach ($groups as $group) {
+                if (isset($group[$guidAttr][0])) {
+                    // Convert binary AD objectGUID to standard GUID string format
+                    if ($guidAttr === 'objectguid') {
+                        try {
+                            $bin = $group[$guidAttr][0];
+                            $adGroupId = strtolower(vsprintf(
+                                '%02x%02x%02x%02x-%02x%02x-%02x%02x-%02x%02x-%02x%02x%02x%02x%02x%02x',
+                                array_values(unpack('C16', $bin))
+                            ));
+                        } catch (\Throwable $e) {
+                            // If conversion fails, assign a unique fallback
+                            $adGroupId = 'invalid_guid_' . uniqid();
+                        }
+                    } else {
+                        // Otherwise treat attribute as plain string (e.g. gidNumber)
+                        $adGroupId = strtolower((string) $group[$guidAttr][0]);
+                    }
+                } else {
+                    // Handle groups missing the expected GUID attribute
+                    $adGroupId = 'missing_' . uniqid();
+                }
+
                 $groupsArr[$adGroupId] = [
                     'ad_group_id' => $adGroupId,
-                    'ad_group_title' => $group['cn'][0],
+                    'ad_group_title' => $group['cn'][0] ?? 'Unknown',
                     'role_id' => -1,
                     'id' => -1,
                     'role_title' => '',
                 ];
-            }            
+            }
 
             return [
                 'error' => false,


### PR DESCRIPTION
- Properly unpacks the binary `objectGUID` attribute returned by AD into standard UUID format, so all groups are listed.
- Respects the configured `LDAP GUID attribute` in the TeamPass LDAP settings.

## Why?
- Previously, setting `objectGUID` returned only a single group, or a few if using lowercase `objectguid`, due to mishandled binary data.
- This broke the expected listing of AD groups in Roles -> LDAP sync.
- Added temporary debug logs helped identify where IDs were incorrectly calculated as 0.

## How was this tested?
- Tested on production AD with 150+ groups. (Windows 2022 Server / Entra Hybrid)
- Screenshots attached: before vs after.
![ldap-fix_before](https://github.com/user-attachments/assets/c14a06bb-ef16-4133-b1f1-2b0430a05c02)
![ldap-fix_after](https://github.com/user-attachments/assets/11b7b669-41c2-4733-86ec-11224eda95b8)

## Before vs After logs
Before:
----------
NOTICE: PHP message: DEBUG: Retrieved raw LDAP groups: Array
NOTICE: PHP message: DEBUG: Processing group CN=AZ-SG-(REDACTED) with computed ID: 0
NOTICE: PHP message: DEBUG: Processing group CN=AZ-MG-(REDACTED) with computed ID: 0
NOTICE: PHP message: DEBUG: Processing group CN=AZ-LIC-(REDACTED) with computed ID: 0
NOTICE: PHP message: DEBUG: Processing group CN=AZ-LIC-(REDACTED) with computed ID: 0
NOTICE: PHP message: DEBUG: Processing group CN=AZ-LIC-(REDACTED) with computed ID: 0
NOTICE: PHP message: DEBUG: Processing group CN=AZ-LIC-(REDACTED) with computed ID: 0

After:
--------
NOTICE: PHP message: DEBUG: Retrieved raw LDAP groups: Array
NOTICE: PHP message: DEBUG: Processing group CN=AZ-SG-(REDACTED) with computed ID: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxfe
NOTICE: PHP message: DEBUG: Processing group CN=AZ-MG-(REDACTED) with computed ID: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxx26
NOTICE: PHP message: DEBUG: Processing group CN=AZ-LIC-(REDACTED) with computed ID: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxx45
NOTICE: PHP message: DEBUG: Processing group CN=AZ-LIC-(REDACTED) with computed ID: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxb3
NOTICE: PHP message: DEBUG: Processing group CN=AZ-LIC-(REDACTED) with computed ID: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxa5
NOTICE: PHP message: DEBUG: Processing group CN=AZ-LIC-(REDACTED)) with computed ID: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxe0

## Notes
- This does *not* hardcode `objectGUID`; it uses whatever is set under "LDAP GUID attribute" in the TeamPass settings.
- Tested with `objectguid` as the configured attribute, fixing the previous binary conversion problem.