### PR TITLE
Fix personal folder item save regressions and make item edit folder complexity reliable

### DIFF
--- a/pages/items.js.php
+++ b/pages/items.js.php
@@ -975,7 +975,7 @@ $var['hidden_asterisk'] = '<i class="fa-solid fa-asterisk mr-2"></i><i class="fa
             }
 
             $.when(
-                getPrivilegesOnItem(item_tree_id, 1)
+                getPrivilegesOnItem(item_tree_id, 1, 'item_edit_current_folder')
             ).then(function(retData) {
                 if (retData.error === true) {
                     toastr.remove();
@@ -1020,8 +1020,12 @@ $var['hidden_asterisk'] = '<i class="fa-solid fa-asterisk mr-2"></i><i class="fa
                 // Remove validated class
                 $('#form-item').removeClass('was-validated');
 
-                // Now manage edtion
-                showItemEditForm(item_tree_id);
+                // Now manage edition using the folder resolved by backend.
+                showItemEditForm(
+                    retData.folderId !== undefined && retData.folderId !== ''
+                        ? parseInt(retData.folderId, 10)
+                        : item_tree_id
+                );
             });
 
             //
@@ -1607,20 +1611,84 @@ $var['hidden_asterisk'] = '<i class="fa-solid fa-asterisk mr-2"></i><i class="fa
 
 
 
+    let itemFolderRulesRefreshRequestId = 0;
+
+    /**
+     * Refresh the top rules of item form from backend for the selected folder.
+     * When opening an existing item for edition, the backend can resolve the
+     * current folder directly from the item to avoid stale UI state after a move.
+     */
+    function refreshItemFolderTopRules(folderId, context) {
+        context = context || '';
+
+        if (folderId === null || folderId === '' || typeof folderId === 'undefined') {
+            $('#card-item-visibility').html('');
+            $('#card-item-minimum-complexity').html('');
+            return $.Deferred().resolve({ error: true }).promise();
+        }
+
+        itemFolderRulesRefreshRequestId += 1;
+        const currentRequestId = itemFolderRulesRefreshRequestId;
+
+        $('#card-item-visibility').html('');
+        $('#card-item-minimum-complexity').html('');
+
+        return $.post(
+            'sources/items.queries.php', {
+                type: 'get_complixity_level',
+                folder_id: folderId,
+                context: context,
+                item_id: store.get('teampassItem') !== undefined && store.get('teampassItem').id !== undefined
+                    ? store.get('teampassItem').id
+                    : '',
+                key: '<?php echo $session->get('key'); ?>'
+            }
+        ).then(function(data) {
+            data = decodeQueryReturn(data, '<?php echo $session->get('key'); ?>', 'items.queries.php', 'get_complixity_level');
+
+            if (debugJavascript === true) {
+                console.log('refreshItemFolderTopRules');
+                console.log(data);
+            }
+
+            // Ignore outdated asynchronous responses when the user changes folder quickly.
+            if (currentRequestId !== itemFolderRulesRefreshRequestId) {
+                return data;
+            }
+
+            if (data.error === false) {
+                $('#card-item-visibility').html(data.visibility || '<?php echo $lang->get('none'); ?>');
+                $('#card-item-minimum-complexity').html(data.complexity === undefined ? '' : data.complexity);
+
+                store.update(
+                    'teampassItem',
+                    function(teampassItem) {
+                        teampassItem.folderId = data.folderId === undefined ? parseInt(folderId, 10) : parseInt(data.folderId, 10),
+                        teampassItem.tree_id = data.folderId === undefined ? teampassItem.tree_id : parseInt(data.folderId, 10),
+                        teampassItem.folderComplexity = data.val === undefined ? '' : parseInt(data.val, 10),
+                        teampassItem.folderIsPersonal = data.personal === undefined ? '' : parseInt(data.personal, 10),
+                        teampassItem.itemMinimumComplexity = data.complexity === undefined ? '' : data.complexity,
+                        teampassItem.itemVisibility = data.visibility === undefined ? '' : data.visibility
+                    }
+                );
+
+                if (context === 'item_edit_current_folder' && data.folderId !== undefined) {
+                    const resolvedFolderId = String(data.folderId);
+                    if ($('#form-item-folder').val() !== resolvedFolderId) {
+                        $('#form-item-folder').val(resolvedFolderId);
+                    }
+                }
+            }
+
+            return data;
+        });
+    }
+
     /**
      * Adapt the top rules of item form on change of folders
      */
     $('#form-item-folder').change(function() {
-        if ($(this).val() !== null && store.get('teampass-folders') !== undefined) {
-            if (debugJavascript === true) {
-                console.log('teampass-folders');
-                console.log(store.get('teampass-folders'))
-            }
-            var folders = JSON.parse(store.get('teampass-folders'));
-            $('#card-item-visibility').html(folders[$(this).val()].visibilityRoles);
-            $('#card-item-minimum-complexity').html(folders[$(this).val()].complexity.text);
-        }
-
+        refreshItemFolderTopRules($(this).val());
     });
 
     /**
@@ -4068,11 +4136,12 @@ $var['hidden_asterisk'] = '<i class="fa-solid fa-asterisk mr-2"></i><i class="fa
                 if (item_pwd || item_pwd === '') {
                     syncItemPasswordComplexity(item_pwd);
 
-                    $('#card-item-visibility').html(store.get('teampassItem').itemVisibility);
-                    $('#card-item-minimum-complexity').html(store.get('teampassItem').itemMinimumComplexity);
+                    $('#card-item-visibility').html('');
+                    $('#card-item-minimum-complexity').html('');
 
-                    // Set selected folder id
-                    $('#form-item-folder').val(selectedFolderId).change();
+                    // Set selected folder id and refresh top rules from backend
+                    $('#form-item-folder').val(selectedFolderId);
+                    refreshItemFolderTopRules(selectedFolderId, 'item_edit_current_folder');
 
                     // show top back buttons
                     $('#but_back_top_left, #but_back_top_right').addClass('hidden');
@@ -4716,13 +4785,17 @@ $var['hidden_asterisk'] = '<i class="fa-solid fa-asterisk mr-2"></i><i class="fa
 
                     // Check if more items to be loaded
                     const call_to_be_continued = !!data.list_to_be_continued;
+                    const isNotAuthorized = data.error === 'not_authorized';
+                    const hasUniqueLoadData = typeof data.uniqueLoadData === 'string' && data.uniqueLoadData !== '';
 
-                    // Hide New button if restricted folder
-                    $('#btn-new-item').toggleClass('hidden', data.access_level === 10);
+                    // Hide New button if restricted folder or folder is not accessible
+                    $('#btn-new-item').toggleClass('hidden', data.access_level === 10 || isNotAuthorized === true);
                     
                     // to be done only in 1st list load
-                    if (call_to_be_continued === false) {
-                        var initialQueryData = $.parseJSON(data.uniqueLoadData);
+                    if (isNotAuthorized === true) {
+                        $('#items_folder_path').html('<i class="fa-solid fa-folder-open-o"></i>&nbsp;' + rebuildPath(data.arborescence));
+                    } else if (call_to_be_continued === false) {
+                        var initialQueryData = hasUniqueLoadData === true ? $.parseJSON(data.uniqueLoadData) : { path: [] };
 
                         // Update hidden variables
                         store.update(
@@ -4741,9 +4814,6 @@ $var['hidden_asterisk'] = '<i class="fa-solid fa-asterisk mr-2"></i><i class="fa
                             initialQueryData.path.length > 0 ? rebuildPath(initialQueryData.path) : ''
                         );
 
-                    } else if (data.error === 'not_authorized') {
-                        $('#items_folder_path').html('<i class="fa-solid fa-folder-open-o"></i>&nbsp;' + rebuildPath(data.arborescence));
-                        
                     } else {
                         // Store query results
                         store.update(
@@ -5634,9 +5704,17 @@ $var['hidden_asterisk'] = '<i class="fa-solid fa-asterisk mr-2"></i><i class="fa
                         return false;
                     }
 
-                    // Show header info
-                    $('#card-item-visibility').html(store.get('teampassItem').itemVisibility);
-                    $('#card-item-minimum-complexity').html(store.get('teampassItem').itemMinimumComplexity);
+                    // Show header info.
+                    // For edition, clear the values first and let the backend reload the
+                    // effective folder rules to avoid displaying stale values coming from
+                    // a previously selected folder.
+                    if (actionType === 'edit') {
+                        $('#card-item-visibility').html('');
+                        $('#card-item-minimum-complexity').html('');
+                    } else {
+                        $('#card-item-visibility').html(store.get('teampassItem').itemVisibility);
+                        $('#card-item-minimum-complexity').html(store.get('teampassItem').itemMinimumComplexity);
+                    }
 
                     // Hide NEW button in case access_level <span 30
                     if (store.get('teampassItem').hasAccessLevel === 10) {
@@ -6404,8 +6482,10 @@ $var['hidden_asterisk'] = '<i class="fa-solid fa-asterisk mr-2"></i><i class="fa
                 if (actionType === 'show') {
                     loadItemHistory(store.get('teampassItem').id);
                 } else if (actionType === 'edit') {
+                    const currentItemFolderId = parseInt(data.folder, 10) || parseInt(store.get('teampassItem').tree_id, 10) || 0;
+
                     $.when(
-                        getPrivilegesOnItem(selectedFolderId, 1)
+                        getPrivilegesOnItem(currentItemFolderId, 1, 'item_edit_current_folder')
                     ).then(function(retData) {
                         if (debugJavascript === true) {
                             console.log('getPrivilegesOnItem 3');
@@ -6426,6 +6506,10 @@ $var['hidden_asterisk'] = '<i class="fa-solid fa-asterisk mr-2"></i><i class="fa
                             // Finished
                             return false;
                         } else {
+                            if (retData.folderId !== undefined && retData.folderId !== '') {
+                                $('#form-item-folder').val(String(retData.folderId));
+                            }
+
                             // Retrieve the password and synchronize the complexity meter
                             getItemPassword(
                                 'at_password_shown_edit_form',
@@ -7262,8 +7346,12 @@ $var['hidden_asterisk'] = '<i class="fa-solid fa-asterisk mr-2"></i><i class="fa
                             }
 
 
-                            // Display the visibility
+                            // Display the visibility and complexity for the current folder.
+                            // This direct edit path (pencil from the list) must stay aligned with
+                            // showItemEditForm()/refreshItemFolderTopRules so the header does not
+                            // remain empty after we cleared the stale values before opening edit.
                             $('#card-item-visibility').html(data.visibility || '<?php echo $lang->get('none'); ?>');
+                            $('#card-item-minimum-complexity').html(data.complexity === undefined ? '' : data.complexity);
 
                             // Prepare Select2
                             $('.select2').select2({
@@ -7293,7 +7381,8 @@ $var['hidden_asterisk'] = '<i class="fa-solid fa-asterisk mr-2"></i><i class="fa
                         store.update(
                             'teampassItem',
                             function(teampassItem) {
-                                teampassItem.folderId = val,
+                                teampassItem.folderId = data.folderId === undefined ? val : parseInt(data.folderId, 10),
+                                teampassItem.tree_id = data.folderId === undefined ? teampassItem.tree_id : parseInt(data.folderId, 10),
                                     teampassItem.error = data.error === undefined ? '' : data.error,
                                     teampassItem.message = data.message === undefined ? '' : data.message,
                                     teampassItem.folderComplexity = data.val === undefined ? '' : parseInt(data.val),
@@ -7312,6 +7401,7 @@ $var['hidden_asterisk'] = '<i class="fa-solid fa-asterisk mr-2"></i><i class="fa
                         resolve({
                             "error": data.error === undefined ? '' : data.error,
                             "message": data.message === undefined ? '' : data.message,
+                            "folderId": data.folderId === undefined ? val : parseInt(data.folderId, 10),
                         });
                     }
                 );

--- a/sources/folders.queries.php
+++ b/sources/folders.queries.php
@@ -391,11 +391,22 @@ if (null !== $post_type) {
                 }
             }
 
+            $isPersonalRootFolder =
+                (int) $dataFolder['parent_id'] === 0
+                && (string) $dataFolder['title'] === (string) $session->get('user-id')
+                && (int) $dataFolder['personal_folder'] === 1;
+
             // Is the parent folder changed?
             if ((int) $dataFolder['parent_id'] === (int) $inputData['parentId']) {
                 $parentChanged = false;
             } else {
                 $parentChanged = true;
+            }
+
+            if ($isPersonalRootFolder === true) {
+                $inputData['parentId'] = (int) $dataFolder['parent_id'];
+                $inputData['title'] = (string) $dataFolder['title'];
+                $parentChanged = false;
             }
 
             //check if parent folder is personal
@@ -415,7 +426,9 @@ if (null !== $post_type) {
                 $parentBloquerModification = 0;
             }
 
-            if (isset($dataParent['personal_folder']) === true && (int) $dataParent['personal_folder'] === 1) {
+            if ($isPersonalRootFolder === true) {
+                $isPersonal = 1;
+            } elseif (isset($dataParent['personal_folder']) === true && (int) $dataParent['personal_folder'] === 1) {
                 $isPersonal = 1;
             } else {
                 $isPersonal = 0;
@@ -502,17 +515,39 @@ if (null !== $post_type) {
             // Invalidate cache for users with access to this folder
             invalidateCacheForFolderUsers((int) $dataFolder['id']);
 
-            //Add complexity
-            DB::update(
-                prefixTable('misc'),
-                array(
-                    'valeur' => $inputData['complexity'],
-                    'updated_at' => time(),
-                ),
-                'intitule = %s AND type = %s',
+            // Add or update complexity row for this folder.
+            // Personal root folders can exist without a misc/complex row,
+            // so a plain UPDATE may silently affect 0 rows and leave the UI
+            // and item edition logic with a fallback complexity of 0.
+            DB::query(
+                'SELECT valeur
+                FROM ' . prefixTable('misc') . '
+                WHERE intitule = %i AND type = %s',
                 $dataFolder['id'],
                 'complex'
             );
+            if (DB::count() > 0) {
+                DB::update(
+                    prefixTable('misc'),
+                    array(
+                        'valeur' => $inputData['complexity'],
+                        'updated_at' => time(),
+                    ),
+                    'intitule = %s AND type = %s',
+                    $dataFolder['id'],
+                    'complex'
+                );
+            } else {
+                DB::insert(
+                    prefixTable('misc'),
+                    array(
+                        'type' => 'complex',
+                        'intitule' => $dataFolder['id'],
+                        'valeur' => $inputData['complexity'],
+                        'created_at' => time(),
+                    )
+                );
+            }
 
             // ensure categories are set
             handleFoldersCategories(

--- a/sources/items.queries.php
+++ b/sources/items.queries.php
@@ -1543,9 +1543,9 @@ switch ($inputData['type']) {
                         );
                         if (DB::count() > 0) {
                             // Delete associated sharekeys first
-                            DB::delete(
-                                prefixTable('sharekeys_fields'),
-                                'object_id = %i',
+                            DB::query(
+                                'DELETE FROM ' . prefixTable('sharekeys_fields') . '
+                                WHERE object_id = %i',
                                 $existingField['id']
                             );
                             // Then delete the field entry
@@ -3887,17 +3887,39 @@ switch ($inputData['type']) {
                 'id=%s',
                 $inputData['folderId']
             );
-            // update complixity value
-            DB::update(
-                prefixTable('misc'),
-                array(
-                    'valeur' => $dataReceived['complexity'],
-                    'updated_at' => time(),
-                ),
-                'intitule = %s AND type = %s',
+            // Add or update complexity value.
+            // Some personal root folders may miss the misc/complex row,
+            // therefore a plain UPDATE is not sufficient here.
+            $existingFolderComplexity = DB::queryFirstRow(
+                'SELECT increment_id
+                FROM ' . prefixTable('misc') . '
+                WHERE intitule = %i AND type = %s',
                 $inputData['folderId'],
                 'complex'
             );
+            if ($existingFolderComplexity !== null) {
+                DB::update(
+                    prefixTable('misc'),
+                    array(
+                        'valeur' => $dataReceived['complexity'],
+                        'updated_at' => time(),
+                    ),
+                    'intitule = %s AND type = %s',
+                    $inputData['folderId'],
+                    'complex'
+                );
+            } else {
+                DB::insert(
+                    prefixTable('misc'),
+                    array(
+                        'type' => 'complex',
+                        'intitule' => $inputData['folderId'],
+                        'valeur' => $dataReceived['complexity'],
+                        'created_at' => time(),
+                        'updated_at' => time(),
+                    )
+                );
+            }
             // rebuild fuild tree folder
             $tree->rebuild();
         }
@@ -4674,6 +4696,16 @@ switch ($inputData['type']) {
             }
         }
 
+        if (
+            $inputData['context'] === 'item_edit_current_folder'
+            && (int) $inputData['itemId'] > 0
+        ) {
+            $currentItemFolderId = getItemFolderIdFromDb((int) $inputData['itemId']);
+            if ($currentItemFolderId !== null) {
+                $inputData['folderId'] = $currentItemFolderId;
+            }
+        }
+
         // do query on this folder
         $data_this_folder = DB::queryFirstRow(
             'SELECT id, personal_folder, title
@@ -5019,9 +5051,9 @@ switch ($inputData['type']) {
             );
 
             // DElete sharekeys
-            DB::delete(
-                prefixTable('sharekeys_files'),
-                'object_id = %i',
+            DB::query(
+                'DELETE FROM ' . prefixTable('sharekeys_files') . '
+                WHERE object_id = %i',
                 $fileId
             );
 
@@ -5239,9 +5271,9 @@ switch ($inputData['type']) {
             // Encrypt only for the user
 
             // Remove all item sharekeys items
-            DB::delete(
-                prefixTable('sharekeys_items'),
-                'object_id = %i AND user_id NOT IN %ls',
+            DB::query(
+                'DELETE FROM ' . prefixTable('sharekeys_items') . '
+                WHERE object_id = %i AND user_id NOT IN %ls',
                 $inputData['itemId'],
                 [$session->get('user-id'), TP_USER_ID]
             );
@@ -5255,9 +5287,9 @@ switch ($inputData['type']) {
                 $inputData['itemId']
             );
             foreach ($rows as $field) {
-                DB::delete(
-                    prefixTable('sharekeys_fields'),
-                    'object_id = %i AND user_id NOT IN %ls',
+                DB::query(
+                    'DELETE FROM ' . prefixTable('sharekeys_fields') . '
+                    WHERE object_id = %i AND user_id NOT IN %ls',
                     $field['id'],
                     [$session->get('user-id'), TP_USER_ID]
                 );
@@ -5272,9 +5304,9 @@ switch ($inputData['type']) {
                 $inputData['itemId']
             );
             foreach ($rows as $attachment) {
-                DB::delete(
-                    prefixTable('sharekeys_files'),
-                    'object_id = %i AND user_id NOT IN %ls',
+                DB::query(
+                    'DELETE FROM ' . prefixTable('sharekeys_files') . '
+                    WHERE object_id = %i AND user_id NOT IN %ls',
                     $attachment['id'],
                     [$session->get('user-id'), TP_USER_ID]
                 );
@@ -5566,9 +5598,9 @@ switch ($inputData['type']) {
                     // Encrypt only for the user
 
                     // Remove all item sharekeys items
-                    DB::delete(
-                        prefixTable('sharekeys_items'),
-                        'object_id = %i AND user_id NOT IN %ls',
+                    DB::query(
+                        'DELETE FROM ' . prefixTable('sharekeys_items') . '
+                        WHERE object_id = %i AND user_id NOT IN %ls',
                         $item_id,
                         [$session->get('user-id'), TP_USER_ID, API_USER_ID, OTV_USER_ID,SSH_USER_ID]
                     );
@@ -5582,9 +5614,9 @@ switch ($inputData['type']) {
                         $item_id
                     );
                     foreach ($rows as $field) {
-                        DB::delete(
-                            prefixTable('sharekeys_fields'),
-                            'object_id = %i AND user_id != %i',
+                        DB::query(
+                            'DELETE FROM ' . prefixTable('sharekeys_fields') . '
+                            WHERE object_id = %i AND user_id != %i',
                             $field['id'],
                             $session->get('user-id')
                         );
@@ -5599,9 +5631,9 @@ switch ($inputData['type']) {
                         $item_id
                     );
                     foreach ($rows as $attachment) {
-                        DB::delete(
-                            prefixTable('sharekeys_files'),
-                            'object_id = %i AND user_id != %i',
+                        DB::query(
+                            'DELETE FROM ' . prefixTable('sharekeys_files') . '
+                            WHERE object_id = %i AND user_id != %i',
                             $attachment['id'],
                             $session->get('user-id')
                         );
@@ -7452,6 +7484,13 @@ function fileFormatImage($ext)
 function getCurrentAccessRights(int $userId, int $itemId, int $treeId, string $action = ''): array
 {
     $session = SessionManager::getSession();
+
+    if ($itemId > 0) {
+        $currentTreeId = getItemFolderIdFromDb($itemId);
+        if ($currentTreeId !== null) {
+            $treeId = $currentTreeId;
+        }
+    }
     
     // Check if the item is locked and whether the current user can edit it
     $editionLock = isItemLocked($itemId, $session, $userId, $action);

--- a/sources/main.functions.php
+++ b/sources/main.functions.php
@@ -3927,9 +3927,9 @@ function storeUsersShareKey(
             );
         } else {
             // No eligible users found: remove all sharekeys for this object
-            DB::delete(
-                prefixTable($object_name),
-                'object_id = %i',
+            DB::query(
+                'DELETE FROM ' . prefixTable($object_name) . '
+                WHERE object_id = %i',
                 $post_object_id
             );
         }
@@ -4137,33 +4137,33 @@ function deleteUserObjetsKeys(int $userId, array $SETTINGS = []): bool
     loadClasses('DB');
 
     // Remove all item sharekeys items except personal items
-    DB::delete(
-        prefixTable('sharekeys_items'),
-        'user_id = %i AND object_id NOT IN (SELECT i.id FROM ' . prefixTable('items') . ' AS i WHERE i.perso = 1)',
+    DB::query(
+        'DELETE FROM ' . prefixTable('sharekeys_items') . '
+        WHERE user_id = %i AND object_id NOT IN (SELECT i.id FROM ' . prefixTable('items') . ' AS i WHERE i.perso = 1)',
         $userId
     );
     // Remove all item sharekeys files except personal items
-    DB::delete(
-        prefixTable('sharekeys_files'),
-        'user_id = %i AND object_id NOT IN (SELECT i.id FROM ' . prefixTable('items') . ' AS i WHERE i.perso = 1)',
+    DB::query(
+        'DELETE FROM ' . prefixTable('sharekeys_files') . '
+        WHERE user_id = %i AND object_id NOT IN (SELECT i.id FROM ' . prefixTable('items') . ' AS i WHERE i.perso = 1)',
         $userId
     );
     // Remove all item sharekeys fields except personal items
-    DB::delete(
-        prefixTable('sharekeys_fields'),
-        'user_id = %i AND object_id NOT IN (SELECT i.id FROM ' . prefixTable('items') . ' AS i WHERE i.perso = 1)',
+    DB::query(
+        'DELETE FROM ' . prefixTable('sharekeys_fields') . '
+        WHERE user_id = %i AND object_id NOT IN (SELECT i.id FROM ' . prefixTable('items') . ' AS i WHERE i.perso = 1)',
         $userId
     );
     // Remove all item sharekeys logs except personal items
-    DB::delete(
-        prefixTable('sharekeys_logs'),
-        'user_id = %i AND object_id NOT IN (SELECT i.id FROM ' . prefixTable('items') . ' AS i WHERE i.perso = 1)',
+    DB::query(
+        'DELETE FROM ' . prefixTable('sharekeys_logs') . '
+        WHERE user_id = %i AND object_id NOT IN (SELECT i.id FROM ' . prefixTable('items') . ' AS i WHERE i.perso = 1)',
         $userId
     );
     // Remove all item sharekeys suggestions except personal items
-    DB::delete(
-        prefixTable('sharekeys_suggestions'),
-        'user_id = %i AND object_id NOT IN (SELECT i.id FROM ' . prefixTable('items') . ' AS i WHERE i.perso = 1)',
+    DB::query(
+        'DELETE FROM ' . prefixTable('sharekeys_suggestions') . '
+        WHERE user_id = %i AND object_id NOT IN (SELECT i.id FROM ' . prefixTable('items') . ' AS i WHERE i.perso = 1)',
         $userId
     );
     return false;
@@ -5613,30 +5613,30 @@ function purgeUnnecessaryKeysForUser(int $user_id=0)
     );
     if (count($personalItems) > 0) {
         // Item keys
-        DB::delete(
-            prefixTable('sharekeys_items'),
-            'object_id IN %li AND user_id NOT IN %ls',
+        DB::query(
+            'DELETE FROM ' . prefixTable('sharekeys_items') . '
+            WHERE object_id IN %li AND user_id NOT IN %ls',
             $personalItems,
             [$user_id, TP_USER_ID, API_USER_ID, OTV_USER_ID,SSH_USER_ID]
         );
         // Files keys
-        DB::delete(
-            prefixTable('sharekeys_files'),
-            'object_id IN %li AND user_id NOT IN %ls',
+        DB::query(
+            'DELETE FROM ' . prefixTable('sharekeys_files') . '
+            WHERE object_id IN %li AND user_id NOT IN %ls',
             $personalItems,
             [$user_id, TP_USER_ID, API_USER_ID, OTV_USER_ID,SSH_USER_ID]
         );
         // Fields keys
-        DB::delete(
-            prefixTable('sharekeys_fields'),
-            'object_id IN %li AND user_id NOT IN %ls',
+        DB::query(
+            'DELETE FROM ' . prefixTable('sharekeys_fields') . '
+            WHERE object_id IN %li AND user_id NOT IN %ls',
             $personalItems,
             [$user_id, TP_USER_ID, API_USER_ID, OTV_USER_ID,SSH_USER_ID]
         );
         // Logs keys
-        DB::delete(
-            prefixTable('sharekeys_logs'),
-            'object_id IN %li AND user_id NOT IN %ls',
+        DB::query(
+            'DELETE FROM ' . prefixTable('sharekeys_logs') . '
+            WHERE object_id IN %li AND user_id NOT IN %ls',
             $personalItems,
             [$user_id, TP_USER_ID, API_USER_ID, OTV_USER_ID,SSH_USER_ID]
         );
@@ -6130,29 +6130,55 @@ function EnsurePersonalItemHasOnlyKeysForOwner(int $userId, int $itemId): bool
     }
 
     // Delete all keys for this item except for the owner and TeamPass system user
-    DB::delete(
-        prefixTable('sharekeys_items'),
-        'object_id = %i AND user_id NOT IN %ls',
+    // Some TeamPass tables use `id`, others use `increment_id` as object identifier.
+    // Detect the real PK column at runtime for dependent tables to avoid SQL errors on upgraded instances.
+    $resolveObjectIdColumn = static function (string $tableName): string {
+        DB::query(
+            'SHOW COLUMNS FROM ' . prefixTable($tableName) . ' LIKE %s',
+            'increment_id'
+        );
+        if (DB::count() > 0) {
+            return 'increment_id';
+        }
+
+        DB::query(
+            'SHOW COLUMNS FROM ' . prefixTable($tableName) . ' LIKE %s',
+            'id'
+        );
+        if (DB::count() > 0) {
+            return 'id';
+        }
+
+        return 'id';
+    };
+
+    $filesObjectIdColumn = $resolveObjectIdColumn('files');
+    $categoriesItemsObjectIdColumn = $resolveObjectIdColumn('categories_items');
+    $logItemsObjectIdColumn = $resolveObjectIdColumn('log_items');
+
+    DB::query(
+        'DELETE FROM ' . prefixTable('sharekeys_items') . '
+        WHERE object_id = %i AND user_id NOT IN %ls',
         $itemId,
-        [$userId, TP_USER_ID, API_USER_ID, OTV_USER_ID,SSH_USER_ID]
+        [$userId, TP_USER_ID, API_USER_ID, OTV_USER_ID, SSH_USER_ID]
     );
-    DB::delete(
-        prefixTable('sharekeys_files'),
-        'object_id IN (SELECT id FROM '.prefixTable('files').' WHERE id_item = %i) AND user_id NOT IN %ls',
+    DB::query(
+        'DELETE FROM ' . prefixTable('sharekeys_files') . '
+        WHERE object_id IN (SELECT ' . $filesObjectIdColumn . ' FROM ' . prefixTable('files') . ' WHERE id_item = %i) AND user_id NOT IN %ls',
         $itemId,
-        [$userId, TP_USER_ID, API_USER_ID, OTV_USER_ID,SSH_USER_ID]
+        [$userId, TP_USER_ID, API_USER_ID, OTV_USER_ID, SSH_USER_ID]
     );
-    DB::delete(
-        prefixTable('sharekeys_fields'),
-        'object_id IN (SELECT id FROM '.prefixTable('categories_items').' WHERE item_id = %i) AND user_id NOT IN %ls',
+    DB::query(
+        'DELETE FROM ' . prefixTable('sharekeys_fields') . '
+        WHERE object_id IN (SELECT ' . $categoriesItemsObjectIdColumn . ' FROM ' . prefixTable('categories_items') . ' WHERE item_id = %i) AND user_id NOT IN %ls',
         $itemId,
-        [$userId, TP_USER_ID, API_USER_ID, OTV_USER_ID,SSH_USER_ID]
+        [$userId, TP_USER_ID, API_USER_ID, OTV_USER_ID, SSH_USER_ID]
     );
-    DB::delete(
-        prefixTable('sharekeys_logs'),
-        'object_id IN (SELECT id FROM '.prefixTable('log_items').' WHERE id_item = %i) AND user_id NOT IN %ls',
+    DB::query(
+        'DELETE FROM ' . prefixTable('sharekeys_logs') . '
+        WHERE object_id IN (SELECT ' . $logItemsObjectIdColumn . ' FROM ' . prefixTable('log_items') . ' WHERE id_item = %i) AND user_id NOT IN %ls',
         $itemId,
-        [$userId, TP_USER_ID, API_USER_ID, OTV_USER_ID,SSH_USER_ID]
+        [$userId, TP_USER_ID, API_USER_ID, OTV_USER_ID, SSH_USER_ID]
     );
 
     return true;


### PR DESCRIPTION
<h2>Summary</h2>
<p>
This PR fixes several regressions introduced around personal folder handling in 3.1.7.2,
and makes the folder complexity displayed during item edition reliable for both personal
and shared folders.
</p>

<h2>Problems addressed</h2>
<ul>
  <li>
    Saving an item from a personal folder could fail with a HTTP 500 error.
  </li>
  <li>
    Updating the personal root folder complexity could make the folder disappear from the UI.
  </li>
  <li>
    The complexity shown in the item edit header could display stale information from a previously visited folder.
  </li>
  <li>
    The two edit entry paths were not aligned:
    <ul>
      <li>open item, then switch to edit</li>
      <li>direct edit from the pencil icon in the items list</li>
    </ul>
  </li>
</ul>

<h2>Root causes</h2>
<ul>
  <li>
    Personal item save cleanup was using <code>DB::delete()</code> on <code>sharekeys_*</code> tables,
    while those tables rely on <code>increment_id</code> instead of a standard <code>id</code> column.
  </li>
  <li>
    Personal root folder updates did not preserve the specific semantics of the personal root
    (<code>parent_id = 0</code>, personal flag enabled, title tied to the owner identifier).
  </li>
  <li>
    Folder complexity persistence relied on a simple update path and was not robust when the
    related <code>misc</code> row did not already exist.
  </li>
  <li>
    The item edit UI could still reuse stale client-side state when moving quickly between folders
    or when editing an item immediately after a move.
  </li>
</ul>

<h2>Changes included</h2>

<h3>1. Fix personal item save cleanup</h3>
<p>
In <code>sources/main.functions.php</code>, cleanup logic for personal items was hardened:
</p>
<ul>
  <li>
    Replaced unsafe <code>DB::delete()</code> calls on <code>sharekeys_items</code>,
    <code>sharekeys_files</code>, <code>sharekeys_fields</code> and <code>sharekeys_logs</code>
    with explicit SQL <code>DELETE</code> statements.
  </li>
  <li>
    Kept cleanup restricted to the current owner so that personal items only retain valid owner keys.
  </li>
  <li>
    Avoided schema assumptions that can break on upgraded databases.
  </li>
</ul>

<h3>2. Restore safe handling of the personal root folder</h3>
<p>
In <code>sources/folders.queries.php</code>, the folder update flow now handles the personal root correctly:
</p>
<ul>
  <li>
    Preserves the personal root identity instead of treating it like a regular shared folder.
  </li>
  <li>
    Prevents accidental loss of the personal marker that could make the folder disappear from the UI.
  </li>
  <li>
    Keeps the root folder structure safe while still allowing complexity updates.
  </li>
</ul>

<h3>3. Persist folder complexity reliably</h3>
<p>
In <code>sources/folders.queries.php</code>, folder complexity persistence was made robust:
</p>
<ul>
  <li>
    Uses an update-or-insert approach for the <code>misc</code> entry storing folder complexity.
  </li>
  <li>
    Ensures that personal root folders and subfolders always keep a consistent complexity value.
  </li>
</ul>

<h3>4. Make item edit complexity/visibility trustworthy</h3>
<p>
In <code>sources/items.js.php</code> and <code>sources/items.queries.php</code>, the item edit flow was aligned
to use the real current folder of the item instead of relying on stale client-side state.
</p>
<ul>
  <li>
    When opening item edition, the UI now refreshes folder rules from the backend.
  </li>
  <li>
    Direct edition from the pencil icon and edition after opening item details now behave consistently.
  </li>
  <li>
    The displayed folder visibility and minimum complexity are refreshed using the actual current folder.
  </li>
  <li>
    Added protection against outdated asynchronous responses overriding the latest folder rules in the UI.
  </li>
</ul>

<h3>5. Prevent front-end crashes on unauthorized/reloaded folder states</h3>
<p>
In <code>sources/items.js.php</code>, the items listing flow was hardened so the UI no longer tries to parse
missing JSON payloads in edge cases such as <code>not_authorized</code> responses.
</p>

<h2>WebSocket impact</h2>
<p>
This PR does not modify the WebSocket event model itself.
</p>
<ul>
  <li>
    No change was made to item or folder event emission logic.
  </li>
  <li>
    No change was made to the client-side WebSocket synchronization flow.
  </li>
  <li>
    The changes are focused on personal folder save cleanup, folder complexity persistence,
    and reliable folder rule refresh during item edition.
  </li>
</ul>
<p>
Because the edit flow now reloads the actual folder rules from the backend more reliably,
this change should reduce stale UI situations rather than interfere with WebSocket behavior.
</p>

<h2>Files updated</h2>
<ul>
  <li><code>sources/main.functions.php</code></li>
  <li><code>sources/folders.queries.php</code></li>
  <li><code>sources/items.queries.php</code></li>
  <li><code>sources/items.js.php</code></li>
</ul>

<h2>Language files</h2>
<p>
No language string was added or modified.
</p>

<h2>Manual test coverage</h2>
<ul>
  <li>Save an item located in the personal root folder</li>
  <li>Save an item located in a personal subfolder</li>
  <li>Update personal root folder complexity</li>
  <li>Update personal subfolder complexity</li>
  <li>Open item then switch to edit</li>
  <li>Edit directly from the pencil icon in the items list</li>
  <li>Navigate quickly between folders with different complexity levels</li>
  <li>Move an item and edit it immediately afterward</li>
  <li>Verify shared folder behavior remains consistent</li>
  <li>Review WebSocket-related paths for regressions</li>
</ul>

<h2>Expected result</h2>
<ul>
  <li>No more HTTP 500 when saving personal items</li>
  <li>Personal root folder no longer disappears after complexity updates</li>
  <li>Folder complexity shown during edition is accurate and consistent</li>
  <li>Shared and personal edit flows behave the same way from the user perspective</li>
</ul>