### PR TITLE
Fix: Bug report modal shows escaped content and clipboard copy fails for textarea

### DIFF
--- a/sources/main.queries.php
+++ b/sources/main.queries.php
@@ -1675,6 +1675,7 @@ function generateBugReport(
 {
     $config_exclude_vars = array(
         'bck_script_passkey',
+        'browser_extension_key',
         'email_smtp_server',
         'email_auth_username',
         'email_auth_pwd',
@@ -1740,6 +1741,12 @@ function generateBugReport(
     // Get error
     $err = error_get_last();
 
+    // Prepare last PHP error line (avoid undefined indexes)
+    $php_last_error = $lang->get('none');
+    if (is_array($err) === true && isset($err['message'], $err['file'], $err['line']) === true) {
+        $php_last_error = $err['message'] . ' - ' . $err['file'] . ' (' . $err['line'] . ')';
+    }
+
     // Get 10 latest errors in Teampass
     $teampass_errors = '';
     $rows = DB::query(
@@ -1751,11 +1758,7 @@ function generateBugReport(
     );
     if (DB::count() > 0) {
         foreach ($rows as $record) {
-            if (empty($teampass_errors) === true) {
-                $teampass_errors = ' * ' . date($SETTINGS['date_format'] . ' ' . $SETTINGS['time_format'], (int) $record['error_date']) . ' - ' . $record['label'];
-            } else {
-                $teampass_errors .= ' * ' . date($SETTINGS['date_format'] . ' ' . $SETTINGS['time_format'], (int) $record['error_date']) . ' - ' . $record['label'];
-            }
+            $teampass_errors .= ' * ' . date($SETTINGS['date_format'] . ' ' . $SETTINGS['time_format'], (int) $record['error_date']) . ' - ' . $record['label'] . "\n";
         }
     }
 
@@ -1808,7 +1811,7 @@ Tell us what happens instead
 
 #### Web server error log
 ```
-' . $err['message'] . ' - ' . $err['file'] . ' (' . $err['line'] . ')
+' . $php_last_error . '
 ```
 
 #### Teampass 10 last system errors
@@ -1824,6 +1827,7 @@ Insert the log here and especially the answer of the query that failed.
 
     return prepareExchangedData(
         array(
+            'text' => $txt,
             'html' => $txt,
             'error' => '',
         ),


### PR DESCRIPTION
<h3>Summary</h3>
<p>
This PR fixes the built-in GitHub issue report generator (bug report modal) to ensure the generated report is displayed
as plain text (not HTML), copied correctly to the clipboard, and that sensitive configuration values are properly redacted.
</p>

<h3>Problems addressed</h3>
<ul>
  <li>
    The bug report content was injected into a <code>&lt;textarea&gt;</code> using <code>.html()</code>,
    causing HTML entities to appear (e.g. <code>=&amp;gt;</code>) and placeholders like <code>&lt;removed&gt;</code>
    to be interpreted as HTML (sometimes disappearing).
  </li>
  <li>
    The “Copy to clipboard” action used <code>textContent</code> instead of <code>value</code> for textareas,
    resulting in incomplete/incorrect copied content.
  </li>
  <li>
    A sensitive configuration key (<code>browser_extension_key</code>) could be included in the report and is now redacted.
  </li>
</ul>

<h3>Changes</h3>
<ul>
  <li>
    <strong>Front-end</strong> (<code>includes/core/load.js.php</code>)
    <ul>
      <li>Write bug report output into the textarea using <code>.val()</code> instead of <code>.html()</code>.</li>
      <li>Decode HTML entities safely before display to avoid escaped sequences in the report.</li>
      <li>Improve clipboard copy logic to correctly copy textarea/input <code>value</code> (with fallbacks).</li>
      <li>Prevent multiple click handlers from accumulating on the “Open in GitHub” button.</li>
    </ul>
  </li>
  <li>
    <strong>Back-end</strong> (<code>sources/main.queries.php</code>)
    <ul>
      <li>Add <code>browser_extension_key</code> to the list of redacted configuration variables in the generated report.</li>
      <li>Minor formatting adjustments to keep the report readable when pasted into GitHub.</li>
    </ul>
  </li>
</ul>

<h3>How to test</h3>
<ol>
  <li>Login as an admin and click the bug icon (issue report).</li>
  <li>Confirm the report is displayed as plain text:
    <ul>
      <li>No escaped entities such as <code>=&amp;gt;</code>.</li>
      <li>Redacted placeholders like <code>&lt;removed&gt;</code> are visible and not interpreted as HTML.</li>
    </ul>
  </li>
  <li>Click “Copy to clipboard” and paste into a text editor; the full report should be copied correctly.</li>
  <li>Click “Open issue report in Github”; ensure it opens once (no duplicate event handlers).</li>
  <li>Verify sensitive values (including <code>browser_extension_key</code>) are not exposed in the generated content.</li>
</ol>

<h3>Notes</h3>
<ul>
  <li>This change is intentionally non-intrusive: it does not alter the content structure of the report beyond making it reliably plain-text and safe to share.</li>
</ul>
