### PR TITLE
Add admin-only sidebar update badge for new TeamPass releases

### DIFF
--- a/includes/core/load.js.php
+++ b/includes/core/load.js.php
@@ -111,6 +111,59 @@ if (
         'userOauth2Info', ''
     );
 
+    /**
+     * Load the TeamPass latest release badge in the sidebar for administrators.
+     *
+     * @returns {void}
+     */
+    function loadTeampassSidebarVersionBadge() {
+        const $badge = $('#tp-sidebar-version-badge');
+
+        if ($badge.length === 0) {
+            return;
+        }
+
+        $.post(
+            'sources/admin.queries.php',
+            {
+                type: 'get_teampass_latest_release',
+                key: '<?php echo $session->get('key'); ?>'
+            },
+            function(data) {
+                try {
+                    data = prepareExchangedData(data, 'decode', '<?php echo $session->get('key'); ?>');
+                } catch (error) {
+                    $badge.addClass('d-none').tooltip('dispose');
+                    return;
+                }
+
+                if (
+                    data.error === true
+                    || data.has_update !== true
+                    || typeof data.latest_version !== 'string'
+                    || data.latest_version.length === 0
+                    || typeof data.release_url !== 'string'
+                    || data.release_url.length === 0
+                ) {
+                    $badge.addClass('d-none').tooltip('dispose');
+                    return;
+                }
+
+                let tooltipText = <?php echo json_encode($lang->get('admin_new_version_available')); ?>;
+                tooltipText = tooltipText.replace('%s', data.latest_version);
+
+                $badge
+                    .text(<?php echo json_encode($lang->get('admin_update_badge')); ?>)
+                    .attr('href', data.release_url)
+                    .attr('title', tooltipText)
+                    .attr('aria-label', tooltipText)
+                    .removeClass('d-none')
+                    .tooltip('dispose')
+                    .tooltip({container: 'body'});
+            }
+        );
+    }
+
 
     $(document).ready(function() {
         // Don't redirect in some conditions
@@ -623,6 +676,8 @@ if (
 
     // Show tooltips
     $('.infotip').tooltip();
+
+    loadTeampassSidebarVersionBadge();
 
     // Sidebar redirection
     $('.nav-link').click(function() {

--- a/includes/language/english.php
+++ b/includes/language/english.php
@@ -2092,4 +2092,6 @@ return array(
     'password_generation_not_compliant_with_folder_complexity' => 'The selected password generation options do not allow reaching the folder required complexity. Please adjust the options or the length and try again.',
     'email_subject_on_user_lock' => '[TeamPass] A user account has been locked',
     'email_body_on_user_lock' => 'Hello,<br><br>This is a generated email from TeamPass.<br><br>User account <b>#tp_user#</b> has been locked by the anti brute force protection on #tp_date# at #tp_time#.<br><br>Details:<ul><li>Name: #tp_name#</li><li>Email: #tp_email#</li><li>Source IP: #tp_ip#</li><li>Automatic unlock at: #tp_unlock_at#</li></ul><br>Regards.',
-    );
+    'admin_update_badge' => 'Update',
+    'admin_new_version_available' => 'version %s available',    
+);

--- a/includes/language/french.php
+++ b/includes/language/french.php
@@ -2097,5 +2097,6 @@ return array(
     'network_security_remote_addr' => 'Adresse distante du client',
     'email_subject_on_user_lock' => '[TeamPass] Un compte utilisateur a été bloqué',
     'email_body_on_user_lock' => 'Bonjour,<br><br>Ceci est un email généré par TeamPass.<br><br>Le compte utilisateur <b>#tp_user#</b> a été bloqué par la protection anti brute force le #tp_date# à #tp_time#.<br><br>Détails :<ul><li>Nom : #tp_name#</li><li>Email : #tp_email#</li><li>Adresse IP source : #tp_ip#</li><li>Déblocage automatique prévu : #tp_unlock_at#</li></ul><br>Cordialement.',
-
+    'admin_update_badge' => 'Update',
+    'admin_new_version_available' => 'version %s disponible',
 );

--- a/index.php
+++ b/index.php
@@ -403,10 +403,23 @@ if ((null === $session->get('user-validite_pw') || empty($session->get('user-val
             <!-- Main Sidebar Container -->
             <aside class="main-sidebar sidebar-dark-primary elevation-4">
                 <!-- Brand Logo -->
-                <a href="<?php echo $cpassman_url . '/index.php?page=' . ((int) $session_user_admin === 1 ? 'admin' : 'items'); ?>" class="brand-link">
-                    <img src="includes/images/teampass-logo2-home.png" alt="Teampass Logo" class="brand-image">
-                    <span class="brand-text font-weight-light"><?php echo TP_TOOL_NAME; ?></span>
-                </a>
+                <div class="brand-link tp-brand-link">
+                    <a href="<?php echo $cpassman_url . '/index.php?page=' . ((int) $session_user_admin === 1 ? 'admin' : 'items'); ?>" class="tp-brand-home-link">
+                        <img src="includes/images/teampass-logo2-home.png" alt="Teampass Logo" class="brand-image">
+                        <span class="brand-text font-weight-light"><?php echo TP_TOOL_NAME; ?></span>
+                    </a>
+                    <?php if ((int) $session_user_admin === 1) { ?>
+                    <a
+                        id="tp-sidebar-version-badge"
+                        href="#"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        class="tp-sidebar-version-badge infotip d-none"
+                        title=""
+                        aria-label=""
+                    ></a>
+                    <?php } ?>
+                </div>
 
                 <!-- Sidebar -->
                 <div class="sidebar">
@@ -1233,6 +1246,83 @@ if ((null === $session->get('user-validite_pw') || empty($session->get('user-val
     <script type="text/javascript" src="plugins/bootstrap-add-clear/bootstrap-add-clear.min.js?v=<?php echo TP_VERSION . '.' . TP_VERSION_MINOR; ?>"></script>
     <!-- DOMPurify -->
     <script type="text/javascript" src="plugins/DOMPurify/purify.min.js?v=<?php echo TP_VERSION . '.' . TP_VERSION_MINOR; ?>"></script>
+
+    <style>
+        .tp-brand-link {
+            display: flex;
+            align-items: center;
+            gap: 0.4rem;
+            overflow: hidden;
+        }
+
+        .tp-brand-home-link {
+            display: flex;
+            align-items: center;
+            min-width: 0;
+            flex: 1 1 auto;
+            overflow: hidden;
+            color: inherit;
+            text-decoration: none !important;
+        }
+
+        .tp-brand-home-link:hover,
+        .tp-brand-home-link:focus {
+            color: inherit;
+            text-decoration: none !important;
+        }
+
+        .tp-brand-home-link .brand-image {
+            float: none;
+            position: static;
+            margin: 0 0.5rem 0 0;
+            flex: 0 0 auto;
+        }
+
+        .tp-brand-home-link .brand-text {
+            display: block;
+            min-width: 0;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+        }
+
+        .tp-sidebar-version-badge {
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            min-height: 18px;
+            padding: 2px 7px;
+            margin-right: 8px;
+            border-radius: 999px;
+            flex: 0 0 auto;
+            font-size: 11.5px;
+            font-weight: 600;
+            line-height: 1;
+            white-space: nowrap;
+            color: #ffffff !important;
+            background: #17a2b8;
+            box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.08);
+            text-decoration: none !important;
+        }
+
+        .tp-sidebar-version-badge:hover,
+        .tp-sidebar-version-badge:focus {
+            color: #ffffff !important;
+            background: #138496;
+            text-decoration: none !important;
+        }
+
+        .sidebar-collapse .tp-sidebar-version-badge,
+        .sidebar-closed .tp-sidebar-version-badge {
+            display: none !important;
+        }
+
+        @media (max-width: 767.98px) {
+            .tp-sidebar-version-badge {
+                display: none !important;
+            }
+        }
+    </style>
 
     <?php
     $get['page'] = $request->query->filter('page', null, FILTER_SANITIZE_SPECIAL_CHARS);

--- a/sources/admin.queries.php
+++ b/sources/admin.queries.php
@@ -4298,6 +4298,178 @@ case 'get_extension_licence_info':
     break;
 
 // ========================================
+// TEAMPASS LATEST RELEASE BADGE
+// ========================================
+
+case 'get_teampass_latest_release':
+    if ($post_key !== $session->get('key')) {
+        echo prepareExchangedData(
+            [
+                'error' => true,
+                'message' => $lang->get('key_is_not_correct'),
+            ],
+            'encode'
+        );
+        break;
+    }
+
+    if ((int) $session->get('user-admin') !== 1) {
+        echo prepareExchangedData(
+            [
+                'error' => true,
+                'message' => $lang->get('error_not_allowed_to'),
+            ],
+            'encode'
+        );
+        break;
+    }
+
+    $currentVersion = TP_VERSION . '.' . TP_VERSION_MINOR;
+
+    $cacheRaw = DB::queryFirstField(
+        'SELECT valeur
+        FROM ' . prefixTable('misc') . '
+        WHERE type = %s
+        AND intitule = %s',
+        'admin',
+        'teampass_latest_release_cache'
+    );
+
+    $cacheAt = (int) DB::queryFirstField(
+        'SELECT valeur
+        FROM ' . prefixTable('misc') . '
+        WHERE type = %s
+        AND intitule = %s',
+        'admin',
+        'teampass_latest_release_cache_at'
+    );
+
+    $cachedResult = is_string($cacheRaw) && $cacheRaw !== '' ? json_decode($cacheRaw, true) : null;
+    $cacheIsValid = is_array($cachedResult);
+    $cacheTtl = $cacheIsValid === true && ($cachedResult['error'] ?? false) === false ? 43200 : 3600;
+
+    if ($cacheIsValid === true && (time() - $cacheAt) < $cacheTtl) {
+        echo prepareExchangedData($cachedResult, 'encode');
+        break;
+    }
+
+    $storeLatestReleaseCache = static function (array $result): void {
+        DB::query(
+            'INSERT INTO ' . prefixTable('misc') . ' (type, intitule, valeur) VALUES (%s, %s, %s)
+             ON DUPLICATE KEY UPDATE valeur = VALUES(valeur)',
+            'admin',
+            'teampass_latest_release_cache',
+            (string) json_encode($result, JSON_UNESCAPED_SLASHES)
+        );
+
+        DB::query(
+            'INSERT INTO ' . prefixTable('misc') . ' (type, intitule, valeur) VALUES (%s, %s, %s)
+             ON DUPLICATE KEY UPDATE valeur = VALUES(valeur)',
+            'admin',
+            'teampass_latest_release_cache_at',
+            (string) time()
+        );
+    };
+
+    $fallbackResult = [
+        'error' => false,
+        'has_update' => false,
+        'current_version' => $currentVersion,
+        'latest_version' => '',
+        'release_url' => '',
+    ];
+
+    if (function_exists('curl_init') === false) {
+        if ($cacheIsValid === true) {
+            echo prepareExchangedData($cachedResult, 'encode');
+            break;
+        }
+
+        $storeLatestReleaseCache($fallbackResult);
+        echo prepareExchangedData($fallbackResult, 'encode');
+        break;
+    }
+
+    $curlHandle = curl_init('https://api.github.com/repos/nilsteampassnet/TeamPass/releases/latest');
+    if ($curlHandle === false) {
+        if ($cacheIsValid === true) {
+            echo prepareExchangedData($cachedResult, 'encode');
+            break;
+        }
+
+        $storeLatestReleaseCache($fallbackResult);
+        echo prepareExchangedData($fallbackResult, 'encode');
+        break;
+    }
+
+    curl_setopt_array($curlHandle, [
+        CURLOPT_RETURNTRANSFER => true,
+        CURLOPT_CONNECTTIMEOUT => 3,
+        CURLOPT_TIMEOUT => 6,
+        CURLOPT_HTTPHEADER => [
+            'Accept: application/vnd.github+json',
+            'X-GitHub-Api-Version: 2022-11-28',
+            'User-Agent: TeamPass/' . $currentVersion,
+        ],
+        CURLOPT_SSL_VERIFYPEER => true,
+        CURLOPT_SSL_VERIFYHOST => 2,
+        CURLOPT_FAILONERROR => false,
+    ]);
+
+    $responseBody = curl_exec($curlHandle);
+    $httpCode = (int) curl_getinfo($curlHandle, CURLINFO_RESPONSE_CODE);
+    curl_close($curlHandle);
+
+    if ($responseBody === false || $httpCode !== 200) {
+        if ($cacheIsValid === true) {
+            echo prepareExchangedData($cachedResult, 'encode');
+            break;
+        }
+
+        $storeLatestReleaseCache($fallbackResult);
+        echo prepareExchangedData($fallbackResult, 'encode');
+        break;
+    }
+
+    $releaseData = json_decode($responseBody, true);
+    if (is_array($releaseData) === false) {
+        if ($cacheIsValid === true) {
+            echo prepareExchangedData($cachedResult, 'encode');
+            break;
+        }
+
+        $storeLatestReleaseCache($fallbackResult);
+        echo prepareExchangedData($fallbackResult, 'encode');
+        break;
+    }
+
+    $tagName = isset($releaseData['tag_name']) && is_string($releaseData['tag_name']) === true
+        ? trim($releaseData['tag_name'])
+        : '';
+    $latestVersion = $tagName !== '' ? preg_replace('/^v/i', '', $tagName) : '';
+    $latestVersion = is_string($latestVersion) === true ? trim($latestVersion) : '';
+
+    $releaseUrl = isset($releaseData['html_url']) && is_string($releaseData['html_url']) === true
+        ? trim($releaseData['html_url'])
+        : '';
+
+    if ($releaseUrl === '' && $tagName !== '') {
+        $releaseUrl = 'https://github.com/nilsteampassnet/TeamPass/releases/tag/' . rawurlencode($tagName);
+    }
+
+    $result = [
+        'error' => false,
+        'has_update' => $latestVersion !== '' && version_compare($currentVersion, $latestVersion, '<'),
+        'current_version' => $currentVersion,
+        'latest_version' => $latestVersion,
+        'release_url' => $releaseUrl,
+    ];
+
+    $storeLatestReleaseCache($result);
+    echo prepareExchangedData($result, 'encode');
+    break;
+
+// ========================================
 // WEBSOCKET STATUS & CONTROL
 // ========================================
 


### PR DESCRIPTION
<h2>Description</h2>
<p>
This PR adds a compact update badge in the left sidebar header, next to the TeamPass logo/title,
to inform administrators when a newer TeamPass release is available.
</p>

<img width="529" height="288" alt="image" src="https://github.com/user-attachments/assets/7837209a-febe-4908-bc0f-9a03b2b903f6" />


<h2>What was implemented</h2>
<ul>
  <li>A small <strong>Update</strong> badge is displayed in the sidebar header area, next to the TeamPass brand.</li>
  <li>The badge is visible <strong>only for administrators</strong>.</li>
  <li>The badge is shown on <strong>all pages</strong>, not only on the admin dashboard.</li>
  <li>On hover, a tooltip displays the detected available version in the format <code>version x.x.x available</code>.</li>
  <li>On click, the badge redirects to the matching GitHub release page for that version.</li>
</ul>

<h2>Technical details</h2>
<ul>
  <li><code>index.php</code>: added the sidebar badge markup and styling.</li>
  <li><code>load.js.php</code>: added the client-side loader executed on page load.</li>
  <li><code>admin.queries.php</code>: added the backend action that retrieves the latest TeamPass release information.</li>
</ul>

<h2>Behavior</h2>
<ul>
  <li>If a newer release is detected, the badge is displayed.</li>
  <li>If the current version is already the latest one, nothing is displayed.</li>
  <li>If the instance cannot reach GitHub, the badge stays hidden and no visible UI error is generated.</li>
  <li>The release lookup uses caching to avoid unnecessary repeated remote calls.</li>
</ul>

<h2>UI/UX choices</h2>
<ul>
  <li>The badge was intentionally kept very small and lightweight to stay aligned with the current sidebar design.</li>
  <li>No icon was added in the badge in order to keep it compact and avoid overflow in the brand area.</li>
  <li>The final size and spacing were adjusted after visual testing to avoid being too close to the right edge.</li>
</ul>

<h2>Validation status</h2>
<ul>
  <li>Visual rendering and positioning were tested.</li>
  <li>The display logic was validated with a forced test value.</li>
  <li>A natural real-world display condition still depends on having an actually newer public release available, so an additional validation by maintainers is recommended.</li>
</ul>

<h2>Impact</h2>
<ul>
  <li>No impact for non-admin users.</li>
  <li>No change in behavior when no update is available.</li>
  <li>No blocking behavior if the remote check fails.</li>
</ul>