### PR TITLE
Fix PHP 8 fatal error in cacheTableAdd() during KeePass import

### DIFF
--- a/sources/main.functions.php
+++ b/sources/main.functions.php
@@ -741,7 +741,7 @@ function cacheTableRefresh(): void
                         WHERE id = %i',
                         $elem->title
                     );
-                    if (count($user) > 0) {
+                    if (!empty($user)) {
                         $elem->title = $user['login'];
                     }
                 }
@@ -816,7 +816,7 @@ function cacheTableUpdate(?int $ident = null): void
                 WHERE id = %i',
                 $elem->title
             );
-            if (count($user) > 0) {
+            if (!empty($user)) {
                 $elem->title = $user['login'];
             }
         }
@@ -894,7 +894,7 @@ function cacheTableAdd(?int $ident = null): void
                 WHERE id = %i',
                 $elem->title
             );
-            if (count($user) > 0) {
+            if (!empty($user)) {
                 $elem->title = $user['login'];
             }
         }


### PR DESCRIPTION
## Summary

On TeamPass `3.1.5.7` with PHP 8 (tested with PHP 8.4), the KeePass import
fails with a 500 error around 70–75% of the progress bar.

The Apache/PHP error log shows a fatal error in `cacheTableAdd()`:
```
PHP Fatal error:  Uncaught TypeError: count(): Argument #1 ($value) must be
of type Countable|array, null given in
sources/main.functions.php:893
Stack trace:
#0 sources/main.functions.php(675): cacheTableAdd()
#1 sources/import.queries.php(1281): updateCacheTable()
#2 {main}
```
## Root cause

In cacheTableReload() and cacheTableAdd(), the code uses
DB::queryFirstRow() to look up a user from nested_tree.title
when the folder name is a numeric user id:
```
$user = DB::queryFirstRow(
    'SELECT id, login
     FROM ' . prefixTable('users') . '
     WHERE id = %i',
    $elem->title
);
if (count($user) > 0) {
    $elem->title = $user['login'];
}
```

DB::queryFirstRow() returns null when no row is found.
In PHP 7 this was tolerated (count(null) == 0),
but in PHP 8+ it raises a TypeError:

```
count(): Argument #1 ($value) must be of type Countable|array, null given
```
This crashes during KeePass import when one of the folders in the path
does not correspond to a user id.

## Fix

Replace if (count($user) > 0) by a safer if (!empty($user))
in the three occurrences, to avoid calling count() on null.

This keeps the original logic ("if a row was found, replace the title by the
user login") but is compatible with PHP 8.

## Testing

Environment: TeamPass 3.1.5.7, PHP 8.4, MariaDB/MySQL.
Import a ~1 MB KeePass XML file into a personal folder.

Before the patch:
Import stops around 73%.
Browser sees a 500 error on sources/import.queries.php.
Apache log shows the count(): Argument #1 ($value) must be of type Countable|array, null given
fatal error in cacheTableAdd().

After the patch:
KeePass import completes (100%).
No PHP fatal error in logs.
Imported items are visible as expected.