### PR TITLE
Enhancement: enforce Network ACL on API entry point

### DIFF
--- a/api/index.php
+++ b/api/index.php
@@ -44,6 +44,36 @@ header("X-Frame-Options: DENY");
 header("Referrer-Policy: no-referrer");
 require __DIR__ . "/inc/bootstrap.php";
 
+if (!isset($SETTINGS) || is_array($SETTINGS) === false) {
+    $configManager = new \TeampassClasses\ConfigManager\ConfigManager();
+    $SETTINGS = $configManager->getAllSettings();
+}
+
+$apiLanguage = 'english';
+$acceptLanguage = strtolower((string) ($_SERVER['HTTP_ACCEPT_LANGUAGE'] ?? ''));
+if (preg_match('/(^|,)\s*fr([-_][a-z]{2})?(\s*;|,|$)/i', $acceptLanguage) === 1) {
+    $apiLanguage = 'french';
+}
+$lang = new \TeampassClasses\Language\Language($apiLanguage);
+
+$networkAccessContext = teampassGetClientIpForSecurity($SETTINGS);
+$networkAccessRules = teampassLoadNetworkAclRules(true);
+$networkAccess = teampassEvaluateNetworkAclAccess(
+    $SETTINGS,
+    isset($networkAccessContext['detected_ip']) === true ? (string) $networkAccessContext['detected_ip'] : null,
+    $networkAccessRules
+);
+if (($networkAccess['checked'] ?? false) === true && ($networkAccess['allowed'] ?? true) === false) {
+    errorHdl(
+        'HTTP/1.1 403 Forbidden',
+        json_encode(
+            ['error' => $lang->get('network_security_access_denied_message')],
+            JSON_UNESCAPED_UNICODE
+        )
+    );
+    exit;
+}
+
 // sanitize url segments
 $base = new BaseController();
 $uri = $base->getUriSegments();


### PR DESCRIPTION
<h2>Summary</h2>
<p>
This pull request extends the existing Network ACL feature to the TeamPass API entry point.
</p>

<p>
The web UI ACL is already enforced early in the application bootstrap. This change applies the same
ACL evaluation logic to the API so that blocked IPs cannot:
</p>
<ul>
  <li>request an authorization token,</li>
  <li>call authenticated API endpoints,</li>
  <li>bypass the web ACL by using the API directly.</li>
</ul>

<h2>Implementation details</h2>
<p>
The ACL check is added in <code>api/index.php</code>, immediately after the API bootstrap and before:
</p>
<ul>
  <li><code>apiIsEnabled()</code></li>
  <li><code>verifyAuth()</code></li>
  <li><code>authorize</code> handling</li>
  <li>routing to API controllers</li>
</ul>

<p>
This keeps the implementation centralized and consistent with the existing web UI ACL behavior.
The API reuses the existing network ACL helper functions already introduced in the main codebase:
</p>
<ul>
  <li>client IP detection</li>
  <li>trusted proxy handling</li>
  <li>whitelist / blacklist evaluation</li>
</ul>

<h2>Behavior</h2>
<p>
When the client IP is denied by the network ACL policy, the API now returns:
</p>
<ul>
  <li><code>HTTP 403 Forbidden</code></li>
  <li>a JSON error response</li>
</ul>

<p>
This applies both to:
</p>
<ul>
  <li>token acquisition requests</li>
  <li>already authenticated API requests</li>
</ul>

<h2>Why this change is needed</h2>
<p>
Without API-side ACL enforcement, a denied IP could still potentially access TeamPass through the API
even if the web UI is blocked. This change makes the behavior consistent across entry points.
</p>

<h2>Files changed</h2>
<ul>
  <li><code>api/index.php</code></li>
</ul>

<h2>Testing status</h2>
<p>
I was able to review the implementation logic and verify the integration point in the codebase,
but I could not fully validate the end-to-end API behavior in my test environment.
</p>

<p>
My TeamPass test environment is isolated and does not have Internet connectivity. The TeamPass browser
extension used to test the API requires access to an external licensing server, so I could not perform
full functional validation from my side.
</p>

<h2>Request for review</h2>
<p>
Please validate the following before merge:
</p>
<ul>
  <li>API authorization request from an allowed IP</li>
  <li>API authorization request from a blacklisted IP</li>
  <li>authenticated API call from an allowed IP</li>
  <li>authenticated API call from a denied IP when whitelist is enabled</li>
  <li>reverse proxy / trusted proxy behavior if applicable</li>
</ul>

<h2>Notes</h2>
<ul>
  <li>This PR only covers the API entry point.</li>
  <li>WebSocket ACL enforcement is not included in this change.</li>
  <li>The goal is to keep the scope small and aligned with the existing ACL implementation already merged in 3.1.7.1.</li>
</ul>