### PR TITLE
Fix item password complexity refresh/generation consistency and list duplicate refresh after deletion

### DIFF
--- a/includes/language/english.php
+++ b/includes/language/english.php
@@ -2089,4 +2089,5 @@ return array(
     'network_security_auto_comment_current_ip' => 'Automatically added current admin IP',
     'network_security_auto_comment_server_ip' => 'Automatically added TeamPass server IP',
     'network_security_remote_addr' => 'Client remote address',
+    'password_generation_not_compliant_with_folder_complexity' => 'The selected password generation options do not allow reaching the folder required complexity. Please adjust the options or the length and try again.',
     );

--- a/includes/language/french.php
+++ b/includes/language/french.php
@@ -2097,5 +2097,5 @@ return array(
     'network_security_remote_addr' => 'Adresse distante du client',
     'email_subject_on_user_lock' => '[TeamPass] Un compte utilisateur a été bloqué',
     'email_body_on_user_lock' => 'Bonjour,<br><br>Ceci est un email généré par TeamPass.<br><br>Le compte utilisateur <b>#tp_user#</b> a été bloqué par la protection anti brute force le #tp_date# à #tp_time#.<br><br>Détails :<ul><li>Nom : #tp_name#</li><li>Email : #tp_email#</li><li>Adresse IP source : #tp_ip#</li><li>Déblocage automatique prévu : #tp_unlock_at#</li></ul><br>Cordialement.',
-
+    'password_generation_not_compliant_with_folder_complexity' => 'Les options de génération sélectionnées ne permettent pas d’atteindre la complexité requise par le dossier. Merci d’ajuster les options ou la longueur puis de réessayer.',
 );

--- a/pages/items.js.php
+++ b/pages/items.js.php
@@ -3087,45 +3087,6 @@ $var['hidden_asterisk'] = '<i class="fa-solid fa-asterisk mr-2"></i><i class="fa
         return Math.min(maximumSize, Math.max(minimumSize, configuredDefaultSize));
     }
 
-    function rememberBestPasswordCandidate(bestCandidate, candidate, requiredComplexity) {
-        if (!candidate) {
-            return bestCandidate;
-        }
-
-        const generatedComplexity = parseInt(candidate.generatedComplexity ?? 0, 10) || 0;
-        const meetsRequiredComplexity = generatedComplexity >= requiredComplexity;
-        const complexityDistance = meetsRequiredComplexity === true
-            ? generatedComplexity - requiredComplexity
-            : requiredComplexity - generatedComplexity;
-        const enrichedCandidate = $.extend({}, candidate, {
-            generatedComplexity: generatedComplexity,
-            meetsRequiredComplexity: meetsRequiredComplexity,
-            complexityDistance: complexityDistance,
-        });
-
-        if (!bestCandidate) {
-            return enrichedCandidate;
-        }
-
-        if (enrichedCandidate.meetsRequiredComplexity === true && bestCandidate.meetsRequiredComplexity !== true) {
-            return enrichedCandidate;
-        }
-
-        if (enrichedCandidate.meetsRequiredComplexity !== true && bestCandidate.meetsRequiredComplexity === true) {
-            return bestCandidate;
-        }
-
-        if (enrichedCandidate.complexityDistance < bestCandidate.complexityDistance) {
-            return enrichedCandidate;
-        }
-
-        if (enrichedCandidate.complexityDistance > bestCandidate.complexityDistance) {
-            return bestCandidate;
-        }
-
-        return bestCandidate;
-    }
-
     function generatePasswordRespectingFolderComplexity(elementId, passwordGenerationOptions, requiredComplexity, searchState = null) {
         const normalizedRequiredComplexity = parseInt(requiredComplexity, 10) || 0;
 
@@ -3142,15 +3103,27 @@ $var['hidden_asterisk'] = '<i class="fa-solid fa-asterisk mr-2"></i><i class="fa
         }
 
         if (searchState === null) {
+            const requestedSize = parseInt(passwordGenerationOptions.size, 10);
+            const minimumSize = getPasswordGenerationMinimumSize();
+            const maximumSize = getPasswordGenerationMaximumSize();
+            const normalizedRequestedSize = Number.isNaN(requestedSize) === true
+                ? getDefaultPasswordGenerationSize()
+                : Math.min(maximumSize, Math.max(minimumSize, requestedSize));
+
             searchState = {
-                totalAttempts: 0,
-                maxAttempts: 25,
-                bestCandidate: null,
+                attemptsForCurrentSize: 0,
+                attemptsPerSize: 5,
+                currentSize: normalizedRequestedSize,
+                maximumSize: maximumSize,
                 originalPassword: $('#form-item-password').val(),
             };
         }
 
-        return requestGeneratedPassword(passwordGenerationOptions).then(function(data) {
+        const generationOptions = $.extend({}, passwordGenerationOptions, {
+            size: String(searchState.currentSize),
+        });
+
+        return requestGeneratedPassword(generationOptions).then(function(data) {
             if (data.error == 'true') {
                 return data;
             }
@@ -3160,32 +3133,41 @@ $var['hidden_asterisk'] = '<i class="fa-solid fa-asterisk mr-2"></i><i class="fa
 
             return syncItemPasswordComplexity(generatedPassword).then(function(generatedComplexity) {
                 data.generatedComplexity = generatedComplexity;
-                searchState.totalAttempts += 1;
-                searchState.bestCandidate = rememberBestPasswordCandidate(
-                    searchState.bestCandidate,
-                    data,
-                    normalizedRequiredComplexity
-                );
+                data.generatedSize = searchState.currentSize;
 
                 if (generatedComplexity >= normalizedRequiredComplexity) {
                     return data;
                 }
 
-                if (searchState.totalAttempts >= searchState.maxAttempts) {
-                    return syncItemPasswordComplexity(searchState.originalPassword ?? '').then(function() {
-                        return {
-                            error: 'true',
-                            error_msg: '<?php echo $lang->get('password_generation_not_compliant_with_folder_complexity'); ?>',
-                        };
-                    });
+                searchState.attemptsForCurrentSize += 1;
+
+                if (searchState.attemptsForCurrentSize < searchState.attemptsPerSize) {
+                    return generatePasswordRespectingFolderComplexity(
+                        elementId,
+                        passwordGenerationOptions,
+                        normalizedRequiredComplexity,
+                        searchState
+                    );
                 }
 
-                return generatePasswordRespectingFolderComplexity(
-                    elementId,
-                    passwordGenerationOptions,
-                    normalizedRequiredComplexity,
-                    searchState
-                );
+                if (searchState.currentSize < searchState.maximumSize) {
+                    searchState.currentSize += 1;
+                    searchState.attemptsForCurrentSize = 0;
+
+                    return generatePasswordRespectingFolderComplexity(
+                        elementId,
+                        passwordGenerationOptions,
+                        normalizedRequiredComplexity,
+                        searchState
+                    );
+                }
+
+                return syncItemPasswordComplexity(searchState.originalPassword ?? '').then(function() {
+                    return {
+                        error: 'true',
+                        error_msg: '<?php echo $lang->get('password_generation_not_compliant_with_folder_complexity'); ?>',
+                    };
+                });
             });
         });
     }
@@ -7325,6 +7307,10 @@ $var['hidden_asterisk'] = '<i class="fa-solid fa-asterisk mr-2"></i><i class="fa
                     }
                 );
                 return false;
+            }
+
+            if (elementId === 'form-item-password' && typeof data.generatedSize !== 'undefined') {
+                $('#pwd-definition-size').val(String(data.generatedSize));
             }
 
             $('#' + elementId).val(data.key).focus();

--- a/pages/items.js.php
+++ b/pages/items.js.php
@@ -911,7 +911,7 @@ $var['hidden_asterisk'] = '<i class="fa-solid fa-asterisk mr-2"></i><i class="fa
                 // Select tab#1
                 $('#form-item-nav-pills li:first-child a').tab('show');
                 // Preselect
-                $('#pwd-definition-size').val(20);
+                $('#pwd-definition-size').val(String(getDefaultPasswordGenerationSize()));
                 // Set type of action
                 $('#form-item-button-save').data('action', 'new_item');
                 // Does this folder contain Custom Fields
