### PR TITLE
Remove unused data from session

### DIFF
--- a/includes/libraries/teampassclasses/configmanager/src/ConfigManager.php
+++ b/includes/libraries/teampassclasses/configmanager/src/ConfigManager.php
@@ -35,31 +35,14 @@ class ConfigManager
 {
     private $settings;
  
-    public function __construct( $rootPath = null, $rootUrl = null)
+    public function __construct()
     {
-        $this->loadConfiguration($rootPath, $rootUrl);
+        $this->loadConfiguration();
     }
  
-    private function loadConfiguration($rootPath = null, $rootUrl = null)
+    private function loadConfiguration()
     {
-        $session = SessionManager::getSession();
-
-        // Get the last modification time of a change in the settings
-        $lastModified = $this->getLastModificationTimestamp();
-
-        // Check if the settings have been loaded before and if a setting hasn't been modified since the last load
-        if ($session->has('teampass-settings') && isset($session->get('teampass-settings')['timestamp']) === true && $session->get('teampass-settings')['timestamp'] > $lastModified && is_null($lastModified) === false) {
-            $this->settings = $session->get('teampass-settings');
-        } else {
-            // Load settings from DB
-            $this->settings = $this->loadSettingsFromDB('DB');
-
-            // Add the timestamp to the settings
-            $this->settings['timestamp'] = time();
-
-            // Save the settings in the session
-            $session->set('teampass-settings', $this->settings);
-        }
+        $this->settings = $this->loadSettingsFromDB('DB');
      }
  
      public function getSetting($key)

--- a/index.php
+++ b/index.php
@@ -84,7 +84,7 @@ if ($session->get('key') === null)
     $session->set('key', generateQuickPassword(30, false));
 
 $request = SymfonyRequest::createFromGlobals();
-$configManager = new ConfigManager(__DIR__, $request->getRequestUri());
+$configManager = new ConfigManager();
 $SETTINGS = $configManager->getAllSettings();
 $antiXss = new AntiXSS();
 $session->set('encryptClientServer', (int) $SETTINGS['encryptClientServer'] ?? 1);

--- a/sources/admin.queries.php
+++ b/sources/admin.queries.php
@@ -2183,12 +2183,6 @@ switch ($post_type) {
             );
         }
 
