### PR TITLE
Fix type errors on keepass import.

### DIFF
--- a/sources/import.queries.php
+++ b/sources/import.queries.php
@@ -611,7 +611,7 @@ switch (filter_input(INPUT_POST, 'type', FILTER_SANITIZE_FULL_SPECIAL_CHARS)) {
          * 
          * @return array The new items to add to the database.
          */
-        function handleGroups($groups, string $previousFolder, array $newItemsToAdd, int $level) : array
+        function handleGroups(array $groups, string $previousFolder, array $newItemsToAdd, int $level) : array
         {
             // If a single group is found, wrap it into an array
             if (isset($groups['UUID'])) {
@@ -630,8 +630,8 @@ switch (filter_input(INPUT_POST, 'type', FILTER_SANITIZE_FULL_SPECIAL_CHARS)) {
                 // Recursively process entries and subgroups inside this group
                 $newItemsToAdd = recursive(
                     [
-                        'Entry' => $group['Entry'] ?? '',
-                        'Group' => $group['Group'] ?? '',
+                        'Entry' => $group['Entry'] ?? [],
+                        'Group' => $group['Group'] ?? [],
                     ],
                     $group['UUID'],
                     $newItemsToAdd,
@@ -715,7 +715,7 @@ switch (filter_input(INPUT_POST, 'type', FILTER_SANITIZE_FULL_SPECIAL_CHARS)) {
                 $parentId['id'],
                 $folder['level'],
                 $startPathLevel,
-                $destinationFolderInfos['levelPwComplexity']
+                (int) $destinationFolderInfos['levelPwComplexity']
             );
 
             // manage parent


### PR DESCRIPTION
Fix for these errors:
```
[2025-08-19 09:45:36.055669] [proxy_fcgi:error] [R:aKQrnw_loZG7IVPcE8E1XwAAAJA] AH01071: Got error 'PHP message: PHP Fatal error:  Uncaught TypeError: handleEntries(): Argument #1 ($entries) must be of type array, string given, called in /var/www/teampass/sources/import.queries.php on line 520 and defined in /var/www/teampass/sources/import.queries.php:541\nStack trace:\n#0 /var/www/teampass/sources/import.queries.php(520): handleEntries('', '******...',Array)\n#1 /var/www/teampass/sources/import.queries.php(631): recursive(Array, '*******...', Array, 2)\n#2 /var/www/teampass/sources/import.queries.php(525): handleGroups(Array, '3555', Array, 1)\n#3 /var/www/teampass/sources/import.queries.php(646): recursive(Array, '3555', Array, 1)\n#4 {main}\n  thrown in /var/www/teampass/sources/import.queries.php on line 541'
```
And:
```
[2025-08-19 10:28:48.070956] [proxy_fcgi:error] [R:aKQ1v-_miuhObt0_0HZrHAAAAEw] AH01071: Got error 'PHP message: PHP Fatal error:  Uncaught MeekroDBException: Column 'valeur' cannot be null in /var/www/teampass/vendor/sergeytsalkov/meekrodb/db.class.php:934\nStack trace:\n#0 /var/www/teampass/vendor/sergeytsalkov/meekrodb/db.class.php(890): MeekroDB->queryHelper(Array, Array)\n#1 /var/www/teampass/vendor/sergeytsalkov/meekrodb/db.class.php(549): MeekroDB->query('%l INTO %b %lc ...', 'INSERT', 'teampass_misc', Array, Array)\n#2 /var/www/teampass/vendor/sergeytsalkov/meekrodb/db.class.php(554): MeekroDB->insertOrReplace('INSERT', 'teampass_misc', Array)\n#3 /var/www/teampass/vendor/sergeytsalkov/meekrodb/db.class.php(116): MeekroDB->insert('teampass_misc', Array)\n#4 /var/www/teampass/sources/import.queries.php(931): DB::__callStatic('insert', Array)\n#5 /var/www/teampass/sources/import.queries.php(713): createFolder('General', 3555, '1', 1, NULL)\n#6 {main}\n  thrown in /var/www/teampass/vendor/sergeytsalkov/meekrodb/db.class.php on line 934'
```