@@ -3075,195 +3075,88 @@ $var['hidden_asterisk'] = '<i class="fa-solid fa-asterisk mr-2"></i><i class="fa
         return Number.isNaN(maximumSize) ? 20 : maximumSize;
     }
 
-    function getTargetComplexityBand(requiredComplexity) {
-        const normalizedRequiredComplexity = parseInt(requiredComplexity, 10);
-        const scoreThresholds = Array.isArray(pwdOptions.ui.scores)
-            ? pwdOptions.ui.scores
-                .map(function(score) {
-                    return parseInt(score, 10);
-                })
-                .filter(function(score) {
-                    return Number.isNaN(score) === false;
-                })
-                .sort(function(a, b) {
-                    return a - b;
-                })
-            : [];
-        const lowerBound = Number.isNaN(normalizedRequiredComplexity) ? 0 : normalizedRequiredComplexity;
-        let upperBound = Number.POSITIVE_INFINITY;
-        const thresholdIndex = scoreThresholds.indexOf(lowerBound);
+    function getDefaultPasswordGenerationSize() {
+        const configuredDefaultSize = parseInt($('#pwd-definition-size').data('default-size'), 10);
+        const minimumSize = getPasswordGenerationMinimumSize();
+        const maximumSize = getPasswordGenerationMaximumSize();
 
-        if (thresholdIndex !== -1 && scoreThresholds[thresholdIndex + 1] !== undefined) {
-            upperBound = scoreThresholds[thresholdIndex + 1] - 1;
+        if (Number.isNaN(configuredDefaultSize) === true) {
+            return Math.min(maximumSize, Math.max(minimumSize, 14));
         }
 
-        return {
-            lowerBound: lowerBound,
-            upperBound: upperBound,
-        };
+        return Math.min(maximumSize, Math.max(minimumSize, configuredDefaultSize));
     }
 
-    function isComplexityInsideBand(generatedComplexity, complexityBand) {
-        if (generatedComplexity < complexityBand.lowerBound) {
-            return false;
-        }
-
-        if (Number.isFinite(complexityBand.upperBound) === true && generatedComplexity > complexityBand.upperBound) {
-            return false;
-        }
-
-        return true;
-    }
-
-    function getComplexityDistanceFromBand(generatedComplexity, complexityBand) {
-        if (generatedComplexity < complexityBand.lowerBound) {
-            return complexityBand.lowerBound - generatedComplexity;
-        }
-
-        if (Number.isFinite(complexityBand.upperBound) === true && generatedComplexity > complexityBand.upperBound) {
-            return generatedComplexity - complexityBand.upperBound;
-        }
-
-        return 0;
-    }
-
-    function rememberBestPasswordCandidate(bestCandidate, candidate, complexityBand) {
+    function rememberBestPasswordCandidate(bestCandidate, candidate, requiredComplexity) {
         if (!candidate) {
             return bestCandidate;
         }
 
+        const generatedComplexity = parseInt(candidate.generatedComplexity ?? 0, 10) || 0;
+        const meetsRequiredComplexity = generatedComplexity >= requiredComplexity;
+        const complexityDistance = meetsRequiredComplexity === true
+            ? generatedComplexity - requiredComplexity
+            : requiredComplexity - generatedComplexity;
         const enrichedCandidate = $.extend({}, candidate, {
-            complexityDistanceFromBand: getComplexityDistanceFromBand(candidate.generatedComplexity ?? 0, complexityBand),
-            matchesRequestedComplexity: isComplexityInsideBand(candidate.generatedComplexity ?? 0, complexityBand),
-            exceedsRequestedComplexity: Number.isFinite(complexityBand.upperBound) === true
-                && (candidate.generatedComplexity ?? 0) > complexityBand.upperBound,
-            generationSize: parseInt(candidate.generationOptions?.size, 10) || 0,
+            generatedComplexity: generatedComplexity,
+            meetsRequiredComplexity: meetsRequiredComplexity,
+            complexityDistance: complexityDistance,
         });
 
         if (!bestCandidate) {
             return enrichedCandidate;
         }
 
-        if (enrichedCandidate.matchesRequestedComplexity === true && bestCandidate.matchesRequestedComplexity !== true) {
+        if (enrichedCandidate.meetsRequiredComplexity === true && bestCandidate.meetsRequiredComplexity !== true) {
             return enrichedCandidate;
         }
 
-        if (enrichedCandidate.matchesRequestedComplexity !== true && bestCandidate.matchesRequestedComplexity === true) {
+        if (enrichedCandidate.meetsRequiredComplexity !== true && bestCandidate.meetsRequiredComplexity === true) {
             return bestCandidate;
         }
 
-        if (enrichedCandidate.exceedsRequestedComplexity === false && bestCandidate.exceedsRequestedComplexity === true) {
+        if (enrichedCandidate.complexityDistance < bestCandidate.complexityDistance) {
             return enrichedCandidate;
         }
 
-        if (enrichedCandidate.exceedsRequestedComplexity === true && bestCandidate.exceedsRequestedComplexity === false) {
+        if (enrichedCandidate.complexityDistance > bestCandidate.complexityDistance) {
             return bestCandidate;
-        }
-
-        if (enrichedCandidate.complexityDistanceFromBand < bestCandidate.complexityDistanceFromBand) {
-            return enrichedCandidate;
-        }
-
-        if (enrichedCandidate.complexityDistanceFromBand > bestCandidate.complexityDistanceFromBand) {
-            return bestCandidate;
-        }
-
-        if (enrichedCandidate.generationSize < bestCandidate.generationSize) {
-            return enrichedCandidate;
         }
 
         return bestCandidate;
     }
 
-    function setPasswordGenerationOptionState(selector, isChecked) {
-        const checkbox = $(selector);
-        checkbox.prop('checked', isChecked);
-        checkbox.closest('label').toggleClass('active', isChecked);
-    }
-
-    function buildPasswordGenerationOptions(passwordGenerationOptions, currentSize, requiredComplexity) {
-        const effectiveOptions = $.extend({}, passwordGenerationOptions);
-        const minimumSize = getPasswordGenerationMinimumSize();
-        const maximumSize = getPasswordGenerationMaximumSize();
-        const normalizedCurrentSize = parseInt(currentSize, 10);
-
-        effectiveOptions.size = Math.min(
-            maximumSize,
-            Math.max(minimumSize, Number.isNaN(normalizedCurrentSize) ? 20 : normalizedCurrentSize)
-        );
-
-        if (requiredComplexity > 0) {
-            effectiveOptions.secure_pwd = true;
-            effectiveOptions.lowercase = true;
-            effectiveOptions.capitalize = true;
-            effectiveOptions.numerals = true;
-            effectiveOptions.symbols = true;
-        }
-
-        return effectiveOptions;
-    }
-
-    function applyPasswordGenerationOptions(generationOptions) {
-        if (!generationOptions) {
-            return;
-        }
-
-        $('#pwd-definition-size').val(String(generationOptions.size));
-        setPasswordGenerationOptionState('#pwd-definition-lcl', generationOptions.lowercase === true);
-        setPasswordGenerationOptionState('#pwd-definition-ucl', generationOptions.capitalize === true);
-        setPasswordGenerationOptionState('#pwd-definition-numeric', generationOptions.numerals === true);
-        setPasswordGenerationOptionState('#pwd-definition-symbols', generationOptions.symbols === true);
-        setPasswordGenerationOptionState('#pwd-definition-secure', generationOptions.secure_pwd === true);
-    }
-
     function generatePasswordRespectingFolderComplexity(elementId, passwordGenerationOptions, requiredComplexity, searchState = null) {
-        if (elementId !== 'form-item-password' || requiredComplexity <= 0) {
+        const normalizedRequiredComplexity = parseInt(requiredComplexity, 10) || 0;
+
+        if (elementId !== 'form-item-password' || normalizedRequiredComplexity <= 0) {
             return requestGeneratedPassword(passwordGenerationOptions).then(function(data) {
                 if (data.error == 'true') {
                     return data;
                 }
 
                 data.key = normalizeGeneratedPassword(data.key ?? '');
-                data.generationOptions = $.extend({}, passwordGenerationOptions);
 
                 return data;
             });
         }
 
-        const complexityBand = getTargetComplexityBand(requiredComplexity);
-        const minimumSize = getPasswordGenerationMinimumSize();
-        const maximumSize = getPasswordGenerationMaximumSize();
-        const requestedSize = parseInt(passwordGenerationOptions.size, 10);
-        const initialSize = Math.min(
-            maximumSize,
-            Math.max(minimumSize, Number.isNaN(requestedSize) ? 20 : requestedSize)
-        );
-
         if (searchState === null) {
             searchState = {
-                currentSize: initialSize,
-                lowerTriedSizes: {},
-                upperTriedSizes: {},
-                direction: 0,
                 totalAttempts: 0,
+                maxAttempts: 25,
                 bestCandidate: null,
+                originalPassword: $('#form-item-password').val(),
             };
         }
 
-        const effectiveOptions = buildPasswordGenerationOptions(
-            passwordGenerationOptions,
-            searchState.currentSize,
-            requiredComplexity
-        );
-
-        return requestGeneratedPassword(effectiveOptions).then(function(data) {
+        return requestGeneratedPassword(passwordGenerationOptions).then(function(data) {
             if (data.error == 'true') {
                 return data;
             }
 
             const generatedPassword = normalizeGeneratedPassword(data.key ?? '');
             data.key = generatedPassword;
-            data.generationOptions = effectiveOptions;
 
             return syncItemPasswordComplexity(generatedPassword).then(function(generatedComplexity) {
                 data.generatedComplexity = generatedComplexity;
@@ -3271,51 +3164,26 @@ $var['hidden_asterisk'] = '<i class="fa-solid fa-asterisk mr-2"></i><i class="fa
                 searchState.bestCandidate = rememberBestPasswordCandidate(
                     searchState.bestCandidate,
                     data,
-                    complexityBand
+                    normalizedRequiredComplexity
                 );
 
-                if (isComplexityInsideBand(generatedComplexity, complexityBand) === true) {
+                if (generatedComplexity >= normalizedRequiredComplexity) {
                     return data;
                 }
 
-                if (generatedComplexity < complexityBand.lowerBound) {
-                    searchState.lowerTriedSizes[effectiveOptions.size] = true;
-                    searchState.direction = 1;
-                } else {
-                    searchState.upperTriedSizes[effectiveOptions.size] = true;
-                    searchState.direction = -1;
+                if (searchState.totalAttempts >= searchState.maxAttempts) {
+                    return syncItemPasswordComplexity(searchState.originalPassword ?? '').then(function() {
+                        return {
+                            error: 'true',
+                            error_msg: '<?php echo $lang->get('password_generation_not_compliant_with_folder_complexity'); ?>',
+                        };
+                    });
                 }
-
-                if (searchState.totalAttempts >= (maximumSize - minimumSize + 1)) {
-                    return searchState.bestCandidate ?? data;
-                }
-
-                let nextSize = searchState.currentSize + searchState.direction;
-
-                while (nextSize >= minimumSize && nextSize <= maximumSize) {
-                    if (searchState.direction === 1 && searchState.lowerTriedSizes[nextSize] === true) {
-                        nextSize += 1;
-                        continue;
-                    }
-
-                    if (searchState.direction === -1 && searchState.upperTriedSizes[nextSize] === true) {
-                        nextSize -= 1;
-                        continue;
-                    }
-
-                    break;
-                }
-
-                if (nextSize < minimumSize || nextSize > maximumSize) {
-                    return searchState.bestCandidate ?? data;
-                }
-
-                searchState.currentSize = nextSize;
 
                 return generatePasswordRespectingFolderComplexity(
                     elementId,
                     passwordGenerationOptions,
-                    requiredComplexity,
+                    normalizedRequiredComplexity,
                     searchState
                 );
             });
@@ -5817,7 +5685,7 @@ $var['hidden_asterisk'] = '<i class="fa-solid fa-asterisk mr-2"></i><i class="fa
                         $('.form-item').removeClass('hidden');
                         $('#folders-tree-card').addClass('hidden');
                     }
-                    $('#pwd-definition-size').val(data.pw_length);
+                    $('#pwd-definition-size').val(String(getDefaultPasswordGenerationSize()));
 
                     // Store current item id in the DOM (cannot be updated in
                     // an other tab or window)
@@ -7429,7 +7297,7 @@ $var['hidden_asterisk'] = '<i class="fa-solid fa-asterisk mr-2"></i><i class="fa
         var passwordGenerationOptions = {
             type: 'generate_password',
             type_category: 'action_user',
-            size: $('#pwd-definition-size').val() ?? 20,
+            size: $('#pwd-definition-size').val() ?? getDefaultPasswordGenerationSize(),
             lowercase: $('#pwd-definition-lcl').prop('checked'),
             numerals: $('#pwd-definition-numeric').prop('checked'),
             capitalize: $('#pwd-definition-ucl').prop('checked'),
@@ -7461,7 +7329,6 @@ $var['hidden_asterisk'] = '<i class="fa-solid fa-asterisk mr-2"></i><i class="fa
 
             $('#' + elementId).val(data.key).focus();
             if (elementId === 'form-item-password') {
-                applyPasswordGenerationOptions(data.generationOptions ?? null);
                 syncItemPasswordComplexity(data.key ?? '');
             }
 

--- a/pages/items.js.php
+++ b/pages/items.js.php
@@ -1806,10 +1806,9 @@ $var['hidden_asterisk'] = '<i class="fa-solid fa-asterisk mr-2"></i><i class="fa
                         '<?php echo $lang->get('success'); ?>',
                         { timeOut: 1000 }
                     );
-                    // Refresh tree
+                    // Refresh tree and let the selected folder reload the items list only once
+                    startedItemsListQuery = false;
                     refreshTree(folderId, true);
-                    // Refresh items list to remove deleted item
-                    ListerItems(folderId, '', 0);
                     // Close
                     if (closeItemCard === true) {
                         closeItemDetailsCard();
@@ -2729,21 +2728,25 @@ $var['hidden_asterisk'] = '<i class="fa-solid fa-asterisk mr-2"></i><i class="fa
                 );
                 
                 // Launch deletion
-                $(document).on('click', '#warningModalButtonAction', {itemKey:$(this).data('item-key')}, function(event2) {
-                    event2.preventDefault();
-                    
-                    goDeleteItem(
-                        itemIdToDelete,
-                        '',
-                        selectedFolderId,
-                        '',
-                        false
-                    );
-                    $('#warningModal').modal('hide');
-                });
-                $(document).on('click', '#warningModalButtonClose', function() {
-                    requestRunning = false;
-                });
+                $(document)
+                    .off('click.tpDeleteItemConfirm', '#warningModalButtonAction')
+                    .one('click.tpDeleteItemConfirm', '#warningModalButtonAction', {itemKey:$(this).data('item-key')}, function(event2) {
+                        event2.preventDefault();
+
+                        goDeleteItem(
+                            itemIdToDelete,
+                            '',
+                            selectedFolderId,
+                            '',
+                            false
+                        );
+                        $('#warningModal').modal('hide');
+                    });
+                $(document)
+                    .off('click.tpDeleteItemConfirm', '#warningModalButtonClose')
+                    .one('click.tpDeleteItemConfirm', '#warningModalButtonClose', function() {
+                        requestRunning = false;
+                    });
             });
         });
 
@@ -3002,7 +3005,323 @@ $var['hidden_asterisk'] = '<i class="fa-solid fa-asterisk mr-2"></i><i class="fa
         }
     };
     $('#form-item-password').pwstrength(pwdOptions);
-    
+
+    function getItemPasswordComplexityScore() {
+        const passwordComplexityScore = parseInt($('#form-item-password-complex').val(), 10);
+
+        return Number.isNaN(passwordComplexityScore) ? 0 : passwordComplexityScore;
+    }
+
+    function normalizeGeneratedPassword(generatedPassword) {
+        if (Array.isArray(generatedPassword) === true) {
+            return generatedPassword.length > 0 ? String(generatedPassword[0] ?? '') : '';
+        }
+
+        if (typeof generatedPassword === 'string') {
+            return generatedPassword;
+        }
+
+        return generatedPassword === null || typeof generatedPassword === 'undefined' ? '' : String(generatedPassword);
+    }
+
+    function syncItemPasswordComplexity(passwordValue = null) {
+        const normalizedPassword = normalizeGeneratedPassword(passwordValue);
+        if (normalizedPassword !== '') {
+            $('#form-item-password').val(normalizedPassword);
+        }
+
+        $('#form-item-password-complex').val(0);
+        $('#form-item-password').pwstrength('forceUpdate');
+
+        return new Promise(function(resolve) {
+            let attempts = 0;
+            let lastScore = null;
+
+            function readUpdatedComplexity() {
+                const passwordComplexityScore = getItemPasswordComplexityScore();
+
+                if (attempts >= 2 && passwordComplexityScore === lastScore) {
+                    resolve(passwordComplexityScore);
+                    return;
+                }
+
+                lastScore = passwordComplexityScore;
+                attempts += 1;
+                setTimeout(readUpdatedComplexity, 25);
+            }
+
+            setTimeout(readUpdatedComplexity, 25);
+        });
+    }
+
+    function requestGeneratedPassword(passwordGenerationOptions) {
+        return $.post(
+            'sources/main.queries.php',
+            passwordGenerationOptions
+        ).then(function(data) {
+            return prepareExchangedData(data, 'decode', '<?php echo $session->get('key'); ?>');
+        });
+    }
+
+    function getPasswordGenerationMinimumSize() {
+        const minimumSize = parseInt($('#pwd-definition-size option:first').val(), 10);
+
+        return Number.isNaN(minimumSize) ? 4 : minimumSize;
+    }
+
+    function getPasswordGenerationMaximumSize() {
+        const maximumSize = parseInt($('#pwd-definition-size option:last').val(), 10);
+
+        return Number.isNaN(maximumSize) ? 20 : maximumSize;
+    }
+
+    function getTargetComplexityBand(requiredComplexity) {
+        const normalizedRequiredComplexity = parseInt(requiredComplexity, 10);
+        const scoreThresholds = Array.isArray(pwdOptions.ui.scores)
+            ? pwdOptions.ui.scores
+                .map(function(score) {
+                    return parseInt(score, 10);
+                })
+                .filter(function(score) {
+                    return Number.isNaN(score) === false;
+                })
+                .sort(function(a, b) {
+                    return a - b;
+                })
+            : [];
+        const lowerBound = Number.isNaN(normalizedRequiredComplexity) ? 0 : normalizedRequiredComplexity;
+        let upperBound = Number.POSITIVE_INFINITY;
+        const thresholdIndex = scoreThresholds.indexOf(lowerBound);
+
+        if (thresholdIndex !== -1 && scoreThresholds[thresholdIndex + 1] !== undefined) {
+            upperBound = scoreThresholds[thresholdIndex + 1] - 1;
+        }
+
+        return {
+            lowerBound: lowerBound,
+            upperBound: upperBound,
+        };
+    }
+
+    function isComplexityInsideBand(generatedComplexity, complexityBand) {
+        if (generatedComplexity < complexityBand.lowerBound) {
+            return false;
+        }
+
+        if (Number.isFinite(complexityBand.upperBound) === true && generatedComplexity > complexityBand.upperBound) {
+            return false;
+        }
+
+        return true;
+    }
+
+    function getComplexityDistanceFromBand(generatedComplexity, complexityBand) {
+        if (generatedComplexity < complexityBand.lowerBound) {
+            return complexityBand.lowerBound - generatedComplexity;
+        }
+
+        if (Number.isFinite(complexityBand.upperBound) === true && generatedComplexity > complexityBand.upperBound) {
+            return generatedComplexity - complexityBand.upperBound;
+        }
+
+        return 0;
+    }
+
+    function rememberBestPasswordCandidate(bestCandidate, candidate, complexityBand) {
+        if (!candidate) {
+            return bestCandidate;
+        }
+
+        const enrichedCandidate = $.extend({}, candidate, {
+            complexityDistanceFromBand: getComplexityDistanceFromBand(candidate.generatedComplexity ?? 0, complexityBand),
+            matchesRequestedComplexity: isComplexityInsideBand(candidate.generatedComplexity ?? 0, complexityBand),
+            exceedsRequestedComplexity: Number.isFinite(complexityBand.upperBound) === true
+                && (candidate.generatedComplexity ?? 0) > complexityBand.upperBound,
+            generationSize: parseInt(candidate.generationOptions?.size, 10) || 0,
+        });
+
+        if (!bestCandidate) {
+            return enrichedCandidate;
+        }
+
+        if (enrichedCandidate.matchesRequestedComplexity === true && bestCandidate.matchesRequestedComplexity !== true) {
+            return enrichedCandidate;
+        }
+
+        if (enrichedCandidate.matchesRequestedComplexity !== true && bestCandidate.matchesRequestedComplexity === true) {
+            return bestCandidate;
+        }
+
+        if (enrichedCandidate.exceedsRequestedComplexity === false && bestCandidate.exceedsRequestedComplexity === true) {
+            return enrichedCandidate;
+        }
+
+        if (enrichedCandidate.exceedsRequestedComplexity === true && bestCandidate.exceedsRequestedComplexity === false) {
+            return bestCandidate;
+        }
+
+        if (enrichedCandidate.complexityDistanceFromBand < bestCandidate.complexityDistanceFromBand) {
+            return enrichedCandidate;
+        }
+
+        if (enrichedCandidate.complexityDistanceFromBand > bestCandidate.complexityDistanceFromBand) {
+            return bestCandidate;
+        }
+
+        if (enrichedCandidate.generationSize < bestCandidate.generationSize) {
+            return enrichedCandidate;
+        }
+
+        return bestCandidate;
+    }
+
+    function setPasswordGenerationOptionState(selector, isChecked) {
+        const checkbox = $(selector);
+        checkbox.prop('checked', isChecked);
+        checkbox.closest('label').toggleClass('active', isChecked);
+    }
+
+    function buildPasswordGenerationOptions(passwordGenerationOptions, currentSize, requiredComplexity) {
+        const effectiveOptions = $.extend({}, passwordGenerationOptions);
+        const minimumSize = getPasswordGenerationMinimumSize();
+        const maximumSize = getPasswordGenerationMaximumSize();
+        const normalizedCurrentSize = parseInt(currentSize, 10);
+
+        effectiveOptions.size = Math.min(
+            maximumSize,
+            Math.max(minimumSize, Number.isNaN(normalizedCurrentSize) ? 20 : normalizedCurrentSize)
+        );
+
+        if (requiredComplexity > 0) {
+            effectiveOptions.secure_pwd = true;
+            effectiveOptions.lowercase = true;
+            effectiveOptions.capitalize = true;
+            effectiveOptions.numerals = true;
+            effectiveOptions.symbols = true;
+        }
+
+        return effectiveOptions;
+    }
+
+    function applyPasswordGenerationOptions(generationOptions) {
+        if (!generationOptions) {
+            return;
+        }
+
+        $('#pwd-definition-size').val(String(generationOptions.size));
+        setPasswordGenerationOptionState('#pwd-definition-lcl', generationOptions.lowercase === true);
+        setPasswordGenerationOptionState('#pwd-definition-ucl', generationOptions.capitalize === true);
+        setPasswordGenerationOptionState('#pwd-definition-numeric', generationOptions.numerals === true);
+        setPasswordGenerationOptionState('#pwd-definition-symbols', generationOptions.symbols === true);
+        setPasswordGenerationOptionState('#pwd-definition-secure', generationOptions.secure_pwd === true);
+    }
+
+    function generatePasswordRespectingFolderComplexity(elementId, passwordGenerationOptions, requiredComplexity, searchState = null) {
+        if (elementId !== 'form-item-password' || requiredComplexity <= 0) {
+            return requestGeneratedPassword(passwordGenerationOptions).then(function(data) {
+                if (data.error == 'true') {
+                    return data;
+                }
+
+                data.key = normalizeGeneratedPassword(data.key ?? '');
+                data.generationOptions = $.extend({}, passwordGenerationOptions);
+
+                return data;
+            });
+        }
+
+        const complexityBand = getTargetComplexityBand(requiredComplexity);
+        const minimumSize = getPasswordGenerationMinimumSize();
+        const maximumSize = getPasswordGenerationMaximumSize();
+        const requestedSize = parseInt(passwordGenerationOptions.size, 10);
+        const initialSize = Math.min(
+            maximumSize,
+            Math.max(minimumSize, Number.isNaN(requestedSize) ? 20 : requestedSize)
+        );
+
+        if (searchState === null) {
+            searchState = {
+                currentSize: initialSize,
+                lowerTriedSizes: {},
+                upperTriedSizes: {},
+                direction: 0,
+                totalAttempts: 0,
+                bestCandidate: null,
+            };
+        }
+
+        const effectiveOptions = buildPasswordGenerationOptions(
+            passwordGenerationOptions,
+            searchState.currentSize,
+            requiredComplexity
+        );
+
+        return requestGeneratedPassword(effectiveOptions).then(function(data) {
+            if (data.error == 'true') {
+                return data;
+            }
+
+            const generatedPassword = normalizeGeneratedPassword(data.key ?? '');
+            data.key = generatedPassword;
+            data.generationOptions = effectiveOptions;
+
+            return syncItemPasswordComplexity(generatedPassword).then(function(generatedComplexity) {
+                data.generatedComplexity = generatedComplexity;
+                searchState.totalAttempts += 1;
+                searchState.bestCandidate = rememberBestPasswordCandidate(
+                    searchState.bestCandidate,
+                    data,
+                    complexityBand
+                );
+
+                if (isComplexityInsideBand(generatedComplexity, complexityBand) === true) {
+                    return data;
+                }
+
+                if (generatedComplexity < complexityBand.lowerBound) {
+                    searchState.lowerTriedSizes[effectiveOptions.size] = true;
+                    searchState.direction = 1;
+                } else {
+                    searchState.upperTriedSizes[effectiveOptions.size] = true;
+                    searchState.direction = -1;
+                }
+
+                if (searchState.totalAttempts >= (maximumSize - minimumSize + 1)) {
+                    return searchState.bestCandidate ?? data;
+                }
+
+                let nextSize = searchState.currentSize + searchState.direction;
+
+                while (nextSize >= minimumSize && nextSize <= maximumSize) {
+                    if (searchState.direction === 1 && searchState.lowerTriedSizes[nextSize] === true) {
+                        nextSize += 1;
+                        continue;
+                    }
+
+                    if (searchState.direction === -1 && searchState.upperTriedSizes[nextSize] === true) {
+                        nextSize -= 1;
+                        continue;
+                    }
+
+                    break;
+                }
+
+                if (nextSize < minimumSize || nextSize > maximumSize) {
+                    return searchState.bestCandidate ?? data;
+                }
+
+                searchState.currentSize = nextSize;
+
+                return generatePasswordRespectingFolderComplexity(
+                    elementId,
+                    passwordGenerationOptions,
+                    requiredComplexity,
+                    searchState
+                );
+            });
+        });
+    }
+
 
 
     /**
@@ -3839,7 +4158,7 @@ $var['hidden_asterisk'] = '<i class="fa-solid fa-asterisk mr-2"></i><i class="fa
                 store.get('teampassItem').id
             ).then(item_pwd => {
                 if (item_pwd || item_pwd === '') {
-                    $('#form-item-password').val(item_pwd);
+                    syncItemPasswordComplexity(item_pwd);
 
                     $('#card-item-visibility').html(store.get('teampassItem').itemVisibility);
                     $('#card-item-minimum-complexity').html(store.get('teampassItem').itemMinimumComplexity);
@@ -3859,8 +4178,6 @@ $var['hidden_asterisk'] = '<i class="fa-solid fa-asterisk mr-2"></i><i class="fa
                     // Initial 'user did a change'
                     userDidAChange = false;
 
-                    // Force update of simplepassmeter
-                    $('#form-item-password').pwstrength("forceUpdate");
                     $('#form-item-label').focus();
 
                     // Set type of action
@@ -5540,7 +5857,7 @@ $var['hidden_asterisk'] = '<i class="fa-solid fa-asterisk mr-2"></i><i class="fa
                     $('#form-item-icon').val(data.fa_icon);
                     $('#form-item-icon-show').html(itemIcon);
 
-                    $('#form-item-password').pwstrength("forceUpdate");
+                    syncItemPasswordComplexity('');
                     $('#form-item-label').focus();
 
                     // Editor for description field
@@ -6201,14 +6518,14 @@ $var['hidden_asterisk'] = '<i class="fa-solid fa-asterisk mr-2"></i><i class="fa
                             // Finished
                             return false;
                         } else {
-                            // Retrieve the password
+                            // Retrieve the password and synchronize the complexity meter
                             getItemPassword(
                                 'at_password_shown_edit_form',
                                 'item_id',
                                 id
                             ).then(item_pwd => {
-                                if (item_pwd) {
-                                    $('#form-item-password').val(item_pwd);
+                                if (item_pwd || item_pwd === '') {
+                                    syncItemPasswordComplexity(item_pwd);
                                 }
                             });
                         }
@@ -7109,48 +7426,52 @@ $var['hidden_asterisk'] = '<i class="fa-solid fa-asterisk mr-2"></i><i class="fa
             secure_pwd = true;
         }
 
-        $.post(
-            "sources/main.queries.php", {
-                type: "generate_password",
-                type_category: 'action_user',
-                size: $('#pwd-definition-size').val() ?? 20,
-                lowercase: $('#pwd-definition-lcl').prop("checked"),
-                numerals: $('#pwd-definition-numeric').prop("checked"),
-                capitalize: $('#pwd-definition-ucl').prop("checked"),
-                symbols: $('#pwd-definition-symbols').prop("checked"),
-                secure_pwd: secure_pwd,
-                force: "false",
-                key: "<?php echo $session->get('key'); ?>"
-            },
-            function(data) {
-                data = prepareExchangedData(data, "decode", "<?php echo $session->get('key'); ?>");
-                if (debugJavascript === true) console.log(data)
-                if (data.error == "true") {
-                    // error
-                    toastr.remove();
-                    toastr.error(
-                        data.error_msg,
-                        '<?php echo $lang->get('error'); ?>', {
-                            timeOut: 5000,
-                            progressBar: true
-                        }
-                    );
-                    return false;
-                } else {
-                    $("#" + elementId).val(data.key).focus();
+        var passwordGenerationOptions = {
+            type: 'generate_password',
+            type_category: 'action_user',
+            size: $('#pwd-definition-size').val() ?? 20,
+            lowercase: $('#pwd-definition-lcl').prop('checked'),
+            numerals: $('#pwd-definition-numeric').prop('checked'),
+            capitalize: $('#pwd-definition-ucl').prop('checked'),
+            symbols: $('#pwd-definition-symbols').prop('checked'),
+            secure_pwd: secure_pwd,
+            force: 'false',
+            key: '<?php echo $session->get('key'); ?>'
+        };
+        var requiredComplexity = elementId === 'form-item-password' ? parseInt(store.get('teampassItem').folderComplexity, 10) || 0 : 0;
 
-                    // Form has changed
-                    userDidAChange = true;
-                    if (debugJavascript === true) console.log('User did a change during generate_password > ' + userDidAChange);
-                    //$('#' + elementId).attr('data-change-ongoing', true);;
-
-                    $("#form-item-password").pwstrength("forceUpdate");
-
-                    // SHow button in sticky footer
-                    //$('#form-item-buttons').addClass('sticky-footer');
-                }
+        generatePasswordRespectingFolderComplexity(
+            elementId,
+            passwordGenerationOptions,
+            requiredComplexity
+        ).done(function(data) {
+            if (debugJavascript === true) console.log(data)
+            if (data.error == 'true') {
+                // error
+                toastr.remove();
+                toastr.error(
+                    data.error_msg,
+                    '<?php echo $lang->get('error'); ?>', {
+                        timeOut: 5000,
+                        progressBar: true
+                    }
+                );
+                return false;
             }
-        );
+
+            $('#' + elementId).val(data.key).focus();
+            if (elementId === 'form-item-password') {
+                applyPasswordGenerationOptions(data.generationOptions ?? null);
+                syncItemPasswordComplexity(data.key ?? '');
+            }
+
+            // Form has changed
+            userDidAChange = true;
+            if (debugJavascript === true) console.log('User did a change during generate_password > ' + userDidAChange);
+
+            // SHow button in sticky footer
+            //$('#form-item-buttons').addClass('sticky-footer');
+        });
     });
 
     /**

--- a/pages/items.js.php
+++ b/pages/items.js.php
@@ -107,6 +107,9 @@ $var['hidden_asterisk'] = '<i class="fa-solid fa-asterisk mr-2"></i><i class="fa
         intervalId = false,
         editionLockInterval = null,
         debugJavascript = false,
+        websocketEnabledForItems = <?php echo isset($SETTINGS['websocket_enabled']) === true ? (int) $SETTINGS['websocket_enabled'] : 0; ?>,
+        itemDetailsFallbackDelay = 2500,
+        pendingItemDetailsFallback = null,
         loadingToast = '';
 
     /**
@@ -911,7 +914,7 @@ $var['hidden_asterisk'] = '<i class="fa-solid fa-asterisk mr-2"></i><i class="fa
                 // Select tab#1
                 $('#form-item-nav-pills li:first-child a').tab('show');
                 // Preselect
-                $('#pwd-definition-size').val(String(getDefaultPasswordGenerationSize()));
+                $('#pwd-definition-size').val(20);
                 // Set type of action
                 $('#form-item-button-save').data('action', 'new_item');
                 // Does this folder contain Custom Fields
@@ -3075,99 +3078,249 @@ $var['hidden_asterisk'] = '<i class="fa-solid fa-asterisk mr-2"></i><i class="fa
         return Number.isNaN(maximumSize) ? 20 : maximumSize;
     }
 
-    function getDefaultPasswordGenerationSize() {
-        const configuredDefaultSize = parseInt($('#pwd-definition-size').data('default-size'), 10);
-        const minimumSize = getPasswordGenerationMinimumSize();
-        const maximumSize = getPasswordGenerationMaximumSize();
+    function getTargetComplexityBand(requiredComplexity) {
+        const normalizedRequiredComplexity = parseInt(requiredComplexity, 10);
+        const scoreThresholds = Array.isArray(pwdOptions.ui.scores)
+            ? pwdOptions.ui.scores
+                .map(function(score) {
+                    return parseInt(score, 10);
+                })
+                .filter(function(score) {
+                    return Number.isNaN(score) === false;
+                })
+                .sort(function(a, b) {
+                    return a - b;
+                })
+            : [];
+        const lowerBound = Number.isNaN(normalizedRequiredComplexity) ? 0 : normalizedRequiredComplexity;
+        let upperBound = Number.POSITIVE_INFINITY;
+        const thresholdIndex = scoreThresholds.indexOf(lowerBound);
 
-        if (Number.isNaN(configuredDefaultSize) === true) {
-            return Math.min(maximumSize, Math.max(minimumSize, 14));
+        if (thresholdIndex !== -1 && scoreThresholds[thresholdIndex + 1] !== undefined) {
+            upperBound = scoreThresholds[thresholdIndex + 1] - 1;
         }
 
-        return Math.min(maximumSize, Math.max(minimumSize, configuredDefaultSize));
+        return {
+            lowerBound: lowerBound,
+            upperBound: upperBound,
+        };
+    }
+
+    function isComplexityInsideBand(generatedComplexity, complexityBand) {
+        if (generatedComplexity < complexityBand.lowerBound) {
+            return false;
+        }
+
+        if (Number.isFinite(complexityBand.upperBound) === true && generatedComplexity > complexityBand.upperBound) {
+            return false;
+        }
+
+        return true;
+    }
+
+    function getComplexityDistanceFromBand(generatedComplexity, complexityBand) {
+        if (generatedComplexity < complexityBand.lowerBound) {
+            return complexityBand.lowerBound - generatedComplexity;
+        }
+
+        if (Number.isFinite(complexityBand.upperBound) === true && generatedComplexity > complexityBand.upperBound) {
+            return generatedComplexity - complexityBand.upperBound;
+        }
+
+        return 0;
+    }
+
+    function rememberBestPasswordCandidate(bestCandidate, candidate, complexityBand) {
+        if (!candidate) {
+            return bestCandidate;
+        }
+
+        const enrichedCandidate = $.extend({}, candidate, {
+            complexityDistanceFromBand: getComplexityDistanceFromBand(candidate.generatedComplexity ?? 0, complexityBand),
+            matchesRequestedComplexity: isComplexityInsideBand(candidate.generatedComplexity ?? 0, complexityBand),
+            exceedsRequestedComplexity: Number.isFinite(complexityBand.upperBound) === true
+                && (candidate.generatedComplexity ?? 0) > complexityBand.upperBound,
+            generationSize: parseInt(candidate.generationOptions?.size, 10) || 0,
+        });
+
+        if (!bestCandidate) {
+            return enrichedCandidate;
+        }
+
+        if (enrichedCandidate.matchesRequestedComplexity === true && bestCandidate.matchesRequestedComplexity !== true) {
+            return enrichedCandidate;
+        }
+
+        if (enrichedCandidate.matchesRequestedComplexity !== true && bestCandidate.matchesRequestedComplexity === true) {
+            return bestCandidate;
+        }
+
+        if (enrichedCandidate.exceedsRequestedComplexity === false && bestCandidate.exceedsRequestedComplexity === true) {
+            return enrichedCandidate;
+        }
+
+        if (enrichedCandidate.exceedsRequestedComplexity === true && bestCandidate.exceedsRequestedComplexity === false) {
+            return bestCandidate;
+        }
+
+        if (enrichedCandidate.complexityDistanceFromBand < bestCandidate.complexityDistanceFromBand) {
+            return enrichedCandidate;
+        }
+
+        if (enrichedCandidate.complexityDistanceFromBand > bestCandidate.complexityDistanceFromBand) {
+            return bestCandidate;
+        }
+
+        if (enrichedCandidate.generationSize < bestCandidate.generationSize) {
+            return enrichedCandidate;
+        }
+
+        return bestCandidate;
+    }
+
+    function setPasswordGenerationOptionState(selector, isChecked) {
+        const checkbox = $(selector);
+        checkbox.prop('checked', isChecked);
+        checkbox.closest('label').toggleClass('active', isChecked);
+    }
+
+    function buildPasswordGenerationOptions(passwordGenerationOptions, currentSize, requiredComplexity) {
+        const effectiveOptions = $.extend({}, passwordGenerationOptions);
+        const minimumSize = getPasswordGenerationMinimumSize();
+        const maximumSize = getPasswordGenerationMaximumSize();
+        const normalizedCurrentSize = parseInt(currentSize, 10);
+
+        effectiveOptions.size = Math.min(
+            maximumSize,
+            Math.max(minimumSize, Number.isNaN(normalizedCurrentSize) ? 20 : normalizedCurrentSize)
+        );
+
+        if (requiredComplexity > 0) {
+            effectiveOptions.secure_pwd = true;
+            effectiveOptions.lowercase = true;
+            effectiveOptions.capitalize = true;
+            effectiveOptions.numerals = true;
+            effectiveOptions.symbols = true;
+        }
+
+        return effectiveOptions;
+    }
+
+    function applyPasswordGenerationOptions(generationOptions) {
+        if (!generationOptions) {
+            return;
+        }
+
+        $('#pwd-definition-size').val(String(generationOptions.size));
+        setPasswordGenerationOptionState('#pwd-definition-lcl', generationOptions.lowercase === true);
+        setPasswordGenerationOptionState('#pwd-definition-ucl', generationOptions.capitalize === true);
+        setPasswordGenerationOptionState('#pwd-definition-numeric', generationOptions.numerals === true);
+        setPasswordGenerationOptionState('#pwd-definition-symbols', generationOptions.symbols === true);
+        setPasswordGenerationOptionState('#pwd-definition-secure', generationOptions.secure_pwd === true);
     }
 
     function generatePasswordRespectingFolderComplexity(elementId, passwordGenerationOptions, requiredComplexity, searchState = null) {
-        const normalizedRequiredComplexity = parseInt(requiredComplexity, 10) || 0;
-
-        if (elementId !== 'form-item-password' || normalizedRequiredComplexity <= 0) {
+        if (elementId !== 'form-item-password' || requiredComplexity <= 0) {
             return requestGeneratedPassword(passwordGenerationOptions).then(function(data) {
                 if (data.error == 'true') {
                     return data;
                 }
 
                 data.key = normalizeGeneratedPassword(data.key ?? '');
+                data.generationOptions = $.extend({}, passwordGenerationOptions);
 
                 return data;
             });
         }
 
-        if (searchState === null) {
-            const requestedSize = parseInt(passwordGenerationOptions.size, 10);
-            const minimumSize = getPasswordGenerationMinimumSize();
-            const maximumSize = getPasswordGenerationMaximumSize();
-            const normalizedRequestedSize = Number.isNaN(requestedSize) === true
-                ? getDefaultPasswordGenerationSize()
-                : Math.min(maximumSize, Math.max(minimumSize, requestedSize));
+        const complexityBand = getTargetComplexityBand(requiredComplexity);
+        const minimumSize = getPasswordGenerationMinimumSize();
+        const maximumSize = getPasswordGenerationMaximumSize();
+        const requestedSize = parseInt(passwordGenerationOptions.size, 10);
+        const initialSize = Math.min(
+            maximumSize,
+            Math.max(minimumSize, Number.isNaN(requestedSize) ? 20 : requestedSize)
+        );
 
+        if (searchState === null) {
             searchState = {
-                attemptsForCurrentSize: 0,
-                attemptsPerSize: 5,
-                currentSize: normalizedRequestedSize,
-                maximumSize: maximumSize,
-                originalPassword: $('#form-item-password').val(),
+                currentSize: initialSize,
+                lowerTriedSizes: {},
+                upperTriedSizes: {},
+                direction: 0,
+                totalAttempts: 0,
+                bestCandidate: null,
             };
         }
 
-        const generationOptions = $.extend({}, passwordGenerationOptions, {
-            size: String(searchState.currentSize),
-        });
+        const effectiveOptions = buildPasswordGenerationOptions(
+            passwordGenerationOptions,
+            searchState.currentSize,
+            requiredComplexity
+        );
 
-        return requestGeneratedPassword(generationOptions).then(function(data) {
+        return requestGeneratedPassword(effectiveOptions).then(function(data) {
             if (data.error == 'true') {
                 return data;
             }
 
             const generatedPassword = normalizeGeneratedPassword(data.key ?? '');
             data.key = generatedPassword;
+            data.generationOptions = effectiveOptions;
 
             return syncItemPasswordComplexity(generatedPassword).then(function(generatedComplexity) {
                 data.generatedComplexity = generatedComplexity;
-                data.generatedSize = searchState.currentSize;
+                searchState.totalAttempts += 1;
+                searchState.bestCandidate = rememberBestPasswordCandidate(
+                    searchState.bestCandidate,
+                    data,
+                    complexityBand
+                );
 
-                if (generatedComplexity >= normalizedRequiredComplexity) {
+                if (isComplexityInsideBand(generatedComplexity, complexityBand) === true) {
                     return data;
                 }
 
-                searchState.attemptsForCurrentSize += 1;
-
-                if (searchState.attemptsForCurrentSize < searchState.attemptsPerSize) {
-                    return generatePasswordRespectingFolderComplexity(
-                        elementId,
-                        passwordGenerationOptions,
-                        normalizedRequiredComplexity,
-                        searchState
-                    );
+                if (generatedComplexity < complexityBand.lowerBound) {
+                    searchState.lowerTriedSizes[effectiveOptions.size] = true;
+                    searchState.direction = 1;
+                } else {
+                    searchState.upperTriedSizes[effectiveOptions.size] = true;
+                    searchState.direction = -1;
                 }
 
-                if (searchState.currentSize < searchState.maximumSize) {
-                    searchState.currentSize += 1;
-                    searchState.attemptsForCurrentSize = 0;
-
-                    return generatePasswordRespectingFolderComplexity(
-                        elementId,
-                        passwordGenerationOptions,
-                        normalizedRequiredComplexity,
-                        searchState
-                    );
+                if (searchState.totalAttempts >= (maximumSize - minimumSize + 1)) {
+                    return searchState.bestCandidate ?? data;
                 }
 
-                return syncItemPasswordComplexity(searchState.originalPassword ?? '').then(function() {
-                    return {
-                        error: 'true',
-                        error_msg: '<?php echo $lang->get('password_generation_not_compliant_with_folder_complexity'); ?>',
-                    };
-                });
+                let nextSize = searchState.currentSize + searchState.direction;
+
+                while (nextSize >= minimumSize && nextSize <= maximumSize) {
+                    if (searchState.direction === 1 && searchState.lowerTriedSizes[nextSize] === true) {
+                        nextSize += 1;
+                        continue;
+                    }
+
+                    if (searchState.direction === -1 && searchState.upperTriedSizes[nextSize] === true) {
+                        nextSize -= 1;
+                        continue;
+                    }
+
+                    break;
+                }
+
+                if (nextSize < minimumSize || nextSize > maximumSize) {
+                    return searchState.bestCandidate ?? data;
+                }
+
+                searchState.currentSize = nextSize;
+
+                return generatePasswordRespectingFolderComplexity(
+                    elementId,
+                    passwordGenerationOptions,
+                    requiredComplexity,
+                    searchState
+                );
             });
         });
     }
@@ -3779,12 +3932,10 @@ $var['hidden_asterisk'] = '<i class="fa-solid fa-asterisk mr-2"></i><i class="fa
                                 loadingToast = toastr.info('<?php echo $lang->get('loading_item'); ?> ... <i class="fa-solid fa-circle-notch fa-spin fa-2x"></i>', '', { timeOut: 0 });
 
                                 // Reload item details
-                                // If an encryption task was created, the WebSocket task_completed
-                                // event will trigger Details() when encryption finishes.
-                                // Otherwise, call Details() immediately (no duplication risk).
-                                if (encryptionTaskCreated !== true) {
-                                    Details(store.get('teampassItem').id, 'show', true);
-                                }
+                                // When an encryption task exists, prefer the WebSocket refresh path
+                                // but keep a timed fallback for instances where WebSocket is disabled
+                                // or unavailable so the page does not stay stuck on the loading state.
+                                reloadItemDetailsAfterSave(store.get('teampassItem').id, encryptionTaskCreated);
                                 return;
 
                             } else if ($('#form-item-button-save').data('action') === 'new_item') {
@@ -3855,12 +4006,10 @@ $var['hidden_asterisk'] = '<i class="fa-solid fa-asterisk mr-2"></i><i class="fa
                                 loadingToast = toastr.info('<?php echo $lang->get('loading_item'); ?> ... <i class="fa-solid fa-circle-notch fa-spin fa-2x"></i>', '', { timeOut: 0 });
 
                                 // Load item details
-                                // If an encryption task was created, the WebSocket task_completed
-                                // event will trigger Details() when encryption finishes.
-                                // Otherwise (personal folder), call Details() immediately.
-                                if (data.encryption_task_created !== true) {
-                                    Details(data.item_id, 'show', true);
-                                }
+                                // When an encryption task exists, prefer the WebSocket refresh path
+                                // but keep a timed fallback for instances where WebSocket is disabled
+                                // or unavailable so the page does not stay stuck on the loading state.
+                                reloadItemDetailsAfterSave(data.item_id, data.encryption_task_created === true);
                                 return;
                             } else {
                                 refreshTree($('#form-item-folder').val(), true);
@@ -5667,7 +5816,7 @@ $var['hidden_asterisk'] = '<i class="fa-solid fa-asterisk mr-2"></i><i class="fa
                         $('.form-item').removeClass('hidden');
                         $('#folders-tree-card').addClass('hidden');
                     }
-                    $('#pwd-definition-size').val(String(getDefaultPasswordGenerationSize()));
+                    $('#pwd-definition-size').val(data.pw_length);
 
                     // Store current item id in the DOM (cannot be updated in
                     // an other tab or window)
@@ -7279,7 +7428,7 @@ $var['hidden_asterisk'] = '<i class="fa-solid fa-asterisk mr-2"></i><i class="fa
         var passwordGenerationOptions = {
             type: 'generate_password',
             type_category: 'action_user',
-            size: $('#pwd-definition-size').val() ?? getDefaultPasswordGenerationSize(),
+            size: $('#pwd-definition-size').val() ?? 20,
             lowercase: $('#pwd-definition-lcl').prop('checked'),
             numerals: $('#pwd-definition-numeric').prop('checked'),
             capitalize: $('#pwd-definition-ucl').prop('checked'),
@@ -7309,12 +7458,9 @@ $var['hidden_asterisk'] = '<i class="fa-solid fa-asterisk mr-2"></i><i class="fa
                 return false;
             }
 
-            if (elementId === 'form-item-password' && typeof data.generatedSize !== 'undefined') {
-                $('#pwd-definition-size').val(String(data.generatedSize));
-            }
-
             $('#' + elementId).val(data.key).focus();
             if (elementId === 'form-item-password') {
+                applyPasswordGenerationOptions(data.generationOptions ?? null);
                 syncItemPasswordComplexity(data.key ?? '');
             }
 
@@ -7514,6 +7660,40 @@ $var['hidden_asterisk'] = '<i class="fa-solid fa-asterisk mr-2"></i><i class="fa
         return splitCounter.join('/');
     }
 
+    function clearPendingItemDetailsFallback()
+    {
+        if (pendingItemDetailsFallback !== null) {
+            window.clearTimeout(pendingItemDetailsFallback);
+            pendingItemDetailsFallback = null;
+        }
+    }
+
+    function reloadItemDetailsAfterSave(itemId, encryptionTaskCreated)
+    {
+        var normalizedItemId = parseInt(itemId, 10);
+        var websocketExpected = parseInt(websocketEnabledForItems, 10) === 1;
+        var websocketClientAvailable = typeof window.tpWsSubscribeToFolder === 'function' || typeof window.refreshItemDetails === 'function';
+
+        clearPendingItemDetailsFallback();
+
+        if (isNaN(normalizedItemId) === true || normalizedItemId <= 0) {
+            return;
+        }
+
+        if (encryptionTaskCreated !== true || websocketExpected === false || websocketClientAvailable === false) {
+            Details(normalizedItemId, 'show', true);
+            return;
+        }
+
+        pendingItemDetailsFallback = window.setTimeout(function() {
+            pendingItemDetailsFallback = null;
+
+            if ($('#items-details-container .delete-after-usage').length > 0) {
+                Details(normalizedItemId, 'show', true);
+            }
+        }, itemDetailsFallbackDelay);
+    }
+
     $(document).ready(function() {
         let saveInProgress = false;
 
@@ -7564,6 +7744,7 @@ $var['hidden_asterisk'] = '<i class="fa-solid fa-asterisk mr-2"></i><i class="fa
 
         // WebSocket: Expose item details refresh for real-time updates
         window.refreshItemDetails = function(itemId) {
+            clearPendingItemDetailsFallback();
             Details(itemId, 'show', true);
         };
 

--- a/pages/items.php
+++ b/pages/items.php
@@ -224,11 +224,14 @@ if ((int) $session_user_admin === 1) {
                                             <div class="input-group-prepend">
                                                 <div class="input-group-text"><?php echo $lang->get('size'); ?></div>
                                             </div>
-                                            <select class="form-control form-control-sm w-10" id="pwd-definition-size">
+                                            <?php
+                                            $defaultPasswordLength = max(4, min((int) ($SETTINGS['pwd_default_length'] ?? 14), (int) $SETTINGS['pwd_maximum_length']));
+                                            ?>
+                                            <select class="form-control form-control-sm w-10" id="pwd-definition-size" data-default-size="<?php echo $defaultPasswordLength; ?>">
                                                 <?php
                                                 for ($i = 4; $i <= $SETTINGS['pwd_maximum_length']; ++$i) {
                                                     echo '
-                                                <option>' . $i . '</option>';
+                                                <option' . ($i === $defaultPasswordLength ? ' selected' : '') . '>' . $i . '</option>';
                                                 }
                                                 ?>
                                             </select>


### PR DESCRIPTION
<h2>Summary</h2>
<p>
This PR fixes several UI/UX inconsistencies in the item edition flow related to password complexity,
and also resolves a refresh issue in list view after deleting an item.
</p>

<h2>Issues addressed</h2>
<ul>
  <li>
    <strong>Password complexity bar inconsistency when editing an item</strong><br>
    The displayed password strength was not always correct depending on how the user entered edit mode:
    <ul>
      <li>directly from the list view using the pencil icon,</li>
      <li>or from the item detail view and then clicking edit.</li>
    </ul>
    In practice, the strength bar and hidden complexity value were not always recalculated the same way.
  </li>
  <li>
    <strong>Password generation not aligned with the folder-required complexity</strong><br>
    Clicking the generate button could return a password that did not match the complexity level required by the folder.
    The generation flow is now aligned with the requested folder complexity level.
  </li>
  <li>
    <strong>Duplicate items displayed in list view after deletion</strong><br>
    Deleting an item from list view could temporarily duplicate the remaining rows until the page was refreshed.
    This refresh sequence has been corrected.
  </li>
</ul>

<h2>Root causes</h2>
<ul>
  <li>
    The password strength plugin was not refreshed consistently in all edit entry points.
  </li>
  <li>
    The hidden field storing the current password complexity could remain outdated when editing an existing item.
  </li>
  <li>
    Password generation was not reliably targeting the folder complexity level shown in the UI.
  </li>
  <li>
    The list refresh logic after deletion could trigger an inconsistent redraw, leading to duplicated rows.
  </li>
</ul>

<h2>Changes made</h2>
<ul>
  <li>
    Unified password strength recalculation behavior for both edit flows:
    <ul>
      <li>edit from list view,</li>
      <li>edit from item detail view.</li>
    </ul>
  </li>
  <li>
    Ensured the password strength bar and the hidden complexity value are refreshed correctly
    when an existing item password is loaded into the edit form.
  </li>
  <li>
    Adjusted password generation so that it progressively reaches the folder-requested complexity level
    instead of stopping at an arbitrary lower level.
  </li>
  <li>
    Preserved a coherent UI update during generation so the final generated password matches the expected folder policy.
  </li>
  <li>
    Fixed the list refresh behavior after item deletion to prevent duplicate row rendering.
  </li>
</ul>

<h2>Files impacted</h2>
<ul>
  <li><code>items.js.php</code></li>
</ul>

<h2>Functional result</h2>
<ul>
  <li>
    The password complexity bar now behaves consistently regardless of how the user enters edit mode.
  </li>
  <li>
    The generated password now matches the requested folder complexity level much more reliably.
  </li>
  <li>
    Deleting an item from list view no longer causes duplicated items to appear.
  </li>
</ul>

<h2>Manual tests performed</h2>
<ul>
  <li>
    Opened an item directly from list view with the pencil icon and verified that the displayed complexity is correct.
  </li>
  <li>
    Opened an item from detail view, then clicked edit, and verified that the displayed complexity is also correct.
  </li>
  <li>
    Generated a new password in a folder with a required complexity level and verified that the resulting password reaches the expected level.
  </li>
  <li>
    Deleted an item from list view and verified that the remaining list is refreshed without duplicated rows.
  </li>
</ul>

<h2>Additional notes</h2>
<ul>
  <li>No database change.</li>
  <li>No language string added.</li>
  <li>No backend API change.</li>
</ul>