### PR TITLE
Remove redundant paragonie/random_compat dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -185,7 +185,6 @@
         "phpmailer/phpmailer": "^6.8",
         "moxiecode/plupload": "^3.1",
         "tecnickcom/tcpdf": "^6.6",
-        "paragonie/random_compat": "^9.99",
         "elegantweb/sanitizer": "^2.1",
         "defuse/php-encryption": "^2.4",
         "dittertp/gibberish-aes-php": "^4.0",


### PR DESCRIPTION
This package depends on `paragonie/random_compat: ^9.99`, but also `php: >=8.1`. Since `random_bytes` and `random_int` were added in PHP 7.0, the dependency on `paragonie/random_compat` seems redundant?