### PR TITLE
Fix: upload any extensions file not being honored

### DIFF
--- a/sources/upload.attachments.php
+++ b/sources/upload.attachments.php
@@ -261,17 +261,21 @@ if (strlen($file_name) == 0 || strlen($file_name) > $MAX_FILENAME_LENGTH) {
 
 // Validate file extension
 $ext = strtolower(getFileExtension($_REQUEST['name']));
-if (
-    in_array(
-        $ext,
-        explode(
-            ',',
-            $SETTINGS['upload_docext'] . ',' . $SETTINGS['upload_imagesext'] .
-                ',' . $SETTINGS['upload_pkgext'] . ',' . $SETTINGS['upload_otherext']
-        )
-    ) === false
-) {
-    handleAttachmentError('Invalid file extension.', 115, 415);
+
+// Check if we should enforce extensions
+if (($SETTINGS['upload_all_extensions_file'] ?? '0') !== '1') {
+    if (
+        in_array(
+            $ext,
+            explode(
+                ',',
+                $SETTINGS['upload_docext'] . ',' . $SETTINGS['upload_imagesext'] .
+                    ',' . $SETTINGS['upload_pkgext'] . ',' . $SETTINGS['upload_otherext']
+            )
+        ) === false
+    ) {
+        handleAttachmentError('Invalid file extension.', 115, 415);
+    }
 }
 
 // 5 minutes execution time

--- a/sources/upload.files.php
+++ b/sources/upload.files.php
@@ -250,15 +250,19 @@ if ($file) {
         $SETTINGS['upload_docext'] . ',' . $SETTINGS['upload_imagesext'] .
             ',' . $SETTINGS['upload_pkgext'] . ',' . $SETTINGS['upload_otherext']
     );
-    if (
-        !in_array($ext, $allowed_extensions) 
-        && $post_type_upload !== 'import_items_from_keepass'
-        && $post_type_upload !== 'import_items_from_csv'
-        && $post_type_upload !== 'restore_db'
-        && $post_type_upload !== 'upload_profile_photo'
-    ) {
-        echo handleUploadError('Invalid file extension.');
-        return false;
+
+    // Check if we should enforce extensions
+    if (($SETTINGS['upload_all_extensions_file'] ?? '0') !== '1') {
+        if (
+            !in_array($ext, $allowed_extensions)
+            && $post_type_upload !== 'import_items_from_keepass'
+            && $post_type_upload !== 'import_items_from_csv'
+            && $post_type_upload !== 'restore_db'
+            && $post_type_upload !== 'upload_profile_photo'
+        ) {
+            echo handleUploadError('Invalid file extension.');
+            return false;
+        }
     }
 } else {
     echo handleUploadError('No upload found for Filedata');


### PR DESCRIPTION
### Summary
- Fixes an issue where the “Upload any extension file” setting (upload_all_extensions_file) was not being respected by the file upload scripts. Even when enabled in the TeamPass UI, uploads were still blocked if the file extension wasn’t explicitly listed in the allowed types.

### Changes
- Updated upload.attachments.php and upload.files.php to check the upload_all_extensions_file setting before enforcing extension validation.
- When this setting is enabled (1), file uploads skip the extension whitelist checks, as expected.
- Retains existing validation when the setting is disabled, ensuring secure defaults.

### Testing
- Verified that enabling “Upload any extension file” in the UI allows uploading files with arbitrary extensions.
- Confirmed that disabling the setting restores the original extension restrictions.

### Why
- Resolves an issue where uploading files with any extension was not functioning as intended, despite the configuration.