-        // Update last settings change timestamp
-        // This to ensure that the settings are refreshed in the session
-        $settings = $session->get('teampass-settings');
-        $settings['timestamp'] = time();
-        $session->set('teampass-settings', $settings);
-
         // Encrypt data to return
         echo prepareExchangedData(
             array(

--- a/sources/folders.queries.php
+++ b/sources/folders.queries.php
@@ -1029,8 +1029,6 @@ if (null !== $post_type) {
                 if ((int) $nodeInfo->personal_folder === 1) {
                     SessionManager::addRemoveFromSessionArray('user-personal_folders', [$newFolderId], 'add');
                     SessionManager::addRemoveFromSessionArray('user-personal_visible_folders', [$newFolderId], 'add');
-                } else {
-                    SessionManager::addRemoveFromSessionArray('user-all_non_personal_folders', [$newFolderId], 'add');
                 }
 
                 // If new folder should not heritate of parent rights

--- a/sources/identify.php
+++ b/sources/identify.php
@@ -647,7 +647,6 @@ function identifyUser(string $sentData, array $SETTINGS): bool
                 $session->set('user-personal_visible_folders', []);
                 $session->set('user-personal_folders', []);
             }
-            $session->set('user-all_non_personal_folders', []);
             $session->set('user-roles_array', []);
             $session->set('user-read_only_folders', []);
             $session->set('user-list_folders_limited', []);
@@ -668,7 +667,6 @@ function identifyUser(string $sentData, array $SETTINGS): bool
         $session->set('system-screen_height', $dataReceived['screenHeight']);
 
         // Get last seen items
-        $session->set('user-latest_items_tab', []);
         $session->set('user-nb_roles', 0);
         foreach ($session->get('user-latest_items') as $item) {
             if (! empty($item)) {
@@ -677,15 +675,6 @@ function identifyUser(string $sentData, array $SETTINGS): bool
                     FROM ' . prefixTable('items') . '
                     WHERE id=%i',
                     $item
-                );
-                SessionManager::addRemoveFromSessionAssociativeArray(
-                    'user-latest_items_tab',
-                    [
-                        'id' => $item,
-                        'label' => $dataLastItems['label'],
-                        'url' => 'index.php?page=items&amp;group=' . $dataLastItems['id_tree'] . '&amp;id=' . $item,
-                    ],
-                    'add'
                 );
             }
         }

--- a/sources/items.queries.php
+++ b/sources/items.queries.php
@@ -6442,9 +6442,6 @@ switch ($inputData['type']) {
             // store array to return
             $arr_data['folders'] = $arrayFolders;
 
-            // update session
-            $session->set('user-folders_list', $arr_data['folders']);
-            
             // update cache
             cacheTreeUserHandler(
                 (int) $session->get('user-id'),

--- a/sources/main.functions.php
+++ b/sources/main.functions.php
@@ -57,7 +57,7 @@ loadClasses('DB');
 $session = SessionManager::getSession();
 
 // Load config if $SETTINGS not defined
-$configManager = new ConfigManager($session);
+$configManager = new ConfigManager();
 $SETTINGS = $configManager->getAllSettings();
 
 /**
@@ -1240,7 +1240,7 @@ function prepareExchangedData($data, string $type, ?string $key = null)
         );
         
         // Now encrypt
-        if ((int) $session->get('teampass-settings')['encryptClientServer'] === 1) {
+        if ((int) $session->get('encryptClientServer') === 1) {
             $data = Encryption::encrypt(
                 $data,
                 $key
@@ -1252,7 +1252,7 @@ function prepareExchangedData($data, string $type, ?string $key = null)
 
     if ($type === 'decode' && is_array($data) === false) {
         // Decrypt if needed
-        if ((int) $session->get('teampass-settings')['encryptClientServer'] === 1) {
+        if ((int) $session->get('encryptClientServer') === 1) {
             $data = (string) Encryption::decrypt(
                 (string) $data,
                 $key

--- a/sources/main.functions.php
+++ b/sources/main.functions.php
@@ -358,7 +358,6 @@ function identAdmin($idFonctions, $SETTINGS, $tree)
         array_push($groupesVisibles, $record['id']);
     }
     $session->set('user-accessible_folders', $groupesVisibles);
-    $session->set('user-all_non_personal_folders', $groupesVisibles);
 
     // get complete list of ROLES
     $tmp = explode(';', $idFonctions);
@@ -512,7 +511,6 @@ function identUser(
     $noAccessPersonalFolders = $arrays['noAccessPersonalFolders'];
 
     // Return data
-    $session->set('user-all_non_personal_folders', $allowedFolders);
     $session->set('user-accessible_folders', array_unique(array_merge($allowedFolders, $personalFolders), SORT_NUMERIC));
     $session->set('user-read_only_folders', $readOnlyFolders);
     $session->set('user-no_access_folders', $noAccessFolders);
@@ -521,15 +519,6 @@ function identUser(
     $session->set('system-list_folders_editable_by_role', $allowedFoldersByRoles, 'SESSION');
     $session->set('system-list_restricted_folders_for_items', $restrictedFoldersForItems);
     $session->set('user-forbiden_personal_folders', $noAccessPersonalFolders);
-    $session->set(
-        'all_folders_including_no_access',
-        array_unique(array_merge(
-            $allowedFolders,
-            $personalFolders,
-            $noAccessFolders,
-            $readOnlyFolders
-        ), SORT_NUMERIC)
-    );
     // Folders and Roles numbers
     DB::queryFirstRow('SELECT id FROM ' . prefixTable('nested_tree') . '');
     DB::queryFirstRow('SELECT id FROM ' . prefixTable('nested_tree') . '');
@@ -3288,16 +3277,6 @@ function loadFoldersListByCache(
             'data' => [],
         ];
     }
-
-    // Does this user has the tree structure in session?
-    // If yes then use it
-    if (count(null !== $session->get('user-folders_list') ? $session->get('user-folders_list') : []) > 0) {
-        return [
-            'state' => true,
-            'data' => json_encode($session->get('user-folders_list')[0]),
-            'extra' => 'to_be_parsed',
-        ];
-    }
     
     // Does this user has a tree cache
     $userCacheTree = DB::queryFirstRow(
@@ -3307,11 +3286,6 @@ function loadFoldersListByCache(
         $session->get('user-id')
     );
     if (empty($userCacheTree[$fieldName]) === false && $userCacheTree[$fieldName] !== '[]') {
-        SessionManager::addRemoveFromSessionAssociativeArray(
-            'user-folders_list',
-            [$userCacheTree[$fieldName]],
-            'add'
-        );
         return [
             'state' => true,
             'data' => $userCacheTree[$fieldName],

--- a/vendor/teampassclasses/configmanager/src/ConfigManager.php
+++ b/vendor/teampassclasses/configmanager/src/ConfigManager.php
@@ -35,31 +35,14 @@ class ConfigManager
 {
     private $settings;
  
-    public function __construct( $rootPath = null, $rootUrl = null)
+    public function __construct()
     {
-        $this->loadConfiguration($rootPath, $rootUrl);
+        $this->loadConfiguration();
     }
  
-    private function loadConfiguration($rootPath = null, $rootUrl = null)
+    private function loadConfiguration()
     {
-        $session = SessionManager::getSession();
-
-        // Get the last modification time of a change in the settings
-        $lastModified = $this->getLastModificationTimestamp();
-
-        // Check if the settings have been loaded before and if a setting hasn't been modified since the last load
-        if ($session->has('teampass-settings') && isset($session->get('teampass-settings')['timestamp']) === true && $session->get('teampass-settings')['timestamp'] > $lastModified && is_null($lastModified) === false) {
-            $this->settings = $session->get('teampass-settings');
-        } else {
-            // Load settings from DB
-            $this->settings = $this->loadSettingsFromDB('DB');
-
-            // Add the timestamp to the settings
-            $this->settings['timestamp'] = time();
-
-            // Save the settings in the session
-            $session->set('teampass-settings', $this->settings);
-        }
+        $this->settings = $this->loadSettingsFromDB('DB');
      }
  
      public function getSetting($key)


### PR DESCRIPTION
`teampass-settings` contains confidential data and is not required during the session.
The other fields are very large and are not useful.

```bash
# Before:
[root@teampass ~]# du -sh /tmp/systemd-private-php-fpm.service/tmp/sess_****************
2,4M    /tmp/systemd-private-php-fpm.service/tmp/sess_****************

# After:
[root@teampass ~]# du -sh /tmp/systemd-private-php-fpm.service/tmp/sess_****************
384K    /tmp/systemd-private-php-fpm.service/tmp/sess_****************
```
This improves performance on large environments.
