### PR TITLE
enhancement: add MD5 hash validation to file integrity check

### DIFF
--- a/scripts/task_generate_files_reference.php
+++ b/scripts/task_generate_files_reference.php
@@ -1,0 +1,89 @@
+#!/usr/bin/php
+<?php
+
+/**
+ * task_generate_files_reference.php
+ * ---
+ * Helper script to generate a `files_reference.txt` file
+ * listing all project files and their MD5 hashes.
+ * 
+ * Output format:
+ *     <relative/path/to/file> <md5_hash>
+ * 
+ * Example:
+ *     vendor/autoload.php 1bc29b36f623ba82aaf6724fd3b16718
+ *
+ * This is used by the enhanced TeamPass file integrity check.
+ *
+ * Usage:
+ *     php scripts/task_generate_files_reference.php
+ *
+ * Configuration:
+ * - Adjust `$excludeDirs` to skip entire directories.
+ * - Adjust `$excludeFilePrefixes` to skip specific files.
+ *
+ * Intended to be run inside the TeamPass project root. 
+ * It will output `files_reference.txt` in the same base directory.
+ *
+ * ---
+ * @file      task_generate_files_refrence.php
+ * @author    Gudmundur Mar Kristjansson (gudmmk@gmail.com)
+ * @license   GPL-3.0
+ * @see       https://www.teampass.net
+ */
+
+$baseDir = realpath(__DIR__ . '/..');
+$outputFile = $baseDir . '/files_reference.txt';
+
+// Optionally exclude folders or specific file prefixes
+$excludeDirs = ['upload', 'files', 'install', '_tools', 'random_compat', 'avatars'];
+$excludeFilePrefixes = ['csrfp.config.php', 'settings.php', 'version-commit.php', 'phpstan.neon'];
+
+function getAllFilesWithMd5($dir, $baseDir, $excludeDirs, $excludeFilePrefixes) {
+    $files = [];
+    $iterator = new RecursiveIteratorIterator(
+        new RecursiveCallbackFilterIterator(
+            new RecursiveDirectoryIterator($dir, FilesystemIterator::SKIP_DOTS),
+            function ($current, $key, $iterator) {
+                return $current->getFilename()[0] !== '.'; // skip dotfiles & dotdirs
+            }
+        ),
+        RecursiveIteratorIterator::SELF_FIRST
+    );
+
+    foreach ($iterator as $file) {
+        if ($file->isFile()) {
+            $relativePath = str_replace($baseDir . DIRECTORY_SEPARATOR, '', $file->getPathname());
+            $relativePath = str_replace('\\', '/', $relativePath);
+
+            // Check for excluded dirs
+            foreach (explode('/', $relativePath) as $part) {
+                if (in_array($part, $GLOBALS['excludeDirs'], true)) {
+                    continue 2;
+                }
+            }
+
+            // Check for excluded prefixes
+            $filename = basename($relativePath);
+            foreach ($GLOBALS['excludeFilePrefixes'] as $prefix) {
+                if (strpos($filename, $prefix) === 0) {
+                    continue 2;
+                }
+            }
+
+            $md5 = md5_file($file->getPathname());
+            $files[$relativePath] = $md5;
+        }
+    }
+    return $files;
+}
+
+$files = getAllFilesWithMd5($baseDir, $baseDir, $excludeDirs, $excludeFilePrefixes);
+
+$handle = fopen($outputFile, 'w');
+foreach ($files as $file => $md5) {
+    fwrite($handle, $file . ' ' . $md5 . PHP_EOL);
+}
+fclose($handle);
+
+echo "[OK] files_reference.txt generated with " . count($files) . " files.\n";

--- a/sources/admin.queries.php
+++ b/sources/admin.queries.php
@@ -2500,7 +2500,9 @@ switch ($post_type) {
             break;
         }
 
-        $ret = filesIntegrityCheck($SETTINGS['cpassman_dir']);        
+        // New hash-based integrity check
+        $SETTINGS['cpassman_dir'] = rtrim($SETTINGS['cpassman_dir'], '/');
+        $ret = verifyFileHashes($SETTINGS['cpassman_dir'], __DIR__.'/../files_reference.txt');
 
         $ignoredFiles = DB::queryFirstField(
             'SELECT valeur 
@@ -2914,4 +2916,108 @@ function tablesIntegrityCheck(): array
         'array' => $tablesInError,
         'message' => ""
     ];
