### PR TITLE
Restore local user password modal display and improve background task user attribution

### DIFF
--- a/includes/core/load.js.php
+++ b/includes/core/load.js.php
@@ -1171,6 +1171,13 @@ if (
     });
     
 
+    function resetAdminChangeUserPasswordDialogContext()
+    {
+        $('#admin_change_user_password_target_user, #admin_change_user_encryption_code_target_user').val('');
+        $('#dialog-admin-change-user-password-show-password-div').addClass('hidden');
+        $('#dialog-admin-change-user-password-do-show-password').prop('checked', false);
+    }
+
     /**
     * ADMIN HAS DECIDED TO CHANGE THE USER'S AUTH PASSWORD
      */
@@ -1264,7 +1271,7 @@ if (
                             );
                         }
 
-                        $('#dialog-admin-change-user-password-do-show-password').iCheck('uncheck');                        
+                        resetAdminChangeUserPasswordDialogContext();
                         $("#dialog-admin-change-user-password-progress").html('<?php echo $lang->get('generate_new_keys_end'); ?>');
                         // Show warning
                         toastr.remove();
@@ -1276,6 +1283,8 @@ if (
         }
     });
     $(document).on('click', '#dialog-admin-change-user-password-close', function() {
+        resetAdminChangeUserPasswordDialogContext();
+
         // HIde
         $('.content-header, .content').removeClass('hidden');
 
@@ -1349,6 +1358,7 @@ if (
 
                         // SHow form
                         $('#dialog-admin-change-user-password').addClass('hidden');
+                        resetAdminChangeUserPasswordDialogContext();
 
                         store.set(
                             'teampassUser', {

--- a/includes/core/load.js.php
+++ b/includes/core/load.js.php
@@ -1171,16 +1171,18 @@ if (
     });
     
 
-    function resetAdminChangeUserPasswordDialogContext()
-    {
-        $('#admin_change_user_password_target_user, #admin_change_user_encryption_code_target_user').val('');
-        $('#dialog-admin-change-user-password-show-password-div').addClass('hidden');
-        $('#dialog-admin-change-user-password-do-show-password').prop('checked', false);
-    }
-
     /**
     * ADMIN HAS DECIDED TO CHANGE THE USER'S AUTH PASSWORD
      */
+    function resetAdminChangeUserPasswordDialogContext() {
+        $('#admin_change_user_password_target_user').val('');
+        $('#admin_change_user_encryption_code_target_user').val('');
+        $('#dialog-admin-change-user-password-do-show-password').prop('checked', false);
+        $('#dialog-admin-change-user-password-show-password-div').addClass('hidden');
+        $('#dialog-admin-change-user-password-info').html('');
+        $('#dialog-admin-change-user-password-progress').html('<?php echo $lang->get('provide_current_psk_and_click_launch'); ?>');
+    }
+
     $(document).on('click', '#dialog-admin-change-user-password-do', function() {
         // When an admin changes the user auth password
         if (debugJavascript === true) console.log('Reencryption based upon admin decision to change user auth password');
@@ -1271,8 +1273,9 @@ if (
                             );
                         }
 
-                        resetAdminChangeUserPasswordDialogContext();
+                        $('#dialog-admin-change-user-password-do-show-password').prop('checked', false);
                         $("#dialog-admin-change-user-password-progress").html('<?php echo $lang->get('generate_new_keys_end'); ?>');
+                        resetAdminChangeUserPasswordDialogContext();
                         // Show warning
                         toastr.remove();
                     }
@@ -1283,10 +1286,10 @@ if (
         }
     });
     $(document).on('click', '#dialog-admin-change-user-password-close', function() {
-        resetAdminChangeUserPasswordDialogContext();
-
         // HIde
         $('.content-header, .content').removeClass('hidden');
+
+        resetAdminChangeUserPasswordDialogContext();
 
         // SHow form
         $('#dialog-admin-change-user-password').addClass('hidden');
@@ -1356,9 +1359,10 @@ if (
                         // HIde
                         $('.content-header, .content').removeClass('hidden');
 
+                        resetAdminChangeUserPasswordDialogContext();
+
                         // SHow form
                         $('#dialog-admin-change-user-password').addClass('hidden');
-                        resetAdminChangeUserPasswordDialogContext();
 
                         store.set(
                             'teampassUser', {

--- a/includes/language/french.php
+++ b/includes/language/french.php
@@ -642,7 +642,7 @@ return array(
     'mask_pw' => 'Afficher/Masquer le mot de passe',
     'max_last_items' => 'Nombre maximum d’éléments dernièrement vus (par défaut 10)',
     'minutes' => 'minutes',
-    'name' => 'Nom',
+    'name' => 'Prénom',
     'nb_false_login_attempts' => 'Nombre de tentatives de connexion erronées avant blocage (0 pour désactiver)',
     'nb_items' => 'Nombre d’éléments',
     'new_label' => 'Nouvel intitulé',

--- a/pages/users.js.php
+++ b/pages/users.js.php
@@ -1144,6 +1144,19 @@ if ($checkUserAccess->checkSession() === false || $checkUserAccess->userAccessPa
                                     timeOut: 4000
                                 }
                             );
+
+                            if (typeof data.user_password !== 'undefined' && data.user_password !== '') {
+                                showModalDialogBox(
+                                    '#warningModal',
+                                    '<i class="fas fa-user-shield fa-lg warning mr-2"></i><?php echo $lang->get('caution'); ?>',
+                                    '<?php echo $lang->get('user_password'); ?>&nbsp;<code class="ml-2">' + data.user_password + '</code>',
+                                    '',
+                                    '<?php echo $lang->get('close'); ?>',
+                                    false,
+                                    false,
+                                    false
+                                );
+                            }
                             // ---
                         } else {
                             // Inform user
@@ -1302,15 +1315,14 @@ if ($checkUserAccess->checkSession() === false || $checkUserAccess->userAccessPa
                             $('#dialog-admin-change-user-password-info')
                                 .html('<i class="icon fas fa-info mr-2"></i><?php echo $lang->get('admin_change_user_password_info'); ?>');
                             $("#dialog-admin-change-user-password-progress").html('<?php echo $lang->get('provide_current_psk_and_click_launch'); ?>');
-
-                            // Reset dialog context for local user password change
-                            $('#admin_change_user_encryption_code_target_user').val('');
-                            $('#admin_change_user_password_target_user').val(userId);
                             $('#dialog-admin-change-user-password-show-password-div').removeClass('hidden');
                             $('#dialog-admin-change-user-password-do-show-password').prop('checked', true);
 
                             // SHow form
                             $('#dialog-admin-change-user-password').removeClass('hidden');
+
+                            $('#admin_change_user_password_target_user').val(userId);
+                            $('#admin_change_user_encryption_code_target_user').val('');
                         }
                     }
                 }
@@ -1353,15 +1365,14 @@ if ($checkUserAccess->checkSession() === false || $checkUserAccess->userAccessPa
             $('#dialog-admin-change-user-password-info')
                 .html('<i class="icon fas fa-info mr-2"></i><?php echo $lang->get('admin_change_user_encryption_code_info'); ?>');
             $("#dialog-admin-change-user-password-progress").html('<?php echo $lang->get('provide_current_psk_and_click_launch'); ?>');
-
-            // Reset dialog context for encryption code regeneration
-            $('#admin_change_user_password_target_user').val('');
-            $('#admin_change_user_encryption_code_target_user').val($(this).data('id'));
             $('#dialog-admin-change-user-password-show-password-div').addClass('hidden');
             $('#dialog-admin-change-user-password-do-show-password').prop('checked', false);
 
             // SHow form
             $('#dialog-admin-change-user-password').removeClass('hidden');
+
+            $('#admin_change_user_password_target_user').val('');
+            $('#admin_change_user_encryption_code_target_user').val($(this).data('id'));
             // ---
 
         } else if ($(this).data('action') === 'logs') {

--- a/pages/users.js.php
+++ b/pages/users.js.php
@@ -1303,10 +1303,14 @@ if ($checkUserAccess->checkSession() === false || $checkUserAccess->userAccessPa
                                 .html('<i class="icon fas fa-info mr-2"></i><?php echo $lang->get('admin_change_user_password_info'); ?>');
                             $("#dialog-admin-change-user-password-progress").html('<?php echo $lang->get('provide_current_psk_and_click_launch'); ?>');
 
+                            // Reset dialog context for local user password change
+                            $('#admin_change_user_encryption_code_target_user').val('');
+                            $('#admin_change_user_password_target_user').val(userId);
+                            $('#dialog-admin-change-user-password-show-password-div').removeClass('hidden');
+                            $('#dialog-admin-change-user-password-do-show-password').prop('checked', true);
+
                             // SHow form
                             $('#dialog-admin-change-user-password').removeClass('hidden');
-
-                            $('#admin_change_user_password_target_user').val(userId);
                         }
                     }
                 }
@@ -1350,10 +1354,14 @@ if ($checkUserAccess->checkSession() === false || $checkUserAccess->userAccessPa
                 .html('<i class="icon fas fa-info mr-2"></i><?php echo $lang->get('admin_change_user_encryption_code_info'); ?>');
             $("#dialog-admin-change-user-password-progress").html('<?php echo $lang->get('provide_current_psk_and_click_launch'); ?>');
 
+            // Reset dialog context for encryption code regeneration
+            $('#admin_change_user_password_target_user').val('');
+            $('#admin_change_user_encryption_code_target_user').val($(this).data('id'));
+            $('#dialog-admin-change-user-password-show-password-div').addClass('hidden');
+            $('#dialog-admin-change-user-password-do-show-password').prop('checked', false);
+
             // SHow form
             $('#dialog-admin-change-user-password').removeClass('hidden');
-
-            $('#admin_change_user_encryption_code_target_user').val($(this).data('id'));
             // ---
 
         } else if ($(this).data('action') === 'logs') {

--- a/scripts/traits/UserHandlerTrait.php
+++ b/scripts/traits/UserHandlerTrait.php
@@ -581,6 +581,13 @@ trait UserHandlerTrait {
         // Config 3: send new password
         // COnfig 4: send new encryption code
         if (isset($arguments['send_email']) === true && (int) $arguments['send_email'] === 1 && !empty($userInfo['email'])) {
+            $receiverName = trim(
+                (string) ($userInfo['name'] ?? '') . ' ' . (string) ($userInfo['lastname'] ?? '')
+            );
+            if ($receiverName === '') {
+                $receiverName = (string) ($userInfo['login'] ?? '');
+            }
+
             sendMailToUser(
                 filter_var($userInfo['email'], FILTER_SANITIZE_EMAIL),
                 // @scrutinizer ignore-type
@@ -594,7 +601,8 @@ trait UserHandlerTrait {
                     FILTER_SANITIZE_FULL_SPECIAL_CHARS
                 ),
                 false,
-                $arguments['new_user_pwd']
+                $arguments['new_user_pwd'],
+                $receiverName
             );
         }
 

--- a/sources/logs.datatables.php
+++ b/sources/logs.datatables.php
@@ -969,26 +969,8 @@ if (isset($params['action']) && $params['action'] === 'connections') {
         $args = json_decode($record['arguments'], true);
         $args = is_array($args) ? $args : [];
 
-        if (in_array($record['process_type'], array('create_user_keys', 'item_copy')) === true) {
-            $newUserId = $args['new_user_id'] ?? ($args['user_id'] ?? null);
-            if (empty($newUserId) === false) {
-                $data_user = DB::queryFirstRow(
-                    'SELECT name, lastname FROM ' . prefixTable('users') . '
-                    WHERE id = %i',
-                    (int) $newUserId
-                );
-                if (DB::count() > 0) {
-                    $sOutput .= '"'.$data_user['name'].' '.$data_user['lastname'].'", ';
-                } else {
-                    $sOutput .= '"<i class=\"fa-solid fa-user-slash\"></i>", ';
-                }
-            } else {
-                $sOutput .= '"<i class=\"fa-solid fa-user-slash\"></i>", ';
-            }
-        } elseif ($record['process_type'] === 'send_email') {
-            $receiver = $args['receiver_name'] ?? ($args['login'] ?? ($args['email'] ?? null));
-            $sOutput .= '"'.(empty($receiver) ? '<i class=\"fa-solid fa-user-slash\"></i>' : $receiver).'", ';
-        }
+        $sOutput .= '"'.resolveBackgroundTaskUserDisplay($args, (string) $record['process_type']).'", ';
+
         // col6
         $sOutput .= '""';
         //Finish the line
@@ -1101,44 +1083,7 @@ if (isset($params['action']) && $params['action'] === 'connections') {
         // col6
         $arguments = json_decode($record['arguments'], true);
         $arguments = is_array($arguments) ? $arguments : [];
-        $newUserId = array_key_exists('new_user_id', $arguments) ? 
-            $arguments['new_user_id'] : 
-            (array_key_exists('user_id', $arguments) ? $arguments['user_id'] : null);
-        if ($record['process_type'] === 'create_user_keys' && is_null($newUserId) === false && empty($newUserId) === false) {
-            $data_user = DB::queryFirstRow(
-                'SELECT name, lastname, login FROM ' . prefixTable('users') . '
-                WHERE id = %i',
-                $newUserId
-            );
-            if (DB::count() > 0) {
-                $txt = (isset($data_user['name']) === true ? $data_user['name'] : '').(isset($data_user['lastname']) === true ? ' '.$data_user['lastname'] : '');
-                $sOutput .= '"'.(empty($txt) === false ? $txt : $data_user['login']).'"';
-            } else {
-                $sOutput .= '"<i class=\"fa-solid fa-user-slash\"></i>"';
-            }
-        } elseif ($record['process_type'] === 'send_email') {
-            $user = $arguments['receiver_name'] ?? ($arguments['login'] ?? ($arguments['email'] ?? null));
-            $sOutput .= '"'.(is_null($user) === true || empty($user) === true ? '<i class=\"fa-solid fa-user-slash\"></i>' : $user).'"';
-        } elseif ($record['process_type'] === 'user_build_cache_tree') {
-            $user = $arguments['user_id'] ?? null;
-            if (empty($user) === false) {
-                $data_user = DB::queryFirstRow(
-                    'SELECT name, lastname, login FROM ' . prefixTable('users') . '
-                    WHERE id = %i',
-                    (int) $user
-                );
-                if (DB::count() > 0) {
-                    $txt = (isset($data_user['name']) === true ? $data_user['name'] : '').(isset($data_user['lastname']) === true ? ' '.$data_user['lastname'] : '');
-                    $sOutput .= '"'.(empty($txt) === false ? $txt : $data_user['login']).'"';
-                } else {
-                    $sOutput .= '"<i class=\"fa-solid fa-user-slash\"></i>"';
-                }
-            } else {
-                $sOutput .= '"<i class=\"fa-solid fa-user-slash\"></i>"';
-            }
-        } else {
-            $sOutput .= '"<i class=\"fa-solid fa-user-slash\"></i>"';
-        }
+        $sOutput .= '"'.resolveBackgroundTaskUserDisplay($arguments, (string) $record['process_type']).'"';
         //Finish the line
         $sOutput .= '],';
     }
@@ -1155,6 +1100,83 @@ if (isset($params['action']) && $params['action'] === 'connections') {
 echo (string) $sOutput;
 
 
+
+
+function getBackgroundTaskUserDisplayFromUserId($userId): string
+{
+    if (empty($userId) === true) {
+        return "<i class='fa-solid fa-user-slash'></i>";
+    }
+
+    $dataUser = DB::queryFirstRow(
+        'SELECT name, lastname, login FROM ' . prefixTable('users') . '
+        WHERE id = %i
+        LIMIT 1',
+        (int) $userId
+    );
+
+    if (DB::count() === 0 || $dataUser === null) {
+        return "<i class='fa-solid fa-user-slash'></i>";
+    }
+
+    $dataUser = secureOutput($dataUser, ['name', 'lastname', 'login']);
+    $displayName = trim(
+        (string) ($dataUser['name'] ?? '') . ' ' . (string) ($dataUser['lastname'] ?? '')
+    );
+
+    if ($displayName === '') {
+        $displayName = trim((string) ($dataUser['login'] ?? ''));
+    }
+
+    return $displayName === '' ? "<i class='fa-solid fa-user-slash'></i>" : $displayName;
+}
+
+function resolveBackgroundTaskUserDisplay(array $arguments, string $processType): string
+{
+    if (in_array($processType, ['create_user_keys', 'item_copy', 'user_build_cache_tree'], true) === true) {
+        $userId = $arguments['new_user_id'] ?? ($arguments['user_id'] ?? null);
+        return getBackgroundTaskUserDisplayFromUserId($userId);
+    }
+
+    if ($processType === 'send_email') {
+        $receiverName = trim((string) ($arguments['receiver_name'] ?? ($arguments['login'] ?? '')));
+        if ($receiverName !== '') {
+            return secureOutput($receiverName);
+        }
+
+        $email = trim((string) ($arguments['receivers'] ?? ($arguments['email'] ?? '')));
+        if ($email !== '') {
+            $dataUser = DB::queryFirstRow(
+                'SELECT name, lastname, login FROM ' . prefixTable('users') . '
+                WHERE email = %s
+                ORDER BY id DESC
+                LIMIT 1',
+                $email
+            );
+
+            if (DB::count() > 0 && $dataUser !== null) {
+                $dataUser = secureOutput($dataUser, ['name', 'lastname', 'login']);
+                $displayName = trim(
+                    (string) ($dataUser['name'] ?? '') . ' ' . (string) ($dataUser['lastname'] ?? '')
+                );
+
+                if ($displayName === '') {
+                    $displayName = trim((string) ($dataUser['login'] ?? ''));
+                }
+
+                if ($displayName !== '') {
+                    return $displayName;
+                }
+            }
+
+            return secureOutput(htmlspecialchars($email, ENT_QUOTES, 'UTF-8'));
+        }
+
+        return "<i class='fa-solid fa-user-slash'></i>";
+    }
+
+    return "<i class='fa-solid fa-user-slash'></i>";
+}
 
 function getSubtaskProgress($id)
 {

--- a/sources/logs.datatables.php
+++ b/sources/logs.datatables.php
@@ -1102,6 +1102,13 @@ echo (string) $sOutput;
 
 
 
+function normalizeBackgroundTaskDisplayValue($value): string
+{
+    $decodedValue = html_entity_decode((string) $value, ENT_QUOTES | ENT_HTML5, 'UTF-8');
+
+    return htmlspecialchars($decodedValue, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8', false);
+}
+
 function getBackgroundTaskUserDisplayFromUserId($userId): string
 {
     if (empty($userId) === true) {
@@ -1119,13 +1126,14 @@ function getBackgroundTaskUserDisplayFromUserId($userId): string
         return "<i class='fa-solid fa-user-slash'></i>";
     }
 
-    $dataUser = secureOutput($dataUser, ['name', 'lastname', 'login']);
     $displayName = trim(
-        (string) ($dataUser['name'] ?? '') . ' ' . (string) ($dataUser['lastname'] ?? '')
+        normalizeBackgroundTaskDisplayValue($dataUser['name'] ?? '')
+        . ' ' .
+        normalizeBackgroundTaskDisplayValue($dataUser['lastname'] ?? '')
     );
 
     if ($displayName === '') {
-        $displayName = trim((string) ($dataUser['login'] ?? ''));
+        $displayName = trim(normalizeBackgroundTaskDisplayValue($dataUser['login'] ?? ''));
     }
 
     return $displayName === '' ? "<i class='fa-solid fa-user-slash'></i>" : $displayName;
@@ -1146,7 +1154,7 @@ function resolveBackgroundTaskUserDisplay(array $arguments, string $processType)
     if ($processType === 'send_email') {
         $receiverName = trim((string) ($arguments['receiver_name'] ?? ($arguments['login'] ?? '')));
         if ($receiverName !== '') {
-            return secureOutput($receiverName);
+            return normalizeBackgroundTaskDisplayValue($receiverName);
         }
 
         $email = trim((string) ($arguments['receivers'] ?? ($arguments['email'] ?? '')));
@@ -1160,13 +1168,14 @@ function resolveBackgroundTaskUserDisplay(array $arguments, string $processType)
             );
 
             if (DB::count() > 0 && $dataUser !== null) {
-                $dataUser = secureOutput($dataUser, ['name', 'lastname', 'login']);
                 $displayName = trim(
-                    (string) ($dataUser['name'] ?? '') . ' ' . (string) ($dataUser['lastname'] ?? '')
+                    normalizeBackgroundTaskDisplayValue($dataUser['name'] ?? '')
+                    . ' ' .
+                    normalizeBackgroundTaskDisplayValue($dataUser['lastname'] ?? '')
                 );
 
                 if ($displayName === '') {
-                    $displayName = trim((string) ($dataUser['login'] ?? ''));
+                    $displayName = trim(normalizeBackgroundTaskDisplayValue($dataUser['login'] ?? ''));
                 }
 
                 if ($displayName !== '') {
@@ -1174,7 +1183,7 @@ function resolveBackgroundTaskUserDisplay(array $arguments, string $processType)
                 }
             }
 
-            return secureOutput(htmlspecialchars($email, ENT_QUOTES, 'UTF-8'));
+            return normalizeBackgroundTaskDisplayValue($email);
         }
 
         return "<i class='fa-solid fa-user-slash'></i>";

--- a/sources/logs.datatables.php
+++ b/sources/logs.datatables.php
@@ -1133,8 +1133,13 @@ function getBackgroundTaskUserDisplayFromUserId($userId): string
 
 function resolveBackgroundTaskUserDisplay(array $arguments, string $processType): string
 {
-    if (in_array($processType, ['create_user_keys', 'item_copy', 'user_build_cache_tree'], true) === true) {
+    if (in_array($processType, ['create_user_keys', 'user_build_cache_tree', 'migrate_user_personal_items'], true) === true) {
         $userId = $arguments['new_user_id'] ?? ($arguments['user_id'] ?? null);
+        return getBackgroundTaskUserDisplayFromUserId($userId);
+    }
+
+    if (in_array($processType, ['item_copy', 'new_item', 'item_update_create_keys', 'update_item'], true) === true) {
+        $userId = $arguments['author'] ?? ($arguments['user_id'] ?? ($arguments['owner_id'] ?? null));
         return getBackgroundTaskUserDisplayFromUserId($userId);
     }
 

--- a/sources/main.functions.php
+++ b/sources/main.functions.php
@@ -5787,6 +5787,7 @@ function returnIfSet($value, $retFalse = '', $retTrue = null): mixed
  * @param array $post_replace
  * @param boolean $immediate_email
  * @param string $encryptedUserPassword
+ * @param string $receiverName
  * @return string
  */
 function sendMailToUser(
@@ -5795,7 +5796,8 @@ function sendMailToUser(
     string $post_subject,
     array $post_replace,
     bool $immediate_email = false,
-    $encryptedUserPassword = ''
+    $encryptedUserPassword = '',
+    string $receiverName = ''
 ): ?string {
     global $SETTINGS;
     $emailSettings = new EmailSettings($SETTINGS);
@@ -5844,7 +5846,7 @@ function sendMailToUser(
             $post_subject,
             $post_body,
             $post_receipt,
-            "",
+            $receiverName,
             $encryptedUserPassword,
         );
     }

--- a/sources/users.queries.php
+++ b/sources/users.queries.php
@@ -475,6 +475,7 @@ if (null !== $post_type) {
                     array(
                         'error' => false,
                         'user_id' => $new_user_id,
+                        'user_password' => $password,
                         'message' => '',
                     ),
                     'encode'


### PR DESCRIPTION
<h2>Summary</h2>
<p>
This PR fixes two functional/UI regressions around local user password management and background task display.
</p>

<ul>
  <li>Restore password modal display for local user password generation flows.</li>
  <li>Improve user attribution in the task manager for several background task types that were displayed as anonymous.</li>
</ul>

<h2>1. Local user password modal display</h2>
<p>
A regression was identified in the local user password generation flow.
When an administrator generated a new password for a local user, TeamPass still sent the password by email,
but the generated password was no longer displayed in the admin modal as it used to be.
</p>

<p>
The backend was still returning <code>user_password</code>, and the display logic was still present in the frontend.
The issue came from the UI flow not restoring the "show password" option properly for the local password reset action.
</p>

<p>
During validation, a related issue was also found for local user creation:
the generated password was not displayed in the modal after creating a new local user, even though it was generated correctly.
</p>

<h3>Changes included</h3>
<ul>
  <li>Restore the "show password" option visibility for the <code>new-password</code> action on local users.</li>
  <li>Pre-check this option to restore the previous admin behavior.</li>
  <li>Keep this option hidden for the encryption code generation flow.</li>
  <li>Reset the modal state properly when opening/closing the dialog to avoid stale checkbox or user context.</li>
  <li>Return <code>user_password</code> in the local user creation flow so the password can also be displayed after user creation.</li>
  <li>Keep email delivery to the target user unchanged.</li>
</ul>

<h2>2. Background task manager user attribution</h2>
<p>
Several completed background tasks were shown without a meaningful user in the "User" column,
which made the task history look partially anonymized or inconsistent.
</p>

<p>
This was not intentional anonymization. The issue came from incomplete user resolution logic in
<code>sources/logs.datatables.php</code> and from email-related tasks not always carrying a displayable receiver name.
</p>

<h3>Changes included</h3>
<ul>
  <li>Improve user resolution for <code>send_email</code> tasks with a stronger fallback strategy.</li>
  <li>Pass a meaningful receiver name when preparing email-related background tasks.</li>
  <li>Improve task user attribution for user-related background tasks such as <code>create_user_keys</code>.</li>
  <li>Improve task user attribution for author-based item tasks such as <code>item_update_create_keys</code>.</li>
  <li>Make the resolver more consistent for related processes such as <code>new_item</code>, <code>item_copy</code> and <code>update_item</code> when an author is available.</li>
</ul>

<h2>Impact</h2>
<ul>
  <li>Local users: administrators can again see the generated password in the modal when resetting a password.</li>
  <li>Local users: administrators can also see the generated password in the modal right after user creation.</li>
  <li>Email delivery remains unchanged.</li>
  <li>AD / Azure / external authentication flows are not impacted.</li>
  <li>Task manager history is now more consistent and shows the expected user for the affected background tasks.</li>
  <li>No language string changes were required.</li>
</ul>

<h2>Files updated</h2>
<ul>
  <li><code>pages/users.js.php</code></li>
  <li><code>includes/core/load.js.php</code></li>
  <li><code>sources/users.queries.php</code></li>
  <li><code>sources/main.functions.php</code></li>
  <li><code>scripts/traits/UserHandlerTrait.php</code></li>
  <li><code>sources/logs.datatables.php</code></li>
</ul>

<h2>Manual tests performed</h2>
<ul>
  <li>Create a new local user and verify that the generated password is displayed in the admin modal.</li>
  <li>Reset the password of an existing local user and verify that the generated password is displayed again in the admin modal.</li>
  <li>Generate a new encryption code and verify that the "show password" option remains hidden for that flow.</li>
  <li>Verify that the email is still queued/sent as before.</li>
  <li>Open the task manager and verify that <code>send_email</code> tasks now display a meaningful user instead of an empty/anonymized value.</li>
  <li>Open the task manager and verify that <code>item_update_create_keys</code> tasks now display the correct author/user.</li>
</ul>