### PR TITLE
Persist browser extension FQDN automatically when enabling API

### DIFF
--- a/sources/admin.queries.php
+++ b/sources/admin.queries.php
@@ -1800,8 +1800,9 @@ switch ($post_type) {
                         if ($path !== '') {
                             $segments = explode('/', $path);
                             if (
-                                $segments[0] !== ''
-                                && strpos($segments[0], '.php') === false
+                                isset($segments[0]) === true
+                                && $segments[0] !== ''
+                                && strpos((string) $segments[0], '.php') === false
                             ) {
                                 $host = (string) $segments[0];
                             }
@@ -1811,22 +1812,14 @@ switch ($post_type) {
                     $detectedBrowserExtensionFqdn = $host;
                 }
 
-                // Sanitize before storage
-                $detectedBrowserExtensionFqdn = htmlspecialchars(
-                    $detectedBrowserExtensionFqdn,
-                    ENT_QUOTES | ENT_HTML5,
-                    'UTF-8'
-                );
-
-                // Read the current DB value
-                $fqdnRow = DB::queryFirstRow(
-                    'SELECT valeur FROM ' . prefixTable('misc') . ' WHERE type = %s AND intitule = %s',
+                DB::query(
+                    'SELECT * FROM ' . prefixTable('misc') . ' WHERE type = %s AND intitule = %s',
                     'admin',
                     'browser_extension_fqdn'
                 );
+                $browserExtensionFqdnExists = DB::count();
 
-                if ($fqdnRow === null) {
-                    // Row does not exist yet → insert it
+                if ($browserExtensionFqdnExists === 0) {
                     DB::insert(
                         prefixTable('misc'),
                         array(
@@ -1836,9 +1829,7 @@ switch ($post_type) {
                             'created_at' => $timestamp,
                         )
                     );
-                    $SETTINGS['browser_extension_fqdn'] = $detectedBrowserExtensionFqdn;
-                } elseif (trim((string) $fqdnRow['valeur']) === '') {
-                    // Row exists but is empty → update only in that case
+                } else {
                     DB::update(
                         prefixTable('misc'),
                         array(
@@ -1849,14 +1840,13 @@ switch ($post_type) {
                         'admin',
                         'browser_extension_fqdn'
                     );
-                    $SETTINGS['browser_extension_fqdn'] = $detectedBrowserExtensionFqdn;
                 }
-                // else: a non-empty value already exists in DB → we keep it
+
+                $SETTINGS['browser_extension_fqdn'] = $detectedBrowserExtensionFqdn;
             }
         }
 
         ConfigManager::invalidateCache();
-
         break;
 
     case 'run_duo_config_check':
@@ -2559,6 +2549,8 @@ switch ($post_type) {
             )['string'];
         }
 
+        $timestamp = time();
+
         // Check if setting is already in DB. If NO then insert, if YES then update.
         $data = DB::query(
             'SELECT * FROM ' . prefixTable('misc') . '
@@ -2574,7 +2566,7 @@ switch ($post_type) {
                     'valeur' => $post_value,
                     'type' => 'admin',
                     'intitule' => $post_field,
-                    'created_at' => time(),
+                    'created_at' => $timestamp,
                 )
             );
             // in case of stats enabled, add the actual time
@@ -2582,10 +2574,10 @@ switch ($post_type) {
                 DB::insert(
                     prefixTable('misc'),
                     array(
-                        'valeur' => time(),
+                        'valeur' => $timestamp,
                         'type' => 'admin',
                         'intitule' => $post_field . '_time',
-                        'updated_at' => time(),
+                        'updated_at' => $timestamp,
                     )
                 );
             }
@@ -2595,7 +2587,7 @@ switch ($post_type) {
                 prefixTable('misc'),
                 array(
                     'valeur' => $post_value,
-                    'updated_at' => time(),
+                    'updated_at' => $timestamp,
                 ),
                 'type = %s AND intitule = %s',
                 'admin',
@@ -2619,7 +2611,7 @@ switch ($post_type) {
                             'valeur' => 0,
                             'type' => 'admin',
                             'intitule' => $post_field . '_time',
-                            'created_at' => time(),
+                            'created_at' => $timestamp,
                         )
                     );
                 } else {
@@ -2627,12 +2619,101 @@ switch ($post_type) {
                         prefixTable('misc'),
                         array(
                             'valeur' => 0,
-                            'updated_at' => time(),
+                            'updated_at' => $timestamp,
                         ),
                         'type = %s AND intitule = %s',
                         'admin',
-                        $post_field
+                        $post_field . '_time'
                     );
+                }
+            }
+        }
+
+        // Keep local settings array aligned with the saved value
+        $SETTINGS[$post_field] = $post_value;
+
+        // Silent default save of browser extension FQDN on first API activation
+        if ($post_field === 'api' && (int) $post_value === 1) {
+            $currentBrowserExtensionFqdn = isset($SETTINGS['browser_extension_fqdn']) === true
+                ? trim((string) $SETTINGS['browser_extension_fqdn'])
+                : '';
+
+            if ($currentBrowserExtensionFqdn === '') {
+                $cpassmanUrl = isset($SETTINGS['cpassman_url']) === true
+                    ? trim((string) $SETTINGS['cpassman_url'])
+                    : '';
+
+                if ($cpassmanUrl === '') {
+                    $detectedBrowserExtensionFqdn = 'localhost';
+                } else {
+                    if (strpos($cpassmanUrl, 'http') !== 0 && strpos($cpassmanUrl, '//') !== 0) {
+                        $cpassmanUrl = 'http://' . $cpassmanUrl;
+                    }
+
+                    $parsedUrl = parse_url($cpassmanUrl);
+                    $host = isset($parsedUrl['host']) === true
+                        ? strtolower(trim((string) $parsedUrl['host'], '.'))
+                        : 'localhost';
+
+                    // Same localhost behaviour as pages/api.php
+                    if (in_array($host, ['localhost', '127.0.0.1', '::1'], true) === true) {
+                        $path = isset($parsedUrl['path']) === true
+                            ? trim((string) $parsedUrl['path'], '/')
+                            : '';
+
+                        if ($path !== '') {
+                            $segments = explode('/', $path);
+                            if (
+                                isset($segments[0]) === true
+                                && $segments[0] !== ''
+                                && strpos((string) $segments[0], '.php') === false
+                            ) {
+                                $host = (string) $segments[0];
+                            }
+                        }
+                    }
+
+                    $detectedBrowserExtensionFqdn = $host;
+                }
+
+                // Sanitize before storage
+                $detectedBrowserExtensionFqdn = htmlspecialchars(
+                    $detectedBrowserExtensionFqdn,
+                    ENT_QUOTES | ENT_HTML5,
+                    'UTF-8'
+                );
+
+                $fqdnRow = DB::queryFirstRow(
+                    'SELECT valeur
+                    FROM ' . prefixTable('misc') . '
+                    WHERE type = %s AND intitule = %s',
+                    'admin',
+                    'browser_extension_fqdn'
+                );
+
+                if ($fqdnRow === null) {
+                    DB::insert(
+                        prefixTable('misc'),
+                        array(
+                            'type' => 'admin',
+                            'intitule' => 'browser_extension_fqdn',
+                            'valeur' => $detectedBrowserExtensionFqdn,
+                            'created_at' => $timestamp,
+                        )
+                    );
+                    $SETTINGS['browser_extension_fqdn'] = $detectedBrowserExtensionFqdn;
+                } elseif (trim((string) $fqdnRow['valeur']) === '') {
+                    DB::update(
+                        prefixTable('misc'),
+                        array(
+                            'valeur' => $detectedBrowserExtensionFqdn,
+                            'updated_at' => $timestamp,
+                        ),
+                        'type = %s AND intitule = %s',
+                        'admin',
+                        'browser_extension_fqdn'
+                    );
+                    $SETTINGS['browser_extension_fqdn'] = $detectedBrowserExtensionFqdn;
                 }
             }
         }
@@ -2653,7 +2734,7 @@ switch ($post_type) {
                 prefixTable('misc'),
                 array(
                     'valeur' => 0,
-                    'updated_at' => time(),
+                    'updated_at' => $timestamp,
                 ),
                 'type = %s AND intitule = %s',
                 'admin',


### PR DESCRIPTION
<h2>Summary</h2>
<p>This PR fixes an inconsistency in the API configuration page related to the browser extension FQDN.</p>

<p>The browser extension tab could display a detected default FQDN derived from <code>cpassman_url</code>, but this value was only prefilled in the UI and was not always persisted in configuration. As a result, backend logic could still operate with an empty <code>browser_extension_fqdn</code> until the field was manually saved.</p>

<h2>What is changed</h2>
<ul>
  <li>Add a silent default persistence of <code>browser_extension_fqdn</code> when API is enabled and no value is already stored.</li>
  <li>Implement the behavior in <code>save_option_change</code>, which is the actual save flow used by the API settings page.</li>
  <li>Keep the same protection in <code>save_api_status</code> as a fallback for alternative or legacy entry points.</li>
  <li>Preserve any existing non-empty <code>browser_extension_fqdn</code> value and never overwrite it.</li>
</ul>

<h2>Why</h2>
<ul>
  <li>Keep frontend display and backend configuration aligned.</li>
  <li>Avoid requiring a manual save of the FQDN after enabling the API.</li>
  <li>Ensure browser extension related backend checks can rely on a persisted FQDN value immediately after activation.</li>
</ul>

<h2>Tests</h2>
<ul>
  <li>Tested with no existing <code>browser_extension_fqdn</code>: enabling API now creates and stores the detected value automatically.</li>
  <li>Tested with an existing non-empty <code>browser_extension_fqdn</code>: enabling API keeps the stored value unchanged.</li>
  <li>Confirmed the behavior is silent and does not introduce any UI regression.</li>
</ul>