### PR TITLE
fix: invalidate sessions for deleted users to prevent unauthorized access

### DIFF
--- a/sources/core.php
+++ b/sources/core.php
@@ -238,11 +238,12 @@ if ((isset($get['session']) === true
 // CHECK IF SESSION EXISTS AND IF SESSION IS VALID
 if (empty($session->get('user-session_duration')) === false) {
     $dataSession = DB::queryFirstRow(
-        'SELECT key_tempo FROM ' . prefixTable('users') . ' WHERE id=%i',
+        'SELECT key_tempo, deleted_at FROM ' . prefixTable('users') . ' WHERE id=%i',
         $session->get('user-id')
     );
 } else {
     $dataSession['key_tempo'] = '';
+    $dataSession['deleted_at'] = null;
 }
 
 if (
@@ -253,7 +254,8 @@ if (
     && (empty($session->get('user-session_duration')) === true
         || $session->get('user-session_duration') < time()
         || null === $session->get('key')
-        || empty($dataSession['key_tempo']) === true)
+        || empty($dataSession['key_tempo']) === true
+        || $dataSession['deleted_at'] !== null)
 ) {
     // Update table by deleting ID
     DB::update(

--- a/vendor/teampassclasses/performchecks/src/PerformChecks.php
+++ b/vendor/teampassclasses/performchecks/src/PerformChecks.php
@@ -181,7 +181,7 @@ class PerformChecks
         
         // load user's data
         $data = DB::queryfirstrow(
-            'SELECT id, login, key_tempo, admin, gestionnaire, can_manage_all_users FROM ' . prefixTable('users') . ' WHERE id = %i',
+            'SELECT id, login, key_tempo, admin, gestionnaire, can_manage_all_users, deleted_at FROM ' . prefixTable('users') . ' WHERE id = %i',
             $this->sessionVar['user_id']
         );
         
@@ -189,7 +189,12 @@ class PerformChecks
         if (empty($data['login']) === true || empty($data['key_tempo']) === true || $data['key_tempo'] !== $this->sessionVar['user_key']) {
             return false;
         }
-        
+
+        // check if user has been deleted
+        if ($data['deleted_at'] !== null) {
+            return false;
+        }
+
         if (
             ((int) $data['admin'] === 1 && $this->isValueInArray($pageVisited, $pagesRights['admin']) === true)
             ||


### PR DESCRIPTION
Fix bug where deleted users could continue accessing secrets through existing active sessions.

This flaw poses a significant risk during employee terminations, as rogue employees could maintain access to sensitive passwords and credentials after being dismissed

Modified session validation to check the deleted_at field and immediately terminate sessions when a user account is deleted.