### PR TITLE
Refactor columnDefs for better readability

### DIFF
--- a/pages/utilities.database.js.php
+++ b/pages/utilities.database.js.php
@@ -77,13 +77,20 @@ if ($checkUserAccess->checkSession() === false || $checkUserAccess->userAccessPa
 }
 ?>
 
-
 <script type='text/javascript'>
     //<![CDATA[
 
     var oTableLoggedIn,
         oTableConnections;
 
+    function decodeHtmlEntities(str) {
+        if (str === null || str === undefined) {
+            return '';
+        }
+        var txt = document.createElement('textarea');
+        txt.innerHTML = str;
+        return txt.value;
+    }
 
     // Prepare tooltips
     $('.infotip').tooltip();
@@ -134,13 +141,26 @@ if ($checkUserAccess->checkSession() === false || $checkUserAccess->userAccessPa
                 }
             );
         },
-        'columnDefs': [{
-            'width': '80px',
-            'targets': 0,
-            'render': function(data, type, row, meta) {
-                return '<i class="far fa-trash-alt text-danger pointer action" data-id="' + $(data).data('id') + '" data-type="item-edited"></i>';
+        'columnDefs': [
+            {
+                'width': '80px',
+                'targets': 0,
+                'render': function(data, type, row, meta) {
+                    // Trashbox icon
+                    return '<i class="far fa-trash-alt text-danger action" data-id="' + $(data).data('id') + '" data-type="item-edited"></i>';
+                }
+            },
+            {
+                // 0 = action, 1 = duration, 2 = user, 3 = label
+                'targets': [2, 3],
+                'render': function(data, type, row, meta) {
+                    if (type !== 'display') {
+                        return data;
+                    }
+                    return decodeHtmlEntities(data);
+                }
             }
-        }],
+        ]
     });
 
     /**
@@ -186,13 +206,26 @@ if ($checkUserAccess->checkSession() === false || $checkUserAccess->userAccessPa
                     }
                 );
             },
-            'columnDefs': [{
-                'width': '80px',
-                'targets': 0,
-                'render': function(data, type, row, meta) {
-                    return '<i class="far fa-trash-alt text-danger pointer action" data-id="' + $(data).data('id') + '" data-type="disconnect-user"></i>';
+            'columnDefs': [
+                {
+                    'width': '80px',
+                    'targets': 0,
+                    'render': function(data, type, row, meta) {
+                        // Disconnect Icon
+                        return '<i class="far fa-trash-alt text-danger action" data-id="' + $(data).data('id') + '" data-type="disconnect-user"></i>';
+                    }
+                },
+                {
+                    // 0 = action, 1 = user, 2 = role, 3 = connected since
+                    'targets': [1],
+                    'render': function(data, type, row, meta) {
+                        if (type !== 'display') {
+                            return data;
+                        }
+                        return decodeHtmlEntities(data);
+                    }
                 }
-            }],
+            ]
         });
     }
 
@@ -242,8 +275,6 @@ if ($checkUserAccess->checkSession() === false || $checkUserAccess->userAccessPa
             );
         }
     });
-
-
 
     //]]>
 </script>


### PR DESCRIPTION
### Summary

This PR fixes the display of HTML entities on the **Database** page (`utilities.database`):

- User names and item labels were shown as `Charl&egrave;ne`, `xxxxx [7033]` with `&amp;`, `&eacute;`, etc.
- We now decode HTML entities on the client side for the two DataTables used in:
  - "Items currently being edited"
  - "Users currently connected"

### Technical details

- Add a small `decodeHtmlEntities()` helper in `pages/utilities.database.js.php`.
- For **Items currently being edited** (`#table-in_edition`):
  - Use `columnDefs.render` to decode HTML entities in:
    - column *User*
    - column *Label* (folder / item title)
- For **Users currently connected** (`#table-logged_in`):
  - Use `columnDefs.render` to decode HTML entities in:
    - column *User*
- Only the display is changed (DataTables `"display"` type).   Database values and backend responses are left untouched.

### Testing

- Tested on my instance (3.1.5.1) with French locale.
- Checked both tabs:
  - "Éléments actuellement en cours d'édition"
  - "Utilisateurs actuellement connectés"
- Names with accents now render correctly (e.g. `Charlène`) and folders/titles no longer show `&amp;` or `&eacute;`.

This is similar to PR #4931 which fixes HTML entities in the "Logs" page.