### PR TITLE
Fix users admin panels visibility/authorization and notify admins on account lock

### DIFF
--- a/includes/language/english.php
+++ b/includes/language/english.php
@@ -2050,4 +2050,6 @@ return array(
     'settings_category_networks_title' => 'Networks',
     'settings_category_networks_goal' => 'IP filtering and access control',
     'settings_category_networks_under_construction' => 'Under construction',
-);
+    'email_subject_on_user_lock' => '[TeamPass] A user account has been locked',
+    'email_body_on_user_lock' => 'Hello,<br><br>This is a generated email from TeamPass.<br><br>User account <b>#tp_user#</b> has been locked by the anti brute force protection on #tp_date# at #tp_time#.<br><br>Details:<ul><li>Name: #tp_name#</li><li>Email: #tp_email#</li><li>Source IP: #tp_ip#</li><li>Automatic unlock at: #tp_unlock_at#</li></ul><br>Regards.',
+    );

--- a/includes/language/french.php
+++ b/includes/language/french.php
@@ -2056,5 +2056,6 @@ return array(
     'settings_redis_prefix_tip' => 'Préfixe pour les clés de session stockées dans Redis (par défaut : teampass_sess_). Utile lorsque plusieurs applications partagent la même instance Redis.',
     'settings_realtime_title' => 'Temps-réel',
     'settings_realtime_title_goal' => 'Configure les fonctionnalités de temps réel.',
-
+    'email_subject_on_user_lock' => '[TeamPass] Un compte utilisateur a été bloqué',
+    'email_body_on_user_lock' => 'Bonjour,<br><br>Ceci est un email généré par TeamPass.<br><br>Le compte utilisateur <b>#tp_user#</b> a été bloqué par la protection anti brute force le #tp_date# à #tp_time#.<br><br>Détails :<ul><li>Nom : #tp_name#</li><li>Email : #tp_email#</li><li>Adresse IP source : #tp_ip#</li><li>Déblocage automatique prévu : #tp_unlock_at#</li></ul><br>Cordialement.',
 );

--- a/pages/users.php
+++ b/pages/users.php
@@ -167,7 +167,15 @@ function count_never_connected_active_users() : int
 }
 
 
-$deleted_users_count = count_deleted_users();
+$canAccessInactiveAndDeletedUsers = (int) $session->get('user-admin') === 1;
+$canUseLdapSync = $canAccessInactiveAndDeletedUsers === true
+    && isset($SETTINGS['ldap_mode']) === true
+    && (int) $SETTINGS['ldap_mode'] === 1;
+$canUseOauth2Sync = $canAccessInactiveAndDeletedUsers === true
+    && isset($SETTINGS['oauth2_enabled']) === true
+    && (int) $SETTINGS['oauth2_enabled'] === 1;
+
+$deleted_users_count = $canAccessInactiveAndDeletedUsers === true ? count_deleted_users() : 0;
 
 // Prepare the CSS class for blinking and the badge for the count.
 $blink_class = '';
@@ -182,7 +190,7 @@ if ($deleted_users_count > 0) {
 }
 
 
-$inactive_never_connected_count = count_never_connected_active_users();
+$inactive_never_connected_count = $canAccessInactiveAndDeletedUsers === true ? count_never_connected_active_users() : 0;
 $inactive_blink_class = $inactive_never_connected_count > 0 ? 'blink_me' : '';
 ?>
 
@@ -215,21 +223,24 @@ $inactive_blink_class = $inactive_never_connected_count > 0 ? 'blink_me' : '';
                         <button type="button" class="btn btn-primary btn-sm tp-action mr-2" data-action="refresh">
                             <i class="fa-solid fa-sync-alt mr-2"></i><?php echo $lang->get('refresh'); ?>
                         </button><?php
-                        if (isset($SETTINGS['ldap_mode']) === true && (int) $SETTINGS['ldap_mode'] === 1 && (int) $session->get('user-admin') === 1) {
-                        '<button type="button" class="btn btn-primary btn-sm tp-action mr-2" data-action="ldap-sync">
-                            <i class="fa-solid fa-address-card mr-2"></i>' . $lang->get('ldap_synchronization') . '
-                        </button>
-                        
-                        <button type="button" class="btn btn-primary btn-sm tp-action mr-2" data-action="oauth2-sync">
-                            <i class="fa-solid fa-plug mr-2"></i>' . $lang->get('oauth2_synchronization') . '
-                        </button>
-                        <button type="button" class="btn btn-primary btn-sm tp-action mr-2 <?php echo $inactive_blink_class; ?>" data-action="inactive-users">
-                            <i class="fa-solid fa-user-clock mr-2"></i>' . $lang->get('inactive_users') . '
-                        </button>
+                        if ($canUseLdapSync === true) {
+                            echo '<button type="button" class="btn btn-primary btn-sm tp-action mr-2" data-action="ldap-sync">
+                                <i class="fa-solid fa-address-card mr-2"></i>' . $lang->get('ldap_synchronization') . '
+                            </button>';
+                        }
+                        if ($canUseOauth2Sync === true) {
+                            echo '<button type="button" class="btn btn-primary btn-sm tp-action mr-2" data-action="oauth2-sync">
+                                <i class="fa-solid fa-plug mr-2"></i>' . $lang->get('oauth2_synchronization') . '
+                            </button>';
+                        }
+                        if ($canAccessInactiveAndDeletedUsers === true) {
+                            echo '<button type="button" class="btn btn-primary btn-sm tp-action mr-2 ' . $inactive_blink_class . '" data-action="inactive-users">
+                                <i class="fa-solid fa-user-clock mr-2"></i>' . $lang->get('inactive_users') . '
+                            </button>';
 
-                        <button type="button" class="btn btn-primary btn-sm tp-action mr-2 ' . $blink_class . '" data-action="deleted-users">
-                            <i class="fa-solid fa-user-xmark mr-2"></i>' . $lang->get('deleted_users') . $count_badge_html . '
-                        </button>';
+                            echo '<button type="button" class="btn btn-primary btn-sm tp-action mr-2 ' . $blink_class . '" data-action="deleted-users">
+                                <i class="fa-solid fa-user-xmark mr-2"></i>' . $lang->get('deleted_users') . $count_badge_html . '
+                            </button>';
                         }
                         ?>
                     </h3>
@@ -672,6 +683,7 @@ $inactive_blink_class = $inactive_never_connected_count > 0 ? 'blink_me' : '';
 
     
 
+    <?php if ($canAccessInactiveAndDeletedUsers === true) { ?>
     <div class="row hidden extra-form user-content with-header-menu" id="inactive-users-section" data-content="inactive-users">
         <div class="card-header">
             <h5><?php echo $lang->get('inactive_users'); ?></h5>
@@ -768,6 +780,8 @@ $inactive_blink_class = $inactive_never_connected_count > 0 ? 'blink_me' : '';
             </div>
         </div>
     </div>
+
+    <?php } ?>
 
     <!-- Shared confirmation modal for user actions (inactive / deleted) -->
     <div class="modal fade" id="users-action-modal" tabindex="-1" role="dialog" aria-hidden="true">

--- a/sources/identify.php
+++ b/sources/identify.php
@@ -3438,32 +3438,121 @@ function handleFailedAttempts($source, $value, $limit) {
     if ($unlock_at !== null && $source === 'login') {
         $configManager = new ConfigManager();
         $SETTINGS = $configManager->getAllSettings();
-        $lang = new Language($SETTINGS['default_language']);
+        $lang = new Language($SETTINGS['default_language'] ?? 'english');
 
-        // Get user email
+        // Get user details
         $userInfos = DB::queryFirstRow(
             'SELECT email, name
-             FROM '.prefixTable('users').'
+             FROM ' . prefixTable('users') . '
              WHERE login = %s',
-             $value
+            $value
         );
 
-        // No valid email address for user
-        if (!$userInfos || !filter_var($userInfos['email'], FILTER_VALIDATE_EMAIL))
-            return;
+        notifyAdminsAboutLockedAccount(
+            $SETTINGS,
+            $lang,
+            $value,
+            is_array($userInfos) === true ? $userInfos : [],
+            getClientIpServer(),
+            $unlock_at
+        );
 
-        $unlock_url = $SETTINGS['cpassman_url'].'/self-unlock.php?login='.$value.'&otp='.$unlock_code;
+        if (is_array($userInfos) === false || !filter_var($userInfos['email'] ?? null, FILTER_VALIDATE_EMAIL)) {
+            return;
+        }
+
+        $unlock_url = $SETTINGS['cpassman_url'] . '/self-unlock.php?login=' . $value . '&otp=' . $unlock_code;
 
         sendMailToUser(
             $userInfos['email'],
             $lang->get('bruteforce_reset_mail_body'),
             $lang->get('bruteforce_reset_mail_subject'),
             [
-                '#name#' => $userInfos['name'],
+                '#name#' => (string) ($userInfos['name'] ?? ''),
                 '#reset_url#' => $unlock_url,
                 '#unlock_at#' => $unlock_at,
             ],
             true
+        );
+    }
+}
+
+/**
+ * Notify all administrators when a user account is locked by anti brute force.
+ *
+ * @param array<string, mixed> $SETTINGS
+ * @param array<string, mixed> $userInfos
+ */
+function notifyAdminsAboutLockedAccount(
+    array $SETTINGS,
+    Language $lang,
+    string $login,
+    array $userInfos,
+    string $sourceIp,
+    string $unlockAt
+): void {
+    $adminUsers = DB::query(
+        'SELECT email, name
+         FROM ' . prefixTable('users') . '
+         WHERE admin = %i
+            AND disabled = %i
+            AND deleted_at IS NULL
+            AND email IS NOT NULL
+            AND email != %s',
+        1,
+        0,
+        ''
+    );
+
+    if (empty($adminUsers) === true) {
+        return;
+    }
+
+    $userName = trim((string) ($userInfos['name'] ?? ''));
+    $userEmail = trim((string) ($userInfos['email'] ?? ''));
+    $userDisplayName = $userName === '' ? $lang->get('undefined') : $userName;
+    $userDisplayEmail = $userEmail === '' ? $lang->get('no_email_set') : $userEmail;
+
+    $unlockAtTimestamp = strtotime($unlockAt);
+    $formattedUnlockAt = $unlockAtTimestamp === false
+        ? $unlockAt
+        : date(
+            ($SETTINGS['date_format'] ?? 'Y-m-d') . ' ' . ($SETTINGS['time_format'] ?? 'H:i:s'),
+            $unlockAtTimestamp
+        );
+
+    $mailBody = str_replace(
+        [
+            '#tp_user#',
+            '#tp_name#',
+            '#tp_email#',
+            '#tp_ip#',
+            '#tp_date#',
+            '#tp_time#',
+            '#tp_unlock_at#',
+        ],
+        [
+            $login,
+            $userDisplayName,
+            $userDisplayEmail,
+            $sourceIp,
+            date($SETTINGS['date_format'] ?? 'Y-m-d', (int) time()),
+            date($SETTINGS['time_format'] ?? 'H:i:s', (int) time()),
+            $formattedUnlockAt,
+        ],
+        $lang->get('email_body_on_user_lock')
+    );
+
+    foreach ($adminUsers as $adminUser) {
+        if (filter_var($adminUser['email'] ?? null, FILTER_VALIDATE_EMAIL) === false) {
+            continue;
+        }
+
+        prepareSendingEmail(
+            $lang->get('email_subject_on_user_lock'),
+            $mailBody,
+            (string) $adminUser['email'],
+            empty($adminUser['name']) === false ? (string) $adminUser['name'] : $lang->get('administrator')
         );
     }
 }

--- a/sources/users.queries.php
+++ b/sources/users.queries.php
@@ -3330,6 +3330,17 @@ if (null !== $post_type) {
                 break;
             }
 
+            if (canAccessInactiveAndDeletedUsersPanels() === false) {
+                echo prepareExchangedData(
+                    array(
+                        'error' => true,
+                        'message' => $lang->get('error_not_allowed_to'),
+                    ),
+                    'encode'
+                );
+                break;
+            }
+
             $result = listDeletedUsers();
 
             echo prepareExchangedData(
@@ -3356,6 +3367,17 @@ if (null !== $post_type) {
                 break;
             }
 
+            if (canAccessInactiveAndDeletedUsersPanels() === false) {
+                echo prepareExchangedData(
+                    array(
+                        'error' => true,
+                        'message' => $lang->get('error_not_allowed_to'),
+                    ),
+                    'encode'
+                );
+                break;
+            }
+
             echo prepareExchangedData(
                 array(
                     'error' => false,
@@ -3373,6 +3395,17 @@ if (null !== $post_type) {
                     array(
                         'error' => true,
                         'message' => $lang->get('key_is_not_correct'),
+                    ),
+                    'encode'
+                );
+                break;
+            }
+
+            if (canAccessInactiveAndDeletedUsersPanels() === false) {
+                echo prepareExchangedData(
+                    array(
+                        'error' => true,
+                        'message' => $lang->get('error_not_allowed_to'),
                     ),
                     'encode'
                 );
@@ -3414,11 +3447,7 @@ if (null !== $post_type) {
                 break;
             }
 
-            // Same rights as manage_user_disable_status
-            if (
-                (int) $session->get('user-admin') !== 1
-                && (int) $session->get('user-can_manage_all_users') !== 1
-            ) {
+            if (canAccessInactiveAndDeletedUsersPanels() === false) {
                 echo prepareExchangedData(
                     array(
                         'error' => true,
@@ -3473,6 +3502,17 @@ if (null !== $post_type) {
                 break;
             }
 
+            if (canAccessInactiveAndDeletedUsersPanels() === false) {
+                echo prepareExchangedData(
+                    array(
+                        'error' => true,
+                        'message' => $lang->get('error_not_allowed_to'),
+                    ),
+                    'encode'
+                );
+                break;
+            }
+
             $userIds = isset($dataReceived['user_ids']) && is_array($dataReceived['user_ids'])
                 ? array_map('intval', $dataReceived['user_ids'])
                 : array();
@@ -3508,8 +3548,7 @@ if (null !== $post_type) {
                 break;
             }
 
-            // Check if user is admin
-            if ($session->get('user-admin') !== 1 && $session->get('user-can_manage_all_users') !== 1) {
+            if (canAccessInactiveAndDeletedUsersPanels() === false) {
                 echo prepareExchangedData(
                     [
                         'error' => true,
@@ -3567,8 +3606,7 @@ break;
                 break;
             }
 
-            // Check if user is admin
-            if ($session->get('user-admin') !== 1 && $session->get('user-can_manage_all_users') !== 1) {
+            if (canAccessInactiveAndDeletedUsersPanels() === false) {
                 echo prepareExchangedData(
                     [
                         'error' => true,
@@ -3632,8 +3670,7 @@ break;
                 break;
             }
 
-            // Check if user is admin
-            if ($session->get('user-admin') !== 1 && $session->get('user-can_manage_all_users') !== 1) {
+            if (canAccessInactiveAndDeletedUsersPanels() === false) {
                 echo prepareExchangedData(
                     [
                         'error' => true,
@@ -3741,8 +3778,7 @@ break;
                 break;
             }
 
-            // Check if user is admin
-            if ($session->get('user-admin') !== 1 && $session->get('user-can_manage_all_users') !== 1) {
+            if (canAccessInactiveAndDeletedUsersPanels() === false) {
                 echo prepareExchangedData(
                     [
                         'error' => true,
@@ -3915,6 +3951,13 @@ break;
             echo 'Non';
         }
     }
+}
+
+function canAccessInactiveAndDeletedUsersPanels(): bool
+{
+    $session = SessionManager::getSession();
+
+    return (int) $session->get('user-admin') === 1;
 }
 
 /**


### PR DESCRIPTION
<h2>Summary</h2>
<p>
This PR includes two security and administration related fixes for TeamPass 3.1.7:
</p>
<ul>
  <li>fixes the visibility and authorization regression on the admin users page for <em>Inactive users</em> and <em>Deleted users</em> panels,</li>
  <li>adds an automatic email notification to administrators when a user account is locked by the anti brute force protection.</li>
</ul>

<h2>1. Users page: restore admin access and enforce authorization</h2>

<h3>Problem</h3>
<p>
A regression introduced in 3.1.7.0 changed the rendering logic on the users administration page.
As a result:
</p>
<ul>
  <li>TeamPass Managers no longer saw the <em>Inactive users</em> and <em>Deleted users</em> buttons, which is correct,</li>
  <li>but administrators also lost access to these buttons, which is not expected.</li>
</ul>

<p>
In addition, the related backend actions were not consistently protected as admin-only operations.
</p>

<h3>Root cause</h3>
<ul>
  <li>
    In <code>users.php</code>, the button rendering logic was modified in a way that prevented the related HTML from being output correctly.
  </li>
  <li>
    The visibility of the <em>Inactive users</em> and <em>Deleted users</em> actions became coupled to unrelated display conditions.
  </li>
  <li>
    In <code>users.queries.php</code>, the related AJAX endpoints were not strictly restricted to administrators.
  </li>
</ul>

<h3>What this fix changes</h3>
<ul>
  <li>Restores the <em>Inactive users</em> and <em>Deleted users</em> buttons for administrators.</li>
  <li>Ensures TeamPass Managers do not see these buttons.</li>
  <li>Ensures the related sections are rendered only for administrators.</li>
  <li>Enforces backend authorization checks on the related AJAX actions to prevent direct unauthorized access.</li>
  <li>Keeps LDAP and OAuth2 synchronization buttons controlled by their own dedicated conditions.</li>
</ul>

<h3>Files updated</h3>
<ul>
  <li><code>users.php</code></li>
  <li><code>users.queries.php</code></li>
</ul>

<h2>2. Anti brute force: notify administrators when an account is locked</h2>

<h3>Problem</h3>
<p>
When a user account is locked by TeamPass anti brute force protection, the affected user can already receive a self-unlock email.
However, administrators are not informed of the lock event.
This makes troubleshooting slower and reduces visibility in case of repeated authentication failures or suspicious account activity.
</p>

<h3>What this change does</h3>
<ul>
  <li>Adds an automatic email notification to administrators when a user account is locked by anti brute force protection.</li>
  <li>Keeps the existing user self-unlock email behavior unchanged.</li>
  <li>Sends the admin notification systematically, with no additional setting, as agreed for the minimal implementation.</li>
</ul>

<h3>Implementation details</h3>
<ul>
  <li>
    The notification is triggered in <code>identify.php</code> when TeamPass creates a lock for <code>source = 'login'</code>.
  </li>
  <li>
    The admin notification is sent to all active, non-deleted administrators with a valid email address.
  </li>
  <li>
    The notification provides context about the locked account and lock event, without exposing the user self-unlock token.
  </li>
</ul>

<h3>Scope</h3>
<p>
This notification is tied to the TeamPass anti brute force lock mechanism.
It therefore covers account lock situations caused by repeated authentication failures that increment the login failure counter, including cases beyond a simple wrong password when they are processed by the same protection flow.
</p>

<h3>Files updated</h3>
<ul>
  <li><code>sources/identify.php</code></li>
  <li><code>includes/language/english.php</code></li>
  <li><code>includes/language/french.php</code></li>
</ul>

<h2>Language strings</h2>
<p>
This PR adds the required language entries for the new administrator notification email.
No hardcoded user-facing text was introduced in the PHP code.
</p>

<h2>Expected behavior after this PR</h2>
<ul>
  <li><strong>Administrators</strong> can again access the <em>Inactive users</em> and <em>Deleted users</em> panels.</li>
  <li><strong>TeamPass Managers</strong> no longer see or access these admin-only panels.</li>
  <li><strong>Administrators</strong> are automatically notified when a user account is locked by anti brute force protection.</li>
  <li><strong>Users</strong> still receive their existing self-unlock email when applicable.</li>
</ul>

<h2>Testing</h2>
<ul>
  <li>Tested with an administrator account:
    <ul>
      <li><em>Inactive users</em> and <em>Deleted users</em> buttons are visible again.</li>
      <li>Both panels open correctly.</li>
      <li>Related actions remain functional.</li>
    </ul>
  </li>
  <li>Tested with a TeamPass Manager account:
    <ul>
      <li>Admin-only buttons are no longer visible.</li>
      <li>Direct access to related backend actions is denied.</li>
    </ul>
  </li>
  <li>Verified the anti brute force notification flow in <code>identify.php</code> for administrator email notification on account lock.</li>
</ul>

<h2>Additional notes</h2>
<ul>
  <li>This PR is intentionally focused and does not introduce a new settings option for the admin lock notification.</li>
  <li>The notification is always enabled for anti brute force account locks.</li>
  <li>This keeps the implementation minimal while improving operational visibility and incident response.</li>
</ul>