### PR TITLE
Fix folder sidebar dropdowns, persist folders depth filter, and add missing admin lock email strings

### DIFF
--- a/includes/language/english.php
+++ b/includes/language/english.php
@@ -2089,4 +2089,6 @@ return array(
     'network_security_auto_comment_current_ip' => 'Automatically added current admin IP',
     'network_security_auto_comment_server_ip' => 'Automatically added TeamPass server IP',
     'network_security_remote_addr' => 'Client remote address',
+    'email_subject_on_user_lock' => '[TeamPass] A user account has been locked',
+    'email_body_on_user_lock' => 'Hello,<br><br>This is a generated email from TeamPass.<br><br>User account <b>#tp_user#</b> has been locked by the anti brute force protection on #tp_date# at #tp_time#.<br><br>Details:<ul><li>Name: #tp_name#</li><li>Email: #tp_email#</li><li>Source IP: #tp_ip#</li><li>Automatic unlock at: #tp_unlock_at#</li></ul><br>Regards.',
     );

--- a/pages/folders.js.php
+++ b/pages/folders.js.php
@@ -83,6 +83,29 @@ if ($checkUserAccess->checkSession() === false || $checkUserAccess->userAccessPa
     // Clear
     $('#folders-search').val('');
 
+    const _foldersDepthStorageKey = 'teampass.folders.depth'
+
+    function getStoredFoldersDepth() {
+        try {
+            const storedDepth = sessionStorage.getItem(_foldersDepthStorageKey)
+            return storedDepth === null || storedDepth === '' ? 'all' : storedDepth
+        } catch (e) {
+            return 'all'
+        }
+    }
+
+    function storeFoldersDepth(depth) {
+        try {
+            if (depth === null || depth === undefined || depth === '') {
+                sessionStorage.removeItem(_foldersDepthStorageKey)
+            } else {
+                sessionStorage.setItem(_foldersDepthStorageKey, String(depth))
+            }
+        } catch (e) {
+            // Ignore browser storage errors and keep default UI behaviour
+        }
+    }
+
     // Generation counter: incremented on each buildTable() call so stale batch loops self-cancel
     var _buildGeneration = 0
 
@@ -401,7 +424,9 @@ if ($checkUserAccess->checkSession() === false || $checkUserAccess->userAccessPa
                         for (let x = 1; x < max_folder_depth; x++) {
                             $('#folders-depth').append('<option value="' + x + '">' + x + '</option>')
                         }
-                        $('#folders-depth').val('all').change()
+                        const storedDepth = getStoredFoldersDepth()
+                        const depthToApply = $('#folders-depth option[value="' + storedDepth + '"]').length > 0 ? storedDepth : 'all'
+                        $('#folders-depth').val(depthToApply).trigger('change')
 
                         // Populate complexity filter (keep current selection if possible)
                         const prevComplexity = $('#folders-complexity').val()
@@ -658,7 +683,10 @@ if ($checkUserAccess->checkSession() === false || $checkUserAccess->userAccessPa
         })
     }
 
-    $(document).on('change', '#folders-depth', applyFilters)
+    $(document).on('change', '#folders-depth', function() {
+        storeFoldersDepth($(this).val())
+        applyFilters()
+    })
     $(document).on('change', '#folders-complexity', applyFilters)
     $('#folders-search').on('keyup', applyFilters)
 