+}
+
+/**
+ * Verify file integrity by checking presence & MD5 hashes.
+ *
+ * This function compares the current files in the project directory against a reference file
+ * containing expected file paths and their MD5 hashes. It reports any missing files or files
+ * whose hashes do not match the reference.
+ *
+ * Steps:
+ *  - Load reference file data (file => hash)
+ *  - Get all current files in the base directory
+ *  - For each file, check if it exists in the reference; if so, compare hashes
+ *  - Collect issues for missing or changed files
+ *
+ * @param string $baseDir        Base directory to scan for files
+ * @param string $referenceFile  Path to reference file with known hashes
+ * @return array                 Result with 'error', 'array' of issues, and 'message'
+ */
+function verifyFileHashes($baseDir, $referenceFile): array
+{
+    // Load reference data (file => hash)
+    $referenceData = parseReferenceFile($referenceFile);
+    // Get list of all current files in the project
+    $allFiles = getAllFiles($baseDir);
+
+    // Debug output
+    error_log("DEBUG: Reference keys: " . json_encode(array_keys($referenceData)));
+    error_log("DEBUG: Current files: " . json_encode($allFiles));
+
+    $issues = [];
+
+    // Compare current files to reference
+    foreach ($allFiles as $file) {
+        // Check if file exists in reference list
+        if (!isset($referenceData[$file])) {
+            error_log("DEBUG: File not found in reference: $file");
+            $issues[] = "$file is not listed in reference file";
+            continue;
+        }
+
+        // Compare hashes
+        $expectedHash = $referenceData[$file];
+        $actualHash = md5_file($baseDir . '/' . $file);
+
+        if ($expectedHash !== $actualHash) {
+            error_log("DEBUG: Hash mismatch for $file => expected: $expectedHash, actual: $actualHash");
+            $issues[] = "$file (expected: $expectedHash, actual: $actualHash)";
+        }
+    }
+
+    // Return summary
+    return [
+        'error' => !empty($issues),
+        'array' => $issues,
+        'message' => empty($issues) ? 'Project files integrity check is successful.' : 'Integrity issues found.'
+    ];
+}
+
+/**
+ * Parse the reference file into an associative array.
+ *
+ * Each line in the reference file should be of the form: "path hash".
+ * The function returns an array mapping file paths to their expected MD5 hashes.
+ *
+ * @param string $referenceFile  Path to reference file
+ * @return array                 [ 'file/path' => 'md5hash' ]
+ */
+function parseReferenceFile($referenceFile) {
+    $data = [];
+    $lines = file($referenceFile, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
+    foreach ($lines as $line) {
+        [$path, $hash] = explode(' ', $line, 2);
+        $data[$path] = trim($hash);
+    }
+    return $data;
+}
+
+/**
+ * Get all files in a directory with their md5 hashes.
+ *
+ * Recursively scans a directory, returning an associative array of file paths
+ * (relative to $dir) mapped to their MD5 hashes. Paths are normalized for cross-platform compatibility.
+ *
+ * @param string $dir    Directory to scan
+ * @return array         [ 'file/path' => 'md5hash' ]
+ */
+function getAllFilesWithHashes(string $dir): array
+{
+    $files = [];
+    $iterator = new RecursiveIteratorIterator(
+        new RecursiveDirectoryIterator($dir, FilesystemIterator::SKIP_DOTS)
+    );
+
+    foreach ($iterator as $file) {
+        if ($file->isFile()) {
+            // Build relative path
+            $relativePath = str_replace($dir . DIRECTORY_SEPARATOR, '', $file->getPathname());
+            $relativePath = str_replace('\\', '/', $relativePath); // Normalize for Windows
+            // Calculate hash
+            $files[$relativePath] = md5_file($file->getPathname());
+        }
+    }
+    return $files;
 }


### PR DESCRIPTION
## What does this PR do?
- Enhances the existing file integrity checker to validate each file’s content by comparing MD5 hashes against a reference list.
- Ensures that modifications to file contents are detected, even if filenames remain unchanged.

## Why?
- Previously, the integrity check only compared filenames to files_reference.txt, which could not catch content tampering.
- Now it verifies actual file contents, improving security and trust in the deployment.

## How was this tested?
- Intentionally modified files in the deployment directory.
- Verified that the admin interface flagged hash mismatches, displaying expected vs. actual hashes.

## Notes
- The format of files_reference.txt now expects:
 `relative/path/to/file.md5hash`
For example:
`vendor/autoload.php 1bc29b36f623ba82aaf6724fd3b16718`

- A helper script is provided at scripts/task_generate_files_reference.php to generate this file in the correct format.
Run it from the TeamPass project root:
`php scripts/task_generate_files_reference.php`
- This means to adopt the new integrity check, you just regenerate files_reference.txt using this script.

## Security Considerations
- Currently, files_reference.txt is stored in the same webroot. This means if the server is compromised, an attacker could update this file to hide malicious changes.
- A more robust approach would be to fetch the reference from the official TeamPass repository (or store it outside the webroot). This would add complexity (different TeamPass versions have different files), so this PR keeps to the existing local approach.