### PR TITLE
Hotfix/fix 3160

### DIFF
--- a/includes/libraries/teampassclasses/cryptomanager/src/CryptoManager.php
+++ b/includes/libraries/teampassclasses/cryptomanager/src/CryptoManager.php
@@ -269,6 +269,11 @@ class CryptoManager
 
                 $decrypted = $cipher->decrypt($data);
 
+                // openssl_decrypt() can return false on failure
+                if ($decrypted === false) {
+                    throw new Exception('AES decryption failed (openssl returned false)');
+                }
+
                 // Success with v3
                 return $decrypted;
             } catch (Exception $e) {
@@ -295,6 +300,11 @@ class CryptoManager
 
                         $cipher->setPassword($password);
                         $decrypted = $cipher->decrypt($data);
+
+                        // openssl_decrypt() can return false on failure
+                        if ($decrypted === false) {
+                            throw new Exception('AES v1 decryption failed (openssl returned false)');
+                        }
 
                         // Success with v1 fallback
                         return $decrypted;
@@ -330,7 +340,14 @@ class CryptoManager
                 }
 
                 $cipher->setPassword($password);
-                return $cipher->decrypt($data);
+                $decrypted = $cipher->decrypt($data);
+
+                // openssl_decrypt() can return false on failure
+                if ($decrypted === false) {
+                    throw new Exception('AES v1-only decryption failed (openssl returned false)');
+                }
+
+                return $decrypted;
             } catch (Exception $e) {
                 throw new Exception('Failed to decrypt with AES: ' . $e->getMessage());
             }

--- a/install/install-steps/install.functions.php
+++ b/install/install-steps/install.functions.php
@@ -161,8 +161,8 @@ function generateUserKeysForInstall(string $userPwd): array
     // Generate RSA key pair using CryptoManager (phpseclib v3)
     $res = \TeampassClasses\CryptoManager\CryptoManager::generateRSAKeyPair(4096);
 
-    // Encrypt the private key with user password using AES
-    $privatekey = \TeampassClasses\CryptoManager\CryptoManager::aesEncrypt($res['privatekey'], $userPwd);
+    // Encrypt the private key with user password using AES (SHA-256 for v3)
+    $privatekey = \TeampassClasses\CryptoManager\CryptoManager::aesEncrypt($res['privatekey'], $userPwd, 'cbc', 'sha256');
 
     return [
         'private_key' => base64_encode($privatekey),

--- a/pages/admin.php
+++ b/pages/admin.php
@@ -401,7 +401,7 @@ header('Cache-Control: no-cache, no-store, must-revalidate');
                                             $user_results = DB::query(
                                                 "SELECT login 
                                                 FROM ".prefixTable('users')."
-                                                WHERE phpseclibv3_migration_completed = 0"
+                                                WHERE phpseclibv3_migration_completed = 0 AND deleted_at IS NULL"
                                             );
                                             if (DB::count() > 0) {
                                                 $logins_array = array_column($user_results, 'login');

--- a/sources/users.queries.php
+++ b/sources/users.queries.php
@@ -307,35 +307,48 @@ if (null !== $post_type) {
                     break;
                 }
 
-                // Add user in DB
+                // Prepare user data for insertion
+                $userData = array(
+                    'login' => $login,
+                    'name' => $name,
+                    'lastname' => $lastname,
+                    'pw' => $hashedPassword,
+                    'email' => $email,
+                    'auth_type' => 'local',
+                    'admin' => empty($is_admin) === true ? 0 : $is_admin,
+                    'can_manage_all_users' => empty($is_hr) === true ? 0 : $is_hr,
+                    'gestionnaire' => empty($is_manager) === true ? 0 : $is_manager,
+                    'read_only' => empty($is_read_only) === true ? 0 : $is_read_only,
+                    'personal_folder' => empty($has_personal_folder) === true ? 0 : $has_personal_folder,
+                    'user_language' => $SETTINGS['default_language'],
+                    'isAdministratedByRole' => $is_administrated_by,
+                    'encrypted_psk' => '',
+                    'last_pw_change' => time(),
+                    'public_key' => $userKeys['public_key'],
+                    'private_key' => $userKeys['private_key'],
+                    'special' => 'auth-pwd-change',
+                    'is_ready_for_usage' => 0,
+                    'otp_provided' => 0,
+                    'can_create_root_folder' => empty($post_root_level) === true ? 0 : $post_root_level,
+                    'mfa_enabled' => empty($mfa_enabled) === true ? 0 : $mfa_enabled,
+                    'created_at' => time(),
+                    'personal_items_migrated' => 1,
+                    'encryption_version' => 3,
+                    'phpseclibv3_migration_completed' => 1,
+                );
+
+                // Add transparent recovery fields if available
+                if (isset($userKeys['user_seed'])) {
+                    $userData['user_derivation_seed'] = $userKeys['user_seed'];
+                    $userData['private_key_backup'] = $userKeys['private_key_backup'];
+                    $userData['key_integrity_hash'] = $userKeys['key_integrity_hash'];
+                    $userData['last_pw_change'] = time();
+                }
+
+                // Insert user in DB
                 DB::insert(
                     prefixTable('users'),
-                    array(
-                        'login' => $login,
-                        'name' => $name,
-                        'lastname' => $lastname,
-                        'pw' => $hashedPassword,
-                        'email' => $email,
-                        'auth_type' => 'local',
-                        'admin' => empty($is_admin) === true ? 0 : $is_admin,
-                        'can_manage_all_users' => empty($is_hr) === true ? 0 : $is_hr,
-                        'gestionnaire' => empty($is_manager) === true ? 0 : $is_manager,
-                        'read_only' => empty($is_read_only) === true ? 0 : $is_read_only,
-                        'personal_folder' => empty($has_personal_folder) === true ? 0 : $has_personal_folder,
-                        'user_language' => $SETTINGS['default_language'],
-                        'isAdministratedByRole' => $is_administrated_by,
-                        'encrypted_psk' => '',
-                        'last_pw_change' => time(),
-                        'public_key' => $userKeys['public_key'],
-                        'private_key' => $userKeys['private_key'],
-                        'special' => 'auth-pwd-change',
-                        'is_ready_for_usage' => 0,
-                        'otp_provided' => 0,
-                        'can_create_root_folder' => empty($post_root_level) === true ? 0 : $post_root_level,
-                        'mfa_enabled' => empty($mfa_enabled) === true ? 0 : $mfa_enabled,
-                        'created_at' => time(),
-                        'personal_items_migrated' => 1,
-                    )
+                    $userData
                 );
                 $new_user_id = DB::insertId();
 
@@ -2412,6 +2425,8 @@ if (null !== $post_type) {
                 'created_at' => time(),
                 'personal_items_migrated' => 1,
                 'otp_provided' => 1,
+                'encryption_version' => 3,
+                'phpseclibv3_migration_completed' => 1,
             );
 
             // Add transparent recovery fields if available

--- a/vendor/teampassclasses/cryptomanager/src/CryptoManager.php
+++ b/vendor/teampassclasses/cryptomanager/src/CryptoManager.php
@@ -269,6 +269,11 @@ class CryptoManager
 
                 $decrypted = $cipher->decrypt($data);
 
+                // openssl_decrypt() can return false on failure
+                if ($decrypted === false) {
+                    throw new Exception('AES decryption failed (openssl returned false)');
+                }
+
                 // Success with v3
                 return $decrypted;
             } catch (Exception $e) {
@@ -295,6 +300,11 @@ class CryptoManager
 
                         $cipher->setPassword($password);
                         $decrypted = $cipher->decrypt($data);
+
+                        // openssl_decrypt() can return false on failure
+                        if ($decrypted === false) {
+                            throw new Exception('AES v1 decryption failed (openssl returned false)');
+                        }
 
                         // Success with v1 fallback
                         return $decrypted;
@@ -330,7 +340,14 @@ class CryptoManager
                 }
 
                 $cipher->setPassword($password);
-                return $cipher->decrypt($data);
+                $decrypted = $cipher->decrypt($data);
+
+                // openssl_decrypt() can return false on failure
+                if ($decrypted === false) {
+                    throw new Exception('AES v1-only decryption failed (openssl returned false)');
+                }
+
+                return $decrypted;
             } catch (Exception $e) {
                 throw new Exception('Failed to decrypt with AES: ' . $e->getMessage());
             }


### PR DESCRIPTION
- Removed deleted users from admin page statistics                                                                    
- Ensured that new user has correct phpseclib version                                                                 
- Fix #5046:                                                
  - Fixed user key encryption using SHA-256 to match declared encryption_version 3                                      
  - Fixed aesDecrypt() returning false instead of throwing exception, preventing SHA-256/SHA-1 fallback                 
  - Fixed attemptTransparentRecovery() not returning private_key_clear on success                                        
  - Fixed AD users first login: private key is now re-encrypted with AD password via transparent recovery               
  - Fixed null private key passed to decryptUserObjectKey() during login    