### PR TITLE
Fix: WebSocket URL generation + release item edit lock after save (Apache doc tweak)

### DIFF
--- a/docs/install/websocket.md
+++ b/docs/install/websocket.md
@@ -61,7 +61,7 @@ Add the following to your VirtualHost block (typically in your SSL vhost):
     RewriteRule ^/ws/?(.*)$ ws://127.0.0.1:8080/$1 [P,L]
 
     ProxyPass /ws/ ws://127.0.0.1:8080/
-    ProxyPassReverse /ws ws://127.0.0.1:8080/
+    ProxyPassReverse /ws/ ws://127.0.0.1:8080/
 </VirtualHost>
 ```
 

--- a/docs/install/websocket.md
+++ b/docs/install/websocket.md
@@ -58,9 +58,9 @@ Add the following to your VirtualHost block (typically in your SSL vhost):
     RewriteEngine On
     RewriteCond %{HTTP:Upgrade} websocket [NC]
     RewriteCond %{HTTP:Connection} upgrade [NC]
-    RewriteRule ^/ws$ ws://127.0.0.1:8080/ [P,L]
+    RewriteRule ^/ws/?(.*)$ ws://127.0.0.1:8080/$1 [P,L]
 
-    ProxyPass /ws ws://127.0.0.1:8080/
+    ProxyPass /ws/ ws://127.0.0.1:8080/
     ProxyPassReverse /ws ws://127.0.0.1:8080/
 </VirtualHost>
 ```

--- a/sources/items.queries.php
+++ b/sources/items.queries.php
@@ -2163,27 +2163,22 @@ switch ($inputData['type']) {
                 }
             }
 
-            // Remove the edition lock if no encryption steps are needed
-            if ($encryptionTaskIsRequested === false) {
-                if (defined('LOG_TO_SERVER') && LOG_TO_SERVER === true) {
-                    error_log('Remove the edition lock if no encryption steps are needed');
-                }
-                DB::delete(
-                    prefixTable('items_edition'),
-                    'item_id = %i AND user_id = %i',
-                    $inputData['itemId'],
-                    $session->get('user-id')
-                );
+            // Remove the edition lock after a successful save
+            DB::delete(
+                prefixTable('items_edition'),
+                'item_id = %i AND user_id = %i',
+                $inputData['itemId'],
+                $session->get('user-id')
+            );
 
-                // Notify other users via WebSocket that this item is now free
-                emitEditionLockEvent(
-                    'stopped',
-                    (int) $inputData['itemId'],
-                    (int) $inputData['folderId'],
-                    $session->get('user-login') ?? '',
-                    (int) $session->get('user-id')
-                );
-            }
+            // Notify other users via WebSocket that this item is now free
+            emitEditionLockEvent(
+                'stopped',
+                (int) $inputData['itemId'],
+                (int) $inputData['folderId'],
+                $session->get('user-login') ?? '',
+                (int) $session->get('user-id')
+            );
 
             // Notifiy changes to the users
             notifyChangesToSubscribers($inputData['itemId'], $inputData['label'], $arrayOfChanges, $SETTINGS);


### PR DESCRIPTION
This PR fixes two issues encountered while testing the new optional WebSocket server behind an Apache reverse proxy (HTTPS), and proposes a small documentation improvement for Apache users.

## Context

Test environment: a “classic” setup with Apache SSL vhost on an HTTPS FQDN (anonymized), and the WebSocket server listening locally on `127.0.0.1:8080` (as recommended). Apache proxies `/ws` to the local WS server.

During testing, WebSocket connections were blocked by the browser (“Mixed Content”) and item edit locks were not released after saving an item.

---

## 1) WebSocket: Mixed Content / wrong endpoint (HTTP vs HTTPS)

### Symptoms

Browser console showed attempts like:

* `ws://<your-teampass-fqdn>:443/?token=...`
  This is blocked on HTTPS pages (Mixed Content). Also, the path used was `/` instead of `/ws`.

### Root cause

`includes/js/teampass-websocket-init.js` hard-coded a fallback:

* `window.TeamPassWebSocketUrl || 'ws://127.0.0.1:8080'`

This bypasses the default client logic that correctly derives `ws/wss` from `window.location.protocol` and uses `/ws`. When `TeamPassWebSocketUrl` is injected from config, the init script forces `ws://` and may omit `/ws`.

### Fix

Harden and normalize the configured URL in `includes/js/teampass-websocket-init.js`:

* If the UI is served over HTTPS, force `wss://`
* Ensure the reverse-proxy route is `/ws` (default to `/ws` if path is missing or `/`)
* Accept flexible input formats (full URL, host:port, /ws, etc.)
* Fall back to `wss://<host>/ws` (or `ws://<host>/ws`) when config is empty/invalid

This makes the feature work consistently across environments:

* HTTPS sites → `wss://<fqdn>/ws`
* HTTP sites → `ws://<fqdn>/ws`
  while still allowing the backend WS server to remain local and unencrypted behind the reverse proxy.

---

## 2) Items: edit lock not released after saving

### Symptoms

When editing an item and saving, the item remained “in edition” (locked) and was not released immediately.

### Root cause

In `sources/items.queries.php`, the edition lock is removed only when:

* `encryptionTaskIsRequested === false`

If encryption/background steps are requested, the lock is not removed at the end of the save, leaving the item in an “editing” state until a later timeout/heartbeat.

### Fix

Always release the edition lock after a successful save, regardless of encryption task creation:

* Delete from `items_edition` for (item_id, user_id)
* Emit the “stopped” edition lock event

Background crypto tasks are already tracked via `background_tasks`, so keeping the UI edit lock is unnecessary and results in stale locks.

---

## 3) Documentation tweak (Apache)

While debugging, it helped to make Apache rules more tolerant to `/ws` vs `/ws/`. Suggest updating docs to use the slash-tolerant pattern and explicit `/ws/` ProxyPass, e.g.:

* `RewriteRule ^/ws/?(.*)$ ws://127.0.0.1:8080/$1 [P,L]`
* `ProxyPass /ws/ ws://127.0.0.1:8080/`

This avoids edge cases where the client uses `/ws` vs `/ws/`.

---

## Files changed

* `includes/js/teampass-websocket-init.js`
* `sources/items.queries.php`
  (+ docs suggestion for `docs/install/websocket.md` for Apache)

---

## How to test

1. WebSocket (HTTPS)

* Configure WS settings with host `<your-teampass-fqdn>` and port `443`
* Ensure Apache proxies `/ws` to `127.0.0.1:8080`
* Load admin pages over HTTPS and confirm the browser connects to `wss://<fqdn>/ws?...` with no Mixed Content errors

2. Edit lock release

* Open the same item in two sessions/browsers
* Start editing in session A, save
* Confirm session B sees the item lock released immediately (no stale “in edition” state)