### PR TITLE
Fix split view layout after saving an item

### DIFF
--- a/includes/language/french.php
+++ b/includes/language/french.php
@@ -471,7 +471,7 @@ return array(
     'settings_upload_imageresize_options_w' => 'Redimensionnement des Images en Largeur (en pixels)',
     'settings_upload_imageresize_options_h' => 'Redimensionnement des Images en Hauteur (en pixels)',
     'settings_upload_imageresize_options_q' => 'Qualité de l’Image redimensionnée',
-    'settings_importing' => 'Permettre d’importer des données depuis des fichiers CVS/KeyPass',
+    'settings_importing' => 'Permettre d’importer des données depuis des fichiers CSV/KeePass',
     'db_items_edited' => 'Éléments actuellement en cours d’édition',
     'item_edition_start_hour' => 'Édition démarrée depuis',
     'settings_delay_for_item_edition' => 'Après quelle durée, en minutes, l’édition d’un Élément est-elle considérée comme échouée',

--- a/pages/items.js.php
+++ b/pages/items.js.php
@@ -5715,19 +5715,40 @@ $bip39Wordlist = loadBip39Wordlist($session->get('user-language') ?? 'english');
 
                         // show split mode or not
                         if (store.get('teampassUser').split_view_mode === 1) {
-                            // Optionnal splited item view
-                            $('#folder-tree-container').removeClass('col-md-5').addClass('col-md-3');
-                            $('#items-list-container').removeClass('col-md-7').addClass('col-md-4');
-                            $('#items-details-container').removeClass('col-md-12').addClass('col-md-5');
+                            // Optional split item view
+                            $('#folders-tree-card').removeClass('hidden');
+
+                            $('#folder-tree-container')
+                                .removeClass('hidden col-md-5')
+                                .addClass('col-md-3');
+
+                            $('#items-list-container')
+                                .removeClass('hidden col-md-7')
+                                .addClass('col-md-4');
+
+                            $('#items-details-container')
+                                .removeClass('hidden col-md-12')
+                                .addClass('col-md-5');
+
                             // Reduce menu size and trigger event listener
                             if ($('body').hasClass('sidebar-collapse') === false) {
                                 $('a[data-widget="pushmenu"]').click();
                             }
                         } else {
-                            // Defaut = full screen item view
-                            $('#folder-tree-container').removeClass('col-md-5').addClass('hidden');
-                            $('#items-list-container').removeClass('col-md-7').addClass('hidden');
-                            $('#items-details-container').removeClass('col-md-5').addClass('col-md-12');
+                            // Default = full screen item view
+                            $('#folder-tree-container')
+                                .removeClass('col-md-3')
+                                .addClass('col-md-5')
+                                .addClass('hidden');
+
+                            $('#items-list-container')
+                                .removeClass('col-md-4')
+                                .addClass('col-md-7')
+                                .addClass('hidden');
+
+                            $('#items-details-container')
+                                .removeClass('col-md-5')
+                                .addClass('col-md-12');
                         }
                         
                         // Show item details


### PR DESCRIPTION
<p>This PR fixes a split view layout issue introduced when saving an item from the edit form.</p>

<h3>Summary</h3>
<p>
When split view mode is enabled in the user profile, saving an item could leave the details panel rendered on the far left side of the page,
hiding the items list instead of restoring the expected 3-column layout.
</p>

<h3>Root cause</h3>
<p>
After save, the UI temporarily switches to a near full-screen item view by hiding the tree and items list containers.
When the item details view is then reloaded in split mode, the layout classes were restored, but the hidden state of the left columns was not.
As a result, the details container became the first visible column and appeared on the left.
</p>

<h3>Fix</h3>
<ul>
    <li>When split view mode is active, explicitly restore the visibility of the tree and items list containers before applying the split layout classes.</li>
    <li>Keep the current wide edit/create form behavior unchanged, as it provides a better editing experience than a narrow split layout.</li>
</ul>

<h3>Result</h3>
<p>
After saving an item in split view mode, the page now correctly returns to the expected layout:
tree on the left, items list in the middle, and item details on the right.
</p>

<h3>Testing</h3>
<ul>
    <li>Split view enabled</li>
    <li>Open an item in edit mode</li>
    <li>Save changes</li>
    <li>Confirmed that the details panel is restored on the right and the items list remains visible</li>
</ul>

<p>
Also includes a very small French translation correction.
</p>