### PR TITLE
Fix jQuery event handler registration in password strength meter

### DIFF
--- a/includes/core/load.js.php
+++ b/includes/core/load.js.php
@@ -999,15 +999,17 @@ if (
             }
         ]
     });
-    $("#profile-password").bind({
-        "score.simplePassMeter": function(jQEvent, score) {
+    $("#profile-password")
+        .on("score.simplePassMeter", function (jQEvent, score) {
             $("#profile-password-complex").val(score);
-        }
-    }).change({
-        "score.simplePassMeter": function(jQEvent, score) {
-            $("#profile-password-complex").val(score);
-        }
-    });
+            $(this).data("tpSimplePassMeterScore", score);
+        })
+        .on("change", function () {
+            var lastScore = $(this).data("tpSimplePassMeterScore");
+            if (typeof lastScore !== "undefined") {
+                $("#profile-password-complex").val(lastScore);
+            }
+        });
 
     // Hide sidebar footer icons when reducing sidebar
     $('a[data-widget="pushmenu"]').click(function(event) {


### PR DESCRIPTION
<h2>Summary</h2>
<p>
When a user is prompted to change an expired password (e.g. after an admin-triggered password reset / expiration flow),
typing in the new password field could trigger a browser console error:
</p>
<pre><code>Uncaught TypeError: ... o.handler).apply is not a function</code></pre>
<p>
This error originated from the password strength meter event wiring and could disrupt the password change UX.
</p>

<h2>Root cause</h2>
<p>
In <code>includes/core/load.js.php</code>, the <code>#profile-password</code> field was correctly listening to
<code>score.simplePassMeter</code>, but the code was also calling <code>.change({ ... })</code> with an object
instead of a function. jQuery expects a function handler for <code>change</code>; passing an object results in
jQuery trying to execute a non-function handler at runtime, leading to the <code>.apply is not a function</code> exception.
</p>

<h2>Fix</h2>
<ul>
  <li>Replace the invalid <code>.change({ ... })</code> handler registration with a proper function-based event binding.</li>
  <li>Keep the password complexity score synchronized with <code>#profile-password-complex</code> without registering invalid handlers.</li>
  <li>No functional change to password policy/validation logic; this is a frontend-only fix.</li>
</ul>

<h2>Files changed</h2>
<ul>
  <li><code>includes/core/load.js.php</code></li>
</ul>

<h2>Testing</h2>
<ul>
  <li>Reset surebackup and reproduced the “password expired” forced change-password page.</li>
  <li>Typed in the new password field and confirmed the console error no longer appears.</li>
  <li>Verified the strength meter still updates the complexity score and the password change flow completes successfully.</li>
</ul>

<h2>Notes</h2>
<ul>
  <li>No database changes.</li>
  <li>No language string changes.</li>
</ul>
