### PR TITLE
Decode HTML entities in email subject

### DIFF
--- a/sources/main.functions.php
+++ b/sources/main.functions.php
@@ -1051,7 +1051,7 @@ function prepareSendingEmail(
             'created_at' => time(),
             'process_type' => 'send_email',
             'arguments' => json_encode([
-                'subject' => $subject,
+                'subject' => html_entity_decode((string) $subject, ENT_QUOTES | ENT_HTML5, 'UTF-8'),
                 'receivers' => $email,
                 'body' => $body,
                 'receiver_name' => $receiverName,


### PR DESCRIPTION
Subject line is HTML-encoded (&apos;)

In French (and probably other languages), the subject currently appears like: Image

The translations store apostrophes as HTML entities (&apos;, etc.), and the subject is used as-is when creating the background task, so the mail client shows the literal entity in the subject.

On my instance I fixed this by decoding HTML entities in sources/main.functions.php, function prepareSendingEmail(), before storing the subject in background_tasks.