### PR TITLE
Fix: Normalize trailing slashes in file integrity check

### DIFF
--- a/sources/admin.queries.php
+++ b/sources/admin.queries.php
@@ -2500,7 +2500,8 @@ switch ($post_type) {
             break;
         }
 
-        $ret = filesIntegrityCheck($SETTINGS['cpassman_dir']);        
+        $SETTINGS['cpassman_dir'] = rtrim($SETTINGS['cpassman_dir'], '/');
+        $ret = filesIntegrityCheck($SETTINGS['cpassman_dir']);
 
         $ignoredFiles = DB::queryFirstField(
             'SELECT valeur 


### PR DESCRIPTION
## What does this PR do?
- Ensures trailing slashes are normalized in the base directory path used by the file integrity checker, avoiding false positives where thousands of files are flagged as unknown.

## Why?
- Previously, if the admin defined the TeamPass base path with or without a trailing slash in the settings, the integrity check could mismatch thousands of files. This was confusing and looked like a serious integrity breach.
- With this fix, the integrity check consistently compares clean paths regardless of the user config.

## How was this tested?
- Tested on a TeamPass deployment with 8,000+ files, toggling the trailing slash in settings.
- Verified debug logs and integrity output show correct results in both cases.

## Notes
- This does *not* alter the reference file format or any existing data. It only normalizes internal path handling.