### PR TITLE
Fix: Prevent Enter key from overwriting manually entered passwords

### DIFF
--- a/pages/items.js.php
+++ b/pages/items.js.php
@@ -6886,6 +6886,7 @@ $var['hidden_asterisk'] = '<i class="fa-solid fa-asterisk mr-2"></i><i class="fa
         let saveInProgress = false;
 
         // Prevent Enter key from propagating in label and password fields and do single save
+        // Enter triggers save in these:
         $('#form-item-label, #form-item-password').on('keydown keyup keypress', function(e) {
             if ((e.key === 'Enter' || e.which === 13)) {
                 e.preventDefault();
@@ -6893,9 +6894,17 @@ $var['hidden_asterisk'] = '<i class="fa-solid fa-asterisk mr-2"></i><i class="fa
                 if (!saveInProgress) {
                     saveInProgress = true;
                     $('#form-item-button-save').click();
-                    // Optionally unlock after a delay if your save is async
                     setTimeout(() => { saveInProgress = false; }, 1000);
                 }
+                return false;
+            }
+        });
+
+        // Enter does nothing in these:
+        $('#form-item-login, #form-item-email, #form-item-url, #form-item-icon').on('keydown keyup keypress', function(e) {
+            if ((e.key === 'Enter' || e.which === 13)) {
+                e.preventDefault();
+                e.stopPropagation();
                 return false;
             }
         });

--- a/pages/items.js.php
+++ b/pages/items.js.php
@@ -6883,6 +6883,14 @@ $var['hidden_asterisk'] = '<i class="fa-solid fa-asterisk mr-2"></i><i class="fa
     }
 
     $(document).ready(function() {
+        // Prevent Enter key from propagating in label and password fields
+        $('#form-item-label, #form-item-password').on('keydown keyup keypress', function(e) {
+            if (e.key === 'Enter' || e.which === 13) {
+                e.preventDefault();
+                e.stopPropagation();
+                return false;
+            }
+        });
         // Event listener for path elems
         $(document).on('click', '.path-elem', function() {
             // Read folder id

--- a/pages/items.js.php
+++ b/pages/items.js.php
@@ -6883,11 +6883,19 @@ $var['hidden_asterisk'] = '<i class="fa-solid fa-asterisk mr-2"></i><i class="fa
     }
 
     $(document).ready(function() {
-        // Prevent Enter key from propagating in label and password fields
+        let saveInProgress = false;
+
+        // Prevent Enter key from propagating in label and password fields and do single save
         $('#form-item-label, #form-item-password').on('keydown keyup keypress', function(e) {
-            if (e.key === 'Enter' || e.which === 13) {
+            if ((e.key === 'Enter' || e.which === 13)) {
                 e.preventDefault();
                 e.stopPropagation();
+                if (!saveInProgress) {
+                    saveInProgress = true;
+                    $('#form-item-button-save').click();
+                    // Optionally unlock after a delay if your save is async
+                    setTimeout(() => { saveInProgress = false; }, 1000);
+                }
                 return false;
             }
         });


### PR DESCRIPTION
### Summary
- Improves the user experience when creating or editing items in TeamPass by preventing the Enter key from inadvertently triggering password generation and overwriting a manually entered password.

### Details
- Previously, pressing Enter while focused on the label or password input field could trigger a global handler that resulted in generating a new random password, silently replacing the manually entered value.
- This could lead to unexpected data loss if a user typed a specific password and hit Enter out of habit (expecting it to save or simply do nothing).

### Changes
- Added explicit event handling to block Enter key propagation on the `#form-item-label` and `#form-item-password` inputs.
- This ensures the Enter key no longer accidentally triggers unrelated global handlers that might overwrite the password field.
- (Enhancement) Pressing Enter inside the Label or Password field triggers a Save action, which aligns with typical form behavior.


### Why
- Protects manually entered passwords from being unexpectedly replaced by a random one.
- Improves predictability and aligns with common user expectations that pressing Enter inside an input does not auto-generate data.
- Saves time by allowing users to simply press Enter to save the item.

### Notes
- This change is minimal and targeted; it does not affect form submission via the Save button or any other interactive elements.
- Tested in multiple scenarios to ensure no side effects.
- Not entirely sure if triggering password generation on Enter was intended as a feature — but from a UX perspective it feels more like a bug, as it can silently overwrite manual inputs.

---

**Update**
After some more practical testing (and a bit of “oops, maybe acted too fast 😅”), this PR is now refined to:
- Only trigger the Enter-to-save behavior when focused in the Label or Password fields.
- Explicitly prevent Enter from doing anything in the Login, Email, URL, and Icon fields, avoiding accidental triggers of other handlers (like password generation or unexpected saves).

Thanks for bearing with the iterations — hopefully this is now more aligned with intuitive UX.