### PR TITLE
FIX : Persist browser extension FQDN on first API activation

### DIFF
--- a/sources/admin.queries.php
+++ b/sources/admin.queries.php
@@ -1733,9 +1733,16 @@ switch ($post_type) {
         break;
 
     case 'save_api_status':
-        // Do query
-        DB::query('SELECT * FROM ' . prefixTable('misc') . ' WHERE type = %s AND intitule = %s', 'admin', 'api');
+        $timestamp = time();
+
+        // Save API status
+        DB::query(
+            'SELECT * FROM ' . prefixTable('misc') . ' WHERE type = %s AND intitule = %s',
+            'admin',
+            'api'
+        );
         $counter = DB::count();
+
         if ($counter === 0) {
             DB::insert(
                 prefixTable('misc'),
@@ -1743,7 +1750,7 @@ switch ($post_type) {
                     'type' => 'admin',
                     'intitule' => 'api',
                     'valeur' => $post_status,
-                    'created_at' => time(),
+                    'created_at' => $timestamp,
                 )
             );
         } else {
@@ -1751,14 +1758,95 @@ switch ($post_type) {
                 prefixTable('misc'),
                 array(
                     'valeur' => $post_status,
-                    'updated_at' => time(),
+                    'updated_at' => $timestamp,
                 ),
                 'type = %s AND intitule = %s',
                 'admin',
                 'api'
             );
         }
-        $SETTINGS['api'] = $post_status;
+
+        $SETTINGS['api'] = (string) $post_status;
+
+        // Silent default save of browser extension FQDN on first API activation
+        if ((int) $post_status === 1) {
+            $currentBrowserExtensionFqdn = isset($SETTINGS['browser_extension_fqdn']) === true
+                ? trim((string) $SETTINGS['browser_extension_fqdn'])
+                : '';
+
+            if ($currentBrowserExtensionFqdn === '') {
+                $cpassmanUrl = isset($SETTINGS['cpassman_url']) === true
+                    ? trim((string) $SETTINGS['cpassman_url'])
+                    : '';
+
+                if ($cpassmanUrl === '') {
+                    $detectedBrowserExtensionFqdn = 'localhost';
+                } else {
+                    if (strpos($cpassmanUrl, 'http') !== 0 && strpos($cpassmanUrl, '//') !== 0) {
+                        $cpassmanUrl = 'http://' . $cpassmanUrl;
+                    }
+
+                    $parsedUrl = parse_url($cpassmanUrl);
+                    $host = isset($parsedUrl['host']) === true
+                        ? strtolower(trim((string) $parsedUrl['host'], '.'))
+                        : 'localhost';
+
+                    // Same localhost behaviour as pages/api.php
+                    if (in_array($host, ['localhost', '127.0.0.1', '::1'], true) === true) {
+                        $path = isset($parsedUrl['path']) === true
+                            ? trim((string) $parsedUrl['path'], '/')
+                            : '';
+
+                        if ($path !== '') {
+                            $segments = explode('/', $path);
+                            if (
+                                isset($segments[0]) === true
+                                && $segments[0] !== ''
+                                && strpos((string) $segments[0], '.php') === false
+                            ) {
+                                $host = (string) $segments[0];
+                            }
+                        }
+                    }
+
+                    $detectedBrowserExtensionFqdn = $host;
+                }
+
+                DB::query(
+                    'SELECT * FROM ' . prefixTable('misc') . ' WHERE type = %s AND intitule = %s',
+                    'admin',
+                    'browser_extension_fqdn'
+                );
+                $browserExtensionFqdnExists = DB::count();
+
+                if ($browserExtensionFqdnExists === 0) {
+                    DB::insert(
+                        prefixTable('misc'),
+                        array(
+                            'type' => 'admin',
+                            'intitule' => 'browser_extension_fqdn',
+                            'valeur' => $detectedBrowserExtensionFqdn,
+                            'created_at' => $timestamp,
+                        )
+                    );
+                } else {
+                    DB::update(
+                        prefixTable('misc'),
+                        array(
+                            'valeur' => $detectedBrowserExtensionFqdn,
+                            'updated_at' => $timestamp,
+                        ),
+                        'type = %s AND intitule = %s',
+                        'admin',
+                        'browser_extension_fqdn'
+                    );
+                }
+
+                $SETTINGS['browser_extension_fqdn'] = $detectedBrowserExtensionFqdn;
+            }
+        }
+
+        ConfigManager::invalidateCache();
         break;
 
     case 'run_duo_config_check':


### PR DESCRIPTION
<p>This PR fixes an inconsistency in the API settings page regarding the browser extension FQDN.</p>

<p>Previously, the browser extension tab could display a detected default FQDN derived from <code>cpassman_url</code>, but this value was only prefilled in the UI and was not automatically persisted in the configuration. As a result, the backend could still operate with an empty <code>browser_extension_fqdn</code> until the administrator manually saved the field.</p>

<p>With this change, when the API feature is enabled for the first time, TeamPass now silently saves the detected browser extension FQDN if no value is already stored.</p>

<h3>Behavior</h3>
<ul>
  <li>When <code>api</code> is switched to enabled, TeamPass checks whether <code>browser_extension_fqdn</code> already exists.</li>
  <li>If the value is empty or missing, it is automatically derived from <code>cpassman_url</code> and persisted.</li>
  <li>If a custom <code>browser_extension_fqdn</code> is already defined, it is preserved and not overwritten.</li>
  <li>No UI message or toast is added, as this is a silent consistency fix.</li>
</ul>

<h3>Why this change</h3>
<ul>
  <li>Keeps frontend display and backend configuration aligned.</li>
  <li>Avoids requiring a manual save of the FQDN after enabling the API.</li>
  <li>Ensures browser extension licensing/configuration can immediately rely on a persisted FQDN value.</li>
</ul>

<h3>Testing</h3>
<ul>
  <li>Tested API activation with no existing <code>browser_extension_fqdn</code>: the detected value is now saved automatically.</li>
  <li>Tested API activation with an existing <code>browser_extension_fqdn</code>: the existing value remains unchanged.</li>
  <li>Confirmed no visible UI regression on the API page.</li>
</ul>