### PR TITLE
Fix HTML entities display in logs page

### DIFF
--- a/pages/utilities.logs.js.php
+++ b/pages/utilities.logs.js.php
@@ -90,6 +90,16 @@ if ($checkUserAccess->checkSession() === false || $checkUserAccess->userAccessPa
     var oTableAdmin;
     var oTableErrors;
 
+    // Decode HTML entities (e.g. &eacute; -> é, &amp; -> &)
+    function decodeHtmlEntities(str) {
+        if (str === null || str === undefined) {
+            return '';
+        }
+        var txt = document.createElement('textarea');
+        txt.innerHTML = str;
+        return txt.value;
+    }
+
     // What type of form? Edit or new user
     store.update(
         'teampassApplication',
@@ -185,6 +195,16 @@ if ($checkUserAccess->checkSession() === false || $checkUserAccess->userAccessPa
                 return filter;
             }
         },
+        'columnDefs': [
+            {
+                // 0 = Date, 1 = Action, 2 = User
+                'targets': [2],
+                'render': function (data, type, row, meta) {
+                    if (type !== 'display') { return data; }
+                    return decodeHtmlEntities(data);
+                }
+            }
+        ],
         'language': {
             'url': '<?php echo $SETTINGS['cpassman_url']; ?>/includes/language/datatables.<?php echo $session->get('user-language'); ?>.txt'
         },
@@ -233,6 +253,16 @@ if ($checkUserAccess->checkSession() === false || $checkUserAccess->userAccessPa
                     d.letter = _alphabetSearch
                 }*/
             },
+            'columnDefs': [
+                {
+                    // Label + User
+                    'targets': [1, 2],
+                    'render': function (data, type) {
+                        if (type !== 'display') { return data; }
+                        return decodeHtmlEntities(data);
+                    }
+                }
+            ],
             'language': {
                 'url': '<?php echo $SETTINGS['cpassman_url']; ?>/includes/language/datatables.<?php echo $session->get('user-language'); ?>.txt'
             },
@@ -282,6 +312,15 @@ if ($checkUserAccess->checkSession() === false || $checkUserAccess->userAccessPa
                     d.letter = _alphabetSearch
                 }*/
             },
+            'columnDefs': [
+                {
+                    'targets': [1, 2],
+                    'render': function (data, type) {
+                        if (type !== 'display') { return data; }
+                        return decodeHtmlEntities(data);
+                    }
+                }
+            ],
             'language': {
                 'url': '<?php echo $SETTINGS['cpassman_url']; ?>/includes/language/datatables.<?php echo $session->get('user-language'); ?>.txt'
             },
@@ -331,21 +370,32 @@ if ($checkUserAccess->checkSession() === false || $checkUserAccess->userAccessPa
                     d.letter = _alphabetSearch
                 }*/
             },
+            'columnDefs': [
+                {
+                    // 0 = Date, 1 = Label, 2 = User
+                    'targets': [1, 2],
+                    'render': function (data, type) {
+                        if (type !== 'display') {
+                            return data;
+                        }
+                        return decodeHtmlEntities(data);
+                    }
+                }
+            ],
             'language': {
                 'url': '<?php echo $SETTINGS['cpassman_url']; ?>/includes/language/datatables.<?php echo $session->get('user-language'); ?>.txt'
             },
             'preDrawCallback': function() {
                 toastr.remove();
-                toastr.info('<?php echo $lang->get('loading_data'); ?> ... <i class="fas fa-circle-notch fa-spin fa-2x"></i>');
+                toastr.info('<?php echo $lang->get('loading_data'); ?> . <i class="fas fa-circle-notch fa-spin fa-2x"></i>');
             },
             'drawCallback': function() {
                 // Inform user
                 toastr.remove();
                 toastr.success(
                     '<?php echo $lang->get('done'); ?>',
-                    '', {
-                        timeOut: 1000
-                    }
+                    '',
+                    { timeOut: 1000 }
                 );
             },
         });
@@ -380,21 +430,32 @@ if ($checkUserAccess->checkSession() === false || $checkUserAccess->userAccessPa
                     d.letter = _alphabetSearch
                 }*/
             },
+            'columnDefs': [
+                {
+                    // 0 = Date, 1 = Author, 2 = Action, 3 = Who
+                    'targets': [1, 3],
+                    'render': function (data, type) {
+                        if (type !== 'display') {
+                            return data;
+                        }
+                        return decodeHtmlEntities(data);
+                    }
+                }
+            ],
             'language': {
                 'url': '<?php echo $SETTINGS['cpassman_url']; ?>/includes/language/datatables.<?php echo $session->get('user-language'); ?>.txt'
             },
             'preDrawCallback': function() {
                 toastr.remove();
-                toastr.info('<?php echo $lang->get('loading_data'); ?> ... <i class="fas fa-circle-notch fa-spin fa-2x"></i>');
+                toastr.info('<?php echo $lang->get('loading_data'); ?> . <i class="fas fa-circle-notch fa-spin fa-2x"></i>');
             },
             'drawCallback': function() {
                 // Inform user
                 toastr.remove();
                 toastr.success(
                     '<?php echo $lang->get('done'); ?>',
-                    '', {
-                        timeOut: 1000
-                    }
+                    '',
+                    { timeOut: 1000 }
                 );
             },
         });
@@ -472,7 +533,7 @@ if ($checkUserAccess->checkSession() === false || $checkUserAccess->userAccessPa
             'responsive': true,
             'stateSave': true,
             'autoWidth': true,
-            'ajax': {
+             'ajax': {
                 url: '<?php echo $SETTINGS['cpassman_url']; ?>/sources/logs.datatables.php?action=items',
                 data: function(filter) {
                     var val = $("select", "#table-items_filter").val();
@@ -480,6 +541,18 @@ if ($checkUserAccess->checkSession() === false || $checkUserAccess->userAccessPa
                     return filter;
                 }
             },
+            'columnDefs': [
+                {
+                    // 0=Date, 1=ID, 2=Label, 3=Folder, 4=User
+                    'targets': [2, 3, 4],
+                    'render': function(data, type, row, meta) {
+                        if (type !== 'display') {
+                            return data;
+                        }
+                        return decodeHtmlEntities(data);
+                    }
+                }
+            ],
             'language': {
                 'url': '<?php echo $SETTINGS['cpassman_url']; ?>/includes/language/datatables.<?php echo $session->get('user-language'); ?>.txt'
             },


### PR DESCRIPTION
### Summary

This PR fixes the display of HTML entities in the logs page (Journaux):

- User names and labels were shown as `M&eacute;lanie`, `F&amp;H`, etc.
- We now decode HTML entities on the client side for the DataTables used in:
  - Connexions
  - Connexions échouées
  - Erreurs
  - Copie faite
  - Administration
  - Éléments

### Technical details

- Add a `decodeHtmlEntities()` helper in `pages/utilities.logs.js.php`.
- Use DataTables `columnDefs.render` for the columns containing user names / labels so they are decoded only for display, without touching the database values.

Tested on my instance (3.1.5.1) with French locale. Should also work on 3.1.5.3 as the file hasn't been touched between those releases.