--- a/pages/folders.js.php
+++ b/pages/folders.js.php
@@ -781,16 +781,32 @@ if ($checkUserAccess->checkSession() === false || $checkUserAccess->userAccessPa
         $('#folder-edit-icon').val(folderIcon)
         $('#folder-edit-icon-selected').val(folderIconSel)
 
+        // Slide in first so Select2 initializes inside a visible container
+        $('#folder-edit-overlay').fadeIn(150)
+        $('#folder-edit-sidebar').addClass('open')
+
         // Populate selects from stored options then set values
         $('#folder-edit-parent').html(store.get('teampassApplication').foldersSelect)
         $('#folder-edit-complexity').html(store.get('teampassApplication').complexityOptions)
 
+        // Re-initialize Select2 cleanly each time the sidebar opens
+        if ($('#folder-edit-parent').hasClass('select2-hidden-accessible')) {
+            $('#folder-edit-parent').select2('destroy')
+        }
+        if ($('#folder-edit-complexity').hasClass('select2-hidden-accessible')) {
+            $('#folder-edit-complexity').select2('destroy')
+        }
+
         $('#folder-edit-parent').select2({
-            language: '<?php echo $session->get('user-language_code'); ?>'
+            language: '<?php echo $session->get('user-language_code'); ?>',
+            dropdownParent: $('#folder-edit-sidebar'),
+            width: '100%'
         }).val(String(folderParent)).trigger('change')
 
         $('#folder-edit-complexity').select2({
-            language: '<?php echo $session->get('user-language_code'); ?>'
+            language: '<?php echo $session->get('user-language_code'); ?>',
+            dropdownParent: $('#folder-edit-sidebar'),
+            width: '100%'
         }).val(String(folderComplexity)).trigger('change')
 
         // Checkboxes
@@ -809,9 +825,6 @@ if ($checkUserAccess->checkSession() === false || $checkUserAccess->userAccessPa
         $('#table-folders tbody tr.editing-active').removeClass('editing-active')
         $row.addClass('editing-active')
 
-        // Slide in
-        $('#folder-edit-overlay').fadeIn(150)
-        $('#folder-edit-sidebar').addClass('open')
     }
 
     /**


### PR DESCRIPTION
<h2>Summary</h2>
<p>
This PR includes three small but useful fixes related to folder management UX and account lock notifications:
</p>
<ul>
  <li>Fix unusable Select2 dropdowns in the folder edit right sidebar.</li>
  <li>Persist the selected folder depth filter on the folders page for the current browser session.</li>
  <li>Add two missing English language strings used in the administrator email notification sent when a user account is blocked.</li>
</ul>

<h2>1. Fix folder edit sidebar Select2 fields</h2>
<p>
On the folders page, when opening the right sidebar to edit a folder, the
<strong>Parent folder</strong> and <strong>Minimum password complexity</strong> dropdowns could not be opened or changed.
</p>
<p>
The issue came from the Select2 initialization: the dropdowns were created without a proper
<code>dropdownParent</code> while the edit panel is displayed inside its own overlay/sidebar stacking context.
This made the generated dropdown unusable in the UI.
</p>
<p>
The fix:
</p>
<ul>
  <li>Open the sidebar before initializing the Select2 fields.</li>
  <li>Attach both dropdowns to <code>#folder-edit-sidebar</code> using <code>dropdownParent</code>.</li>
  <li>Destroy any existing Select2 instance before reinitializing, to avoid duplicate initialization when switching between folders.</li>
</ul>

<h2>2. Persist folders depth filter during the browser session</h2>
<p>
The folders page now keeps the last selected folder depth filter during the current browser session.
</p>
<p>
This improves usability when repeatedly coming back to the folders page or refreshing the table, especially on large environments.
The selected depth is restored after a page reload or table rebuild, instead of always falling back to the default value.
</p>
<p>
This behavior is intentionally temporary and browser-session scoped, which keeps it consistent with the expected usage and avoids storing anything sensitive.
</p>
<ul>
  <li>No backend change.</li>
  <li>No database change.</li>
  <li>No permission or access control impact.</li>
  <li>Only a UI preference is stored client-side for the current session.</li>
</ul>

<h2>3. Add missing English strings for admin lock notification email</h2>
<p>
This PR also adds the two missing entries in <code>english.php</code> required by the email notification sent to administrators when a user account is blocked.
</p>
<p>
This ensures the notification content is complete and avoids missing language keys in English for this case.
</p>

<h2>Why this is safe</h2>
<ul>
  <li>The Select2 fix is limited to the folder edit sidebar UI behavior.</li>
  <li>The depth persistence only stores a display preference in the browser session.</li>
  <li>No sensitive data is stored client-side.</li>
  <li>No backend business logic is changed by the depth persistence.</li>
  <li>The language fix only adds missing translation entries and does not alter the notification workflow itself.</li>
</ul>

<h2>Testing</h2>
<ul>
  <li>Opened the folders page as admin.</li>
  <li>Opened a folder in the right sidebar.</li>
  <li>Verified that <strong>Parent folder</strong> dropdown now opens and can be changed.</li>
  <li>Verified that <strong>Minimum password complexity</strong> dropdown now opens and can be changed.</li>
  <li>Saved changes successfully.</li>
  <li>Selected a folder depth filter on the folders page.</li>
  <li>Reloaded the page and confirmed the selected depth is restored.</li>
  <li>Refreshed/rebuilt the folders table and confirmed the selected depth is preserved.</li>
  <li>Verified the English language file now contains the two missing strings for the admin account lock notification email.</li>
</ul>

<h2>Files changed</h2>
<ul>
  <li><code>folders.js.php</code></li>
  <li><code>english.php</code></li>
</ul>