### PR TITLE
Fix console error when pressing Enter in Users search

### DIFF
--- a/pages/users.js.php
+++ b/pages/users.js.php
@@ -2846,8 +2846,19 @@ if ($checkUserAccess->checkSession() === false || $checkUserAccess->userAccessPa
         }
         if (e.keyCode === 13 && actionOnGoing === false) {
             // Enter key
-            actionOnGoing = true;
-            saveChange(item, currentText, $(':focus'), field);
+            // Only trigger save when an inline editable field is focused (avoid DataTables search input, etc.)
+            var focusedElement = $(':focus');
+
+            if (
+                focusedElement.length === 1
+                && focusedElement.hasClass('save-me') === true
+                && item !== ''
+                && typeof item.data === 'function'
+                && field !== ''
+            ) {
+                actionOnGoing = true;
+                saveChange(item, currentText, focusedElement, field);
+            }
         }
     });
 


### PR DESCRIPTION
<h3>Context</h3>
<p>
The Users administration page relies on a global <code>$(document).keyup(...)</code> handler to support
inline editing: when an inline editor is open, pressing <kbd>Enter</kbd> triggers <code>saveChange(...)</code>.

Adapted for version 3.1.6.4
</p>

<h3>Issue</h3>
<p>
The same global keyup handler also fires when the focus is inside the DataTables search input.
In that case, no inline editing session is active, so the global variable <code>item</code> may still be
an empty string (<code>''</code>) instead of a jQuery object.
</p>
<p>
When <kbd>Enter</kbd> is pressed in the search box, the handler calls <code>saveChange(item, ...)</code>,
and <code>saveChange()</code> tries to execute <code>item.data(...)</code>. Since <code>item</code> is a string,
it throws:
</p>
<pre><code>Uncaught TypeError: item.data is not a function</code></pre>

<h3>Fix</h3>
<p>
We restrict the <kbd>Enter</kbd> behavior to the intended scope: only run the save logic when the
currently focused element is an inline editor input (class <code>.save-me</code>) and when the edit
context is valid.
</p>

<ul>
  <li>Capture the focused element once: <code>var focusedElement = $(':focus');</code></li>
  <li>Require <code>focusedElement</code> to be the inline editor input via <code>.hasClass('save-me')</code></li>
  <li>Ensure we have a valid edit context:
    <ul>
      <li><code>item</code> is not empty</li>
      <li><code>item</code> exposes jQuery <code>.data()</code> (guard: <code>typeof item.data === 'function'</code>)</li>
      <li><code>field</code> is not empty</li>
    </ul>
  </li>
  <li>If any condition is not met, pressing <kbd>Enter</kbd> does nothing (so DataTables search remains unaffected)</li>
</ul>

<h3>Why this is safe</h3>
<p>
This change does not alter the inline editing workflow: when an inline editor is active, the focused
element is <code>.save-me</code> and the save continues to run exactly as before. It only prevents the save
logic from being executed in unrelated inputs (notably the DataTables search field), removing the JS
exception while keeping the live search behavior unchanged.
</p>

<h3>How to test</h3>
<ul>
  <li>Administration → Users: focus the search box, type a query and press <kbd>Enter</kbd> → no console error.</li>
  <li>Start an inline edit, change the value and press <kbd>Enter</kbd> → value is saved as before.</li>
</ul>
