### PR TITLE
Refactor email notification condition

### DIFF
--- a/sources/identify.php
+++ b/sources/identify.php
@@ -827,10 +827,7 @@ function performPostLoginTasks(
 
     // Send email notification if enabled
     $lang = new Language($session->get('user-language') ?? 'english');
-    if (
-        isKeyExistingAndEqual('enable_send_email_on_user_login', 1, $SETTINGS) === true
-        && (int) $userInfo['admin'] !== 1
-    ) {
+    if (isKeyExistingAndEqual('enable_send_email_on_user_login', 1, $SETTINGS) === true) {
         // get all Admin users
         $val = DB::queryFirstRow('SELECT email FROM ' . prefixTable('users') . " WHERE admin = %i and email != ''", 1);
         if (DB::count() > 0) {


### PR DESCRIPTION
with current identify.php emails notifications are well sent on users login but not on admin login. This fix re-enable email notification on admin login