### PR TITLE
Fix 5122 backup script passkey initialization and preserve restore compatibility for legacy scheduled backups

### DIFF
--- a/install/install-steps/run.step5.php
+++ b/install/install-steps/run.step5.php
@@ -486,6 +486,15 @@ class DatabaseInstaller
         require_once __DIR__.'/../../includes/config/include.php';
 
         // add by default settings
+        $backupScriptPasskeyClear = GenerateCryptKeyForInstall(40, false, true, true, false, true);
+        $backupScriptPasskeyStorage = $backupScriptPasskeyClear;
+        $backupScriptPasskeyIsEncrypted = 0;
+        $backupScriptPasskeyCipher = cryptionForInstall($backupScriptPasskeyClear, '', 'encrypt');
+        if (isset($backupScriptPasskeyCipher['string']) && is_string($backupScriptPasskeyCipher['string']) && $backupScriptPasskeyCipher['string'] !== '') {
+            $backupScriptPasskeyStorage = $backupScriptPasskeyCipher['string'];
+            $backupScriptPasskeyIsEncrypted = 1;
+        }
+
         $aMiscVal = array(
             array('admin', 'max_latest_items', '10'),
             array('admin', 'enable_favourites', '1'),
@@ -605,7 +614,7 @@ class DatabaseInstaller
             array('admin', 'secure_display_image', '1'),
             array('admin', 'upload_zero_byte_file', '0'),
             array('admin', 'upload_all_extensions_file', '0'),
-            array('admin', 'bck_script_passkey', cryptionForInstall(GenerateCryptKeyForInstall(40, false, true, true, false, true), '', 'encrypt')['string'], '1'),
+            array('admin', 'bck_script_passkey', $backupScriptPasskeyStorage, $backupScriptPasskeyIsEncrypted),
             array('admin', 'admin_2fa_required', '1'),
             array('admin', 'password_overview_delay', '4'),
             array('admin', 'copy_to_clipboard_small_icons', '1'),

--- a/install/install-steps/run.step5.php
+++ b/install/install-steps/run.step5.php
@@ -605,7 +605,7 @@ class DatabaseInstaller
             array('admin', 'secure_display_image', '1'),
             array('admin', 'upload_zero_byte_file', '0'),
             array('admin', 'upload_all_extensions_file', '0'),
-            array('admin', 'bck_script_passkey', '', '1'),
+            array('admin', 'bck_script_passkey', cryptionForInstall(GenerateCryptKeyForInstall(40, false, true, true, false, true), '', 'encrypt')['string'], '1'),
             array('admin', 'admin_2fa_required', '1'),
             array('admin', 'password_overview_delay', '4'),
             array('admin', 'copy_to_clipboard_small_icons', '1'),

--- a/install/upgrade_run_3.1.7.php
+++ b/install/upgrade_run_3.1.7.php
@@ -242,6 +242,92 @@ foreach ($networkAclDefaults as $key => $value) {
 
 // <---
 // ==========================================
+// Backup script passkey: ensure an encrypted non-empty value exists
+// ==========================================
+$backupPasskeyRow = DB::queryFirstRow(
+    'SELECT increment_id, valeur FROM ' . prefixTable('misc') . ' WHERE type=%s AND intitule=%s LIMIT 1',
+    'admin',
+    'bck_script_passkey'
+);
+$backupPasskeyStoredValue = isset($backupPasskeyRow['valeur']) ? (string) $backupPasskeyRow['valeur'] : '';
+$backupPasskeyClearValue = '';
+
+if ($backupPasskeyStoredValue !== '') {
+    try {
+        $tmp = cryption($backupPasskeyStoredValue, '', 'decrypt', $SETTINGS);
+        $dec = isset($tmp['string']) ? (string) $tmp['string'] : '';
+        if (preg_match('/^[A-Za-z0-9]{40}$/', $dec) === 1) {
+            $backupPasskeyClearValue = $dec;
+        }
+    } catch (Throwable $e) {
+        // Continue below for legacy clear-text values.
+    }
+
+    if ($backupPasskeyClearValue === '' && preg_match('/^[A-Za-z0-9]{40}$/', $backupPasskeyStoredValue) === 1) {
+        $backupPasskeyClearValue = $backupPasskeyStoredValue;
+    }
+}
+
+if ($backupPasskeyClearValue === '') {
+    $backupPasskeyClearValue = GenerateCryptKey(40, false, true, true, false, true);
+}
+
+$backupPasskeyEncrypted = cryption($backupPasskeyClearValue, '', 'encrypt', $SETTINGS);
+$backupPasskeyEncryptedValue = isset($backupPasskeyEncrypted['string']) ? (string) $backupPasskeyEncrypted['string'] : '';
+if ($backupPasskeyEncryptedValue !== '') {
+    try {
+        if (!empty($backupPasskeyRow['increment_id'])) {
+            DB::update(
+                prefixTable('misc'),
+                [
+                    'valeur' => $backupPasskeyEncryptedValue,
+                    'updated_at' => time(),
+                    'is_encrypted' => 1,
+                ],
+                'increment_id=%i',
+                (int) $backupPasskeyRow['increment_id']
+            );
+        } else {
+            DB::insert(
+                prefixTable('misc'),
+                [
+                    'type' => 'admin',
+                    'intitule' => 'bck_script_passkey',
+                    'valeur' => $backupPasskeyEncryptedValue,
+                    'created_at' => time(),
+                    'is_encrypted' => 1,
+                ]
+            );
+        }
+    } catch (Throwable $e) {
+        if (!empty($backupPasskeyRow['increment_id'])) {
+            DB::update(
+                prefixTable('misc'),
+                [
+                    'valeur' => $backupPasskeyEncryptedValue,
+                    'updated_at' => time(),
+                ],
+                'increment_id=%i',
+                (int) $backupPasskeyRow['increment_id']
+            );
+        } else {
+            DB::insert(
+                prefixTable('misc'),
+                [
+                    'type' => 'admin',
+                    'intitule' => 'bck_script_passkey',
+                    'valeur' => $backupPasskeyEncryptedValue,
+                    'created_at' => time(),
+                ]
+            );
+        }
+    }
+}
+
+// --->
+
+// <---
+// ==========================================
 // roles_values: Clean up duplicates and add UNIQUE constraint
 // Ensures each (role_id, folder_id) pair exists only once
 // ==========================================

--- a/install/upgrade_run_3.1.7.php
+++ b/install/upgrade_run_3.1.7.php
@@ -32,6 +32,7 @@ use TeampassClasses\ConfigManager\ConfigManager;
 
 // Load functions
 require_once __DIR__.'/../sources/main.functions.php';
+require_once __DIR__.'/../sources/backup.functions.php';
 
 // init
 loadClasses('DB');
@@ -242,92 +243,6 @@ foreach ($networkAclDefaults as $key => $value) {
 
 // <---
 // ==========================================
-// Backup script passkey: ensure an encrypted non-empty value exists
-// ==========================================
-$backupPasskeyRow = DB::queryFirstRow(
-    'SELECT increment_id, valeur FROM ' . prefixTable('misc') . ' WHERE type=%s AND intitule=%s LIMIT 1',
-    'admin',
-    'bck_script_passkey'
-);
-$backupPasskeyStoredValue = isset($backupPasskeyRow['valeur']) ? (string) $backupPasskeyRow['valeur'] : '';
-$backupPasskeyClearValue = '';
-
-if ($backupPasskeyStoredValue !== '') {
-    try {
-        $tmp = cryption($backupPasskeyStoredValue, '', 'decrypt', $SETTINGS);
-        $dec = isset($tmp['string']) ? (string) $tmp['string'] : '';
-        if (preg_match('/^[A-Za-z0-9]{40}$/', $dec) === 1) {
-            $backupPasskeyClearValue = $dec;
-        }
-    } catch (Throwable $e) {
-        // Continue below for legacy clear-text values.
-    }
-
-    if ($backupPasskeyClearValue === '' && preg_match('/^[A-Za-z0-9]{40}$/', $backupPasskeyStoredValue) === 1) {
-        $backupPasskeyClearValue = $backupPasskeyStoredValue;
-    }
-}
-
-if ($backupPasskeyClearValue === '') {
-    $backupPasskeyClearValue = GenerateCryptKey(40, false, true, true, false, true);
-}
-
-$backupPasskeyEncrypted = cryption($backupPasskeyClearValue, '', 'encrypt', $SETTINGS);
-$backupPasskeyEncryptedValue = isset($backupPasskeyEncrypted['string']) ? (string) $backupPasskeyEncrypted['string'] : '';
-if ($backupPasskeyEncryptedValue !== '') {
-    try {
-        if (!empty($backupPasskeyRow['increment_id'])) {
-            DB::update(
-                prefixTable('misc'),
-                [
-                    'valeur' => $backupPasskeyEncryptedValue,
-                    'updated_at' => time(),
-                    'is_encrypted' => 1,
-                ],
-                'increment_id=%i',
-                (int) $backupPasskeyRow['increment_id']
-            );
-        } else {
-            DB::insert(
-                prefixTable('misc'),
-                [
-                    'type' => 'admin',
-                    'intitule' => 'bck_script_passkey',
-                    'valeur' => $backupPasskeyEncryptedValue,
-                    'created_at' => time(),
-                    'is_encrypted' => 1,
-                ]
-            );
-        }
-    } catch (Throwable $e) {
-        if (!empty($backupPasskeyRow['increment_id'])) {
-            DB::update(
-                prefixTable('misc'),
-                [
-                    'valeur' => $backupPasskeyEncryptedValue,
-                    'updated_at' => time(),
-                ],
-                'increment_id=%i',
-                (int) $backupPasskeyRow['increment_id']
-            );
-        } else {
-            DB::insert(
-                prefixTable('misc'),
-                [
-                    'type' => 'admin',
-                    'intitule' => 'bck_script_passkey',
-                    'valeur' => $backupPasskeyEncryptedValue,
-                    'created_at' => time(),
-                ]
-            );
-        }
-    }
-}
-
-// --->
-
-// <---
-// ==========================================
 // roles_values: Clean up duplicates and add UNIQUE constraint
 // Ensures each (role_id, folder_id) pair exists only once
 // ==========================================
@@ -462,6 +377,18 @@ foreach ($healthLogsDefaults as $key => $value) {
                 '" . mysqli_real_escape_string($db_link, $value) . "',
                 UNIX_TIMESTAMP())"
     );
+}
+// --->
+
+// <---
+// ==========================================
+// Backup script passkey: repair empty values and archive legacy restore candidates
+// ==========================================
+if (function_exists('tpArchiveCurrentBackupScriptPasskeyState')) {
+    tpArchiveCurrentBackupScriptPasskeyState($SETTINGS);
+}
+if (function_exists('tpResolveBackupScriptPasskey')) {
+    tpResolveBackupScriptPasskey($SETTINGS, true);
 }
 // --->
 

--- a/pages/backups.php
+++ b/pages/backups.php
@@ -83,9 +83,12 @@ header('Cache-Control: no-cache, no-store, must-revalidate');
 
 // --------------------------------- //
 
-// Resolve backup script key (self-heal empty / legacy values for this admin page)
-$backupScriptPasskey = tpResolveBackupScriptPasskey($SETTINGS, true);
-$localEncryptionKey = !empty($backupScriptPasskey['success']) ? (string) $backupScriptPasskey['clear_key'] : '';
+// Resolve backup script key (self-heal empty values on impacted instances)
+$localEncryptionKey = '';
+$resolvedBackupScriptPasskey = tpResolveBackupScriptPasskey($SETTINGS, true);
+if (!empty($resolvedBackupScriptPasskey['success']) && !empty($resolvedBackupScriptPasskey['clear_key'])) {
+    $localEncryptionKey = (string) $resolvedBackupScriptPasskey['clear_key'];
+}
 ?>
 
 <!-- Content Header (Page header) -->

--- a/pages/backups.php
+++ b/pages/backups.php
@@ -38,6 +38,7 @@ use TeampassClasses\ConfigManager\ConfigManager;
 
 // Load functions
 require_once __DIR__.'/../sources/main.functions.php';
+require_once __DIR__.'/../sources/backup.functions.php';
 
 // init
 $session = SessionManager::getSession();
@@ -82,9 +83,9 @@ header('Cache-Control: no-cache, no-store, must-revalidate');
 
 // --------------------------------- //
 
-// Decrypt key
-$localEncryptionKey = isset($SETTINGS['bck_script_passkey']) === true ?
-    cryption($SETTINGS['bck_script_passkey'], '', 'decrypt', $SETTINGS)['string'] : '';
+// Resolve backup script key (self-heal empty / legacy values for this admin page)
+$backupScriptPasskey = tpResolveBackupScriptPasskey($SETTINGS, true);
+$localEncryptionKey = !empty($backupScriptPasskey['success']) ? (string) $backupScriptPasskey['clear_key'] : '';
 ?>
 
 <!-- Content Header (Page header) -->

--- a/scripts/background_tasks___worker.php
+++ b/scripts/background_tasks___worker.php
@@ -31,6 +31,7 @@ declare(strict_types=1);
 use TeampassClasses\ConfigManager\ConfigManager;
 use TeampassClasses\Language\Language;
 require_once __DIR__.'/../sources/main.functions.php';
+require_once __DIR__ . '/../sources/backup.functions.php';
 require_once __DIR__ . '/../sources/users_purge.functions.php';
 require_once __DIR__.'/background_tasks___functions.php';
 require_once __DIR__.'/traits/ItemHandlerTrait.php';
@@ -149,9 +150,11 @@ class TaskWorker {
             throw new Exception('Backup target dir is not writable: ' . $targetDir);
         }
 
-        // Resolve backup script passkey to the clear key used to encrypt backup files.
-        $backupScriptPasskey = tpResolveBackupScriptPasskey($this->settings, true);
-        $encryptionKey = !empty($backupScriptPasskey['success']) ? (string) $backupScriptPasskey['clear_key'] : '';
+        // Use the resolved clear backup key and self-heal empty values on impacted instances.
+        $resolvedBackupScriptPasskey = tpResolveBackupScriptPasskey($this->settings, true);
+        $encryptionKey = !empty($resolvedBackupScriptPasskey['success'])
+            ? (string) ($resolvedBackupScriptPasskey['clear_key'] ?? '')
+            : '';
         if ($encryptionKey === '') {
             throw new Exception('Missing encryption key (bck_script_passkey).');
         }

--- a/scripts/background_tasks___worker.php
+++ b/scripts/background_tasks___worker.php
@@ -149,8 +149,9 @@ class TaskWorker {
             throw new Exception('Backup target dir is not writable: ' . $targetDir);
         }
 
-        // Use stored encryption key (same as UI)
-        $encryptionKey = (string)($this->settings['bck_script_passkey'] ?? '');
+        // Resolve backup script passkey to the clear key used to encrypt backup files.
+        $backupScriptPasskey = tpResolveBackupScriptPasskey($this->settings, true);
+        $encryptionKey = !empty($backupScriptPasskey['success']) ? (string) $backupScriptPasskey['clear_key'] : '';
         if ($encryptionKey === '') {
             throw new Exception('Missing encryption key (bck_script_passkey).');
         }

--- a/scripts/restore.php
+++ b/scripts/restore.php
@@ -444,11 +444,14 @@ try {
     $log('WARN', 'Unable to decrypt stored secrets: ' . $e->getMessage());
 }
 
-// Instance key (scheduled backups)
+// Instance key candidates (scheduled backups + archived legacy values)
 try {
-    $keysToTry = array_merge($keysToTry, tpGetBackupScriptPasskeyCandidates($SETTINGS, false));
+    $keysToTry = array_merge(
+        $keysToTry,
+        tpGetBackupScriptPasskeyCandidates($SETTINGS, false)
+    );
 } catch (Throwable $e) {
-    $log('WARN', 'Unable to resolve instance backup key: ' . $e->getMessage());
+    $log('WARN', 'Unable to load instance backup key candidates: ' . $e->getMessage());
 }
 
 $keysToTry = array_values(array_unique($keysToTry));

--- a/scripts/restore.php
+++ b/scripts/restore.php
@@ -446,21 +446,9 @@ try {
 
 // Instance key (scheduled backups)
 try {
-    if (!empty($SETTINGS['bck_script_passkey'] ?? '') === true) {
-        $rawInstanceKey = (string) $SETTINGS['bck_script_passkey'];
-        $tmp = cryption($rawInstanceKey, '', 'decrypt', $SETTINGS);
-        $decInstanceKey = isset($tmp['string']) ? (string) $tmp['string'] : '';
-
-        if ($decInstanceKey !== '') {
-            $keysToTry[] = $decInstanceKey;
-        }
-        // Some environments may store bck_script_passkey already in clear
-        if ($rawInstanceKey !== '' && $rawInstanceKey !== $decInstanceKey) {
-            $keysToTry[] = $rawInstanceKey;
-        }
-    }
+    $keysToTry = array_merge($keysToTry, tpGetBackupScriptPasskeyCandidates($SETTINGS, false));
 } catch (Throwable $e) {
-    $log('WARN', 'Unable to decrypt instance backup key: ' . $e->getMessage());
+    $log('WARN', 'Unable to resolve instance backup key: ' . $e->getMessage());
 }
 
 $keysToTry = array_values(array_unique($keysToTry));

--- a/sources/admin.queries.php
+++ b/sources/admin.queries.php
@@ -2661,6 +2661,10 @@ switch ($post_type) {
 
         // In case of key, then encrypt it
         if ($post_field === 'bck_script_passkey') {
+            if (trim((string) $post_value) === '') {
+                $post_value = GenerateCryptKey(40, false, true, true, false, true);
+            }
+
             $post_value = cryption(
                 $post_value,
                 '',

--- a/sources/admin.queries.php
+++ b/sources/admin.queries.php
@@ -2659,18 +2659,30 @@ switch ($post_type) {
         
         require_once 'main.functions.php';
 
-        // In case of key, then encrypt it
+        // In case of backup script key, then normalize, archive the previous state and encrypt it.
         if ($post_field === 'bck_script_passkey') {
-            if (trim((string) $post_value) === '') {
-                $post_value = GenerateCryptKey(40, false, true, true, false, true);
+            require_once 'backup.functions.php';
+
+            $clearBackupScriptPasskey = trim((string) $post_value);
+            if ($clearBackupScriptPasskey === '') {
+                $clearBackupScriptPasskey = tpGenerateBackupScriptPasskey();
             }
 
-            $post_value = cryption(
-                $post_value,
-                '',
-                'encrypt',
-                $SETTINGS
-            )['string'];
+            $storedBackupScriptPasskey = tpStoreBackupScriptPasskey($clearBackupScriptPasskey, $SETTINGS, true);
+            if (!empty($storedBackupScriptPasskey['success'])) {
+                $post_value = (string) $storedBackupScriptPasskey['encrypted_key'];
+            } else {
+                $fallbackEncryptedBackupScriptPasskey = cryption(
+                    $clearBackupScriptPasskey,
+                    '',
+                    'encrypt',
+                    $SETTINGS
+                )['string'];
+
+                $post_value = $fallbackEncryptedBackupScriptPasskey !== ''
+                    ? $fallbackEncryptedBackupScriptPasskey
+                    : $clearBackupScriptPasskey;
+            }
         }
 
         $timestamp = time();

--- a/sources/backup.functions.php
+++ b/sources/backup.functions.php
@@ -372,6 +372,277 @@ $filename = $prefix . time() . '-' . $token . $schemaSuffix . '.sql';
 }
 
 
+if (function_exists('tpGenerateBackupScriptPasskey') === false) {
+    /**
+     * Generate a clear backup script passkey.
+     */
+    function tpGenerateBackupScriptPasskey(): string
+    {
+        if (function_exists('GenerateCryptKey')) {
+            return GenerateCryptKey(40, false, true, true, false, true);
+        }
+
+        $alphabet = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+        $maxIndex = strlen($alphabet) - 1;
+        $key = '';
+
+        for ($i = 0; $i < 40; $i++) {
+            try {
+                $key .= $alphabet[random_int(0, $maxIndex)];
+            } catch (Throwable $e) {
+                $key .= $alphabet[mt_rand(0, $maxIndex)];
+            }
+        }
+
+        return $key;
+    }
+}
+
+if (function_exists('tpStoreBackupScriptPasskey') === false) {
+    /**
+     * Store the backup script passkey in teampass_misc as an encrypted admin setting.
+     *
+     * @return array{success: bool, clear_key: string, encrypted_key: string, message: string}
+     */
+    function tpStoreBackupScriptPasskey(string $clearKey, array &$SETTINGS): array
+    {
+        if (preg_match('/^[A-Za-z0-9]{40}$/', $clearKey) !== 1) {
+            return [
+                'success' => false,
+                'clear_key' => '',
+                'encrypted_key' => '',
+                'message' => 'Invalid backup script passkey format',
+            ];
+        }
+
+        $enc = cryption($clearKey, '', 'encrypt', $SETTINGS);
+        $encryptedKey = isset($enc['string']) ? (string) $enc['string'] : '';
+        if ($encryptedKey === '') {
+            return [
+                'success' => false,
+                'clear_key' => '',
+                'encrypted_key' => '',
+                'message' => 'Unable to encrypt backup script passkey',
+            ];
+        }
+
+        $row = DB::queryFirstRow(
+            'SELECT increment_id FROM ' . prefixTable('misc') . ' WHERE type=%s AND intitule=%s LIMIT 1',
+            'admin',
+            'bck_script_passkey'
+        );
+
+        try {
+            if (!empty($row['increment_id'])) {
+                DB::update(
+                    prefixTable('misc'),
+                    [
+                        'valeur' => $encryptedKey,
+                        'updated_at' => time(),
+                        'is_encrypted' => 1,
+                    ],
+                    'increment_id=%i',
+                    (int) $row['increment_id']
+                );
+            } else {
+                DB::insert(
+                    prefixTable('misc'),
+                    [
+                        'type' => 'admin',
+                        'intitule' => 'bck_script_passkey',
+                        'valeur' => $encryptedKey,
+                        'created_at' => time(),
+                        'is_encrypted' => 1,
+                    ]
+                );
+            }
+        } catch (Throwable $e) {
+            try {
+                if (!empty($row['increment_id'])) {
+                    DB::update(
+                        prefixTable('misc'),
+                        [
+                            'valeur' => $encryptedKey,
+                            'updated_at' => time(),
+                        ],
+                        'increment_id=%i',
+                        (int) $row['increment_id']
+                    );
+                } else {
+                    DB::insert(
+                        prefixTable('misc'),
+                        [
+                            'type' => 'admin',
+                            'intitule' => 'bck_script_passkey',
+                            'valeur' => $encryptedKey,
+                            'created_at' => time(),
+                        ]
+                    );
+                }
+            } catch (Throwable $e2) {
+                return [
+                    'success' => false,
+                    'clear_key' => '',
+                    'encrypted_key' => '',
+                    'message' => $e2->getMessage(),
+                ];
+            }
+        }
+
+        $SETTINGS['bck_script_passkey'] = $encryptedKey;
+
+        if (
+            class_exists('\TeampassClasses\ConfigManager\ConfigManager')
+            && method_exists('\TeampassClasses\ConfigManager\ConfigManager', 'invalidateCache')
+        ) {
+            \TeampassClasses\ConfigManager\ConfigManager::invalidateCache();
+        }
+
+        return [
+            'success' => true,
+            'clear_key' => $clearKey,
+            'encrypted_key' => $encryptedKey,
+            'message' => '',
+        ];
+    }
+}
+
+if (function_exists('tpResolveBackupScriptPasskey') === false) {
+    /**
+     * Resolve the backup script passkey to a clear key.
+     *
+     * Supported cases:
+     * - encrypted value stored in misc/config (expected format)
+     * - legacy clear-text 40 chars value
+     * - empty value (optionally self-healed)
+     *
+     * Corrupted non-empty values are never overwritten automatically.
+     *
+     * @return array{success: bool, clear_key: string, stored_value: string, source: string, message: string}
+     */
+    function tpResolveBackupScriptPasskey(array &$SETTINGS, bool $autoHeal = false): array
+    {
+        $storedValue = isset($SETTINGS['bck_script_passkey']) ? (string) $SETTINGS['bck_script_passkey'] : '';
+
+        if ($storedValue !== '') {
+            try {
+                $tmp = cryption($storedValue, '', 'decrypt', $SETTINGS);
+                $decryptedValue = isset($tmp['string']) ? (string) $tmp['string'] : '';
+                if (preg_match('/^[A-Za-z0-9]{40}$/', $decryptedValue) === 1) {
+                    return [
+                        'success' => true,
+                        'clear_key' => $decryptedValue,
+                        'stored_value' => $storedValue,
+                        'source' => 'encrypted',
+                        'message' => '',
+                    ];
+                }
+            } catch (Throwable $e) {
+                // Continue below to check legacy clear-text values.
+            }
+
+            if (preg_match('/^[A-Za-z0-9]{40}$/', $storedValue) === 1) {
+                if ($autoHeal === true) {
+                    $stored = tpStoreBackupScriptPasskey($storedValue, $SETTINGS);
+                    if (!empty($stored['success'])) {
+                        return [
+                            'success' => true,
+                            'clear_key' => $storedValue,
+                            'stored_value' => (string) $stored['encrypted_key'],
+                            'source' => 'legacy_clear_migrated',
+                            'message' => '',
+                        ];
+                    }
+
+                    return [
+                        'success' => false,
+                        'clear_key' => '',
+                        'stored_value' => $storedValue,
+                        'source' => 'legacy_clear',
+                        'message' => (string) $stored['message'],
+                    ];
+                }
+
+                return [
+                    'success' => true,
+                    'clear_key' => $storedValue,
+                    'stored_value' => $storedValue,
+                    'source' => 'legacy_clear',
+                    'message' => '',
+                ];
+            }
+
+            return [
+                'success' => false,
+                'clear_key' => '',
+                'stored_value' => $storedValue,
+                'source' => 'invalid',
+                'message' => 'Invalid backup script passkey format',
+            ];
+        }
+
+        if ($autoHeal === true) {
+            $generatedKey = tpGenerateBackupScriptPasskey();
+            $stored = tpStoreBackupScriptPasskey($generatedKey, $SETTINGS);
+            if (!empty($stored['success'])) {
+                return [
+                    'success' => true,
+                    'clear_key' => $generatedKey,
+                    'stored_value' => (string) $stored['encrypted_key'],
+                    'source' => 'generated',
+                    'message' => '',
+                ];
+            }
+
+            return [
+                'success' => false,
+                'clear_key' => '',
+                'stored_value' => '',
+                'source' => 'empty',
+                'message' => (string) $stored['message'],
+            ];
+        }
+
+        return [
+            'success' => false,
+            'clear_key' => '',
+            'stored_value' => '',
+            'source' => 'empty',
+            'message' => 'Backup script passkey is not set',
+        ];
+    }
+}
+
+if (function_exists('tpGetBackupScriptPasskeyCandidates') === false) {
+    /**
+     * Return candidate backup script passkeys for backward-compatible restore operations.
+     *
+     * @return array<int, string>
+     */
+    function tpGetBackupScriptPasskeyCandidates(array &$SETTINGS, bool $autoHeal = false): array
+    {
+        $keys = [];
+        $resolved = tpResolveBackupScriptPasskey($SETTINGS, $autoHeal);
+        if (!empty($resolved['success']) && $resolved['clear_key'] !== '') {
+            $keys[] = (string) $resolved['clear_key'];
+        }
+
+        $storedValue = isset($resolved['stored_value']) ? (string) $resolved['stored_value'] : '';
+        if ($storedValue === '') {
+            $storedValue = isset($SETTINGS['bck_script_passkey']) ? (string) $SETTINGS['bck_script_passkey'] : '';
+        }
+
+        if ($storedValue !== '' && !in_array($storedValue, $keys, true)) {
+            $keys[] = $storedValue;
+        }
+
+        return array_values(array_unique(array_filter($keys, static function ($value): bool {
+            return is_string($value) && $value !== '';
+        })));
+    }
+}
+
+
 // -----------------------------------------------------------------------------
 // Helpers for restore logic (used by backups.queries.php)
 // -----------------------------------------------------------------------------

--- a/sources/backup.functions.php
+++ b/sources/backup.functions.php
@@ -372,6 +372,16 @@ $filename = $prefix . time() . '-' . $token . $schemaSuffix . '.sql';
 }
 
 
+if (function_exists('tpBackupScriptPasskeyIsClear') === false) {
+    /**
+     * Check whether the provided value matches the clear backup passkey format.
+     */
+    function tpBackupScriptPasskeyIsClear(string $value): bool
+    {
+        return $value !== '' && preg_match('/^[A-Za-z0-9]{40}$/', $value) === 1;
+    }
+}
+
 if (function_exists('tpGenerateBackupScriptPasskey') === false) {
     /**
      * Generate a clear backup script passkey.
@@ -398,20 +408,232 @@ if (function_exists('tpGenerateBackupScriptPasskey') === false) {
     }
 }
 
+if (function_exists('tpGetBackupScriptPasskeyArchiveSettingName') === false) {
+    function tpGetBackupScriptPasskeyArchiveSettingName(): string
+    {
+        return 'bck_script_passkey_restore_candidates';
+    }
+}
+
+if (function_exists('tpNormalizeBackupScriptPasskeyCandidates') === false) {
+    /**
+     * @param array<int|string, mixed> $candidates
+     * @return array<int, string>
+     */
+    function tpNormalizeBackupScriptPasskeyCandidates(array $candidates): array
+    {
+        $normalized = [];
+        foreach ($candidates as $candidate) {
+            if (!is_scalar($candidate)) {
+                continue;
+            }
+
+            $value = trim((string) $candidate);
+            if ($value === '') {
+                continue;
+            }
+
+            if (!in_array($value, $normalized, true)) {
+                $normalized[] = $value;
+            }
+        }
+
+        return $normalized;
+    }
+}
+
+if (function_exists('tpLoadBackupScriptPasskeyRestoreCandidates') === false) {
+    /**
+     * Load archived restore candidates for backward compatibility with historical backups.
+     *
+     * @return array<int, string>
+     */
+    function tpLoadBackupScriptPasskeyRestoreCandidates(array &$SETTINGS): array
+    {
+        $settingName = tpGetBackupScriptPasskeyArchiveSettingName();
+        $storedPayload = isset($SETTINGS[$settingName]) ? (string) $SETTINGS[$settingName] : '';
+
+        if ($storedPayload === '') {
+            $row = DB::queryFirstRow(
+                'SELECT valeur FROM ' . prefixTable('misc') . ' WHERE type=%s AND intitule=%s LIMIT 1',
+                'admin',
+                $settingName
+            );
+            $storedPayload = isset($row['valeur']) ? (string) $row['valeur'] : '';
+            if ($storedPayload !== '') {
+                $SETTINGS[$settingName] = $storedPayload;
+            }
+        }
+
+        if ($storedPayload === '') {
+            return [];
+        }
+
+        $decodedPayload = '';
+        try {
+            $tmp = cryption($storedPayload, '', 'decrypt', $SETTINGS);
+            $decodedPayload = isset($tmp['string']) ? (string) $tmp['string'] : '';
+        } catch (Throwable $e) {
+            $decodedPayload = '';
+        }
+
+        if ($decodedPayload === '') {
+            $decodedPayload = $storedPayload;
+        }
+
+        $data = json_decode($decodedPayload, true);
+        if (is_array($data)) {
+            return tpNormalizeBackupScriptPasskeyCandidates($data);
+        }
+
+        return tpNormalizeBackupScriptPasskeyCandidates([$decodedPayload]);
+    }
+}
+
+if (function_exists('tpStoreBackupScriptPasskeyRestoreCandidates') === false) {
+    /**
+     * Persist archived restore candidates as an encrypted JSON payload.
+     */
+    function tpStoreBackupScriptPasskeyRestoreCandidates(array $candidates, array &$SETTINGS): bool
+    {
+        $settingName = tpGetBackupScriptPasskeyArchiveSettingName();
+        $normalized = tpNormalizeBackupScriptPasskeyCandidates($candidates);
+
+        $json = json_encode($normalized, JSON_UNESCAPED_SLASHES);
+        if ($json === false) {
+            return false;
+        }
+
+        $enc = cryption($json, '', 'encrypt', $SETTINGS);
+        $storedPayload = isset($enc['string']) ? (string) $enc['string'] : '';
+        if ($storedPayload === '') {
+            return false;
+        }
+
+        $row = DB::queryFirstRow(
+            'SELECT increment_id FROM ' . prefixTable('misc') . ' WHERE type=%s AND intitule=%s LIMIT 1',
+            'admin',
+            $settingName
+        );
+
+        try {
+            if (!empty($row['increment_id'])) {
+                DB::update(
+                    prefixTable('misc'),
+                    [
+                        'valeur' => $storedPayload,
+                        'updated_at' => time(),
+                        'is_encrypted' => 1,
+                    ],
+                    'increment_id=%i',
+                    (int) $row['increment_id']
+                );
+            } else {
+                DB::insert(
+                    prefixTable('misc'),
+                    [
+                        'type' => 'admin',
+                        'intitule' => $settingName,
+                        'valeur' => $storedPayload,
+                        'created_at' => time(),
+                        'is_encrypted' => 1,
+                    ]
+                );
+            }
+        } catch (Throwable $e) {
+            try {
+                if (!empty($row['increment_id'])) {
+                    DB::update(
+                        prefixTable('misc'),
+                        [
+                            'valeur' => $storedPayload,
+                            'updated_at' => time(),
+                        ],
+                        'increment_id=%i',
+                        (int) $row['increment_id']
+                    );
+                } else {
+                    DB::insert(
+                        prefixTable('misc'),
+                        [
+                            'type' => 'admin',
+                            'intitule' => $settingName,
+                            'valeur' => $storedPayload,
+                            'created_at' => time(),
+                        ]
+                    );
+                }
+            } catch (Throwable $e2) {
+                return false;
+            }
+        }
+
+        $SETTINGS[$settingName] = $storedPayload;
+
+        if (
+            class_exists('\TeampassClasses\ConfigManager\ConfigManager')
+            && method_exists('\TeampassClasses\ConfigManager\ConfigManager', 'invalidateCache')
+        ) {
+            \TeampassClasses\ConfigManager\ConfigManager::invalidateCache();
+        }
+
+        return true;
+    }
+}
+
+if (function_exists('tpArchiveBackupScriptPasskeyCandidate') === false) {
+    /**
+     * Store a restore candidate if it is not already archived.
+     */
+    function tpArchiveBackupScriptPasskeyCandidate(string $candidate, array &$SETTINGS): bool
+    {
+        $candidate = trim($candidate);
+        if ($candidate === '') {
+            return false;
+        }
+
+        $candidates = tpLoadBackupScriptPasskeyRestoreCandidates($SETTINGS);
+        if (in_array($candidate, $candidates, true)) {
+            return true;
+        }
+
+        $candidates[] = $candidate;
+        return tpStoreBackupScriptPasskeyRestoreCandidates($candidates, $SETTINGS);
+    }
+}
+
+if (function_exists('tpArchiveCurrentBackupScriptPasskeyState') === false) {
+    /**
+     * Archive the current backup passkey state so historical scheduled backups remain restorable.
+     */
+    function tpArchiveCurrentBackupScriptPasskeyState(array &$SETTINGS): void
+    {
+        $storedValue = isset($SETTINGS['bck_script_passkey']) ? (string) $SETTINGS['bck_script_passkey'] : '';
+        if ($storedValue !== '') {
+            tpArchiveBackupScriptPasskeyCandidate($storedValue, $SETTINGS);
+        }
+
+        $resolved = tpResolveBackupScriptPasskey($SETTINGS, false);
+        if (!empty($resolved['success']) && !empty($resolved['clear_key'])) {
+            tpArchiveBackupScriptPasskeyCandidate((string) $resolved['clear_key'], $SETTINGS);
+        }
+    }
+}
+
 if (function_exists('tpStoreBackupScriptPasskey') === false) {
     /**
      * Store the backup script passkey in teampass_misc as an encrypted admin setting.
      *
-     * @return array{success: bool, clear_key: string, encrypted_key: string, message: string}
+     * @return array{success: bool, clear_key: string, encrypted_key: string, message_code: string}
      */
-    function tpStoreBackupScriptPasskey(string $clearKey, array &$SETTINGS): array
+    function tpStoreBackupScriptPasskey(string $clearKey, array &$SETTINGS, bool $archiveCurrent = true): array
     {
-        if (preg_match('/^[A-Za-z0-9]{40}$/', $clearKey) !== 1) {
+        if (!tpBackupScriptPasskeyIsClear($clearKey)) {
             return [
                 'success' => false,
                 'clear_key' => '',
                 'encrypted_key' => '',
-                'message' => 'Invalid backup script passkey format',
+                'message_code' => 'invalid_format',
             ];
         }
 
@@ -422,8 +644,23 @@ if (function_exists('tpStoreBackupScriptPasskey') === false) {
                 'success' => false,
                 'clear_key' => '',
                 'encrypted_key' => '',
-                'message' => 'Unable to encrypt backup script passkey',
+                'message_code' => 'encrypt_failed',
             ];
+        }
+
+        if ($archiveCurrent === true) {
+            $currentStoredValue = isset($SETTINGS['bck_script_passkey']) ? (string) $SETTINGS['bck_script_passkey'] : '';
+            if ($currentStoredValue !== '' && $currentStoredValue !== $encryptedKey) {
+                tpArchiveBackupScriptPasskeyCandidate($currentStoredValue, $SETTINGS);
+            }
+
+            $currentResolved = tpResolveBackupScriptPasskey($SETTINGS, false);
+            if (!empty($currentResolved['success']) && !empty($currentResolved['clear_key'])) {
+                $currentClearKey = (string) $currentResolved['clear_key'];
+                if ($currentClearKey !== '' && $currentClearKey !== $clearKey) {
+                    tpArchiveBackupScriptPasskeyCandidate($currentClearKey, $SETTINGS);
+                }
+            }
         }
 
         $row = DB::queryFirstRow(
@@ -484,7 +721,7 @@ if (function_exists('tpStoreBackupScriptPasskey') === false) {
                     'success' => false,
                     'clear_key' => '',
                     'encrypted_key' => '',
-                    'message' => $e2->getMessage(),
+                    'message_code' => 'db_write_failed',
                 ];
             }
         }
@@ -502,7 +739,7 @@ if (function_exists('tpStoreBackupScriptPasskey') === false) {
             'success' => true,
             'clear_key' => $clearKey,
             'encrypted_key' => $encryptedKey,
-            'message' => '',
+            'message_code' => '',
         ];
     }
 }
@@ -518,49 +755,28 @@ if (function_exists('tpResolveBackupScriptPasskey') === false) {
      *
      * Corrupted non-empty values are never overwritten automatically.
      *
-     * @return array{success: bool, clear_key: string, stored_value: string, source: string, message: string}
+     * @return array{success: bool, clear_key: string, stored_value: string, source: string, message_code: string}
      */
     function tpResolveBackupScriptPasskey(array &$SETTINGS, bool $autoHeal = false): array
     {
         $storedValue = isset($SETTINGS['bck_script_passkey']) ? (string) $SETTINGS['bck_script_passkey'] : '';
 
         if ($storedValue !== '') {
-            try {
-                $tmp = cryption($storedValue, '', 'decrypt', $SETTINGS);
-                $decryptedValue = isset($tmp['string']) ? (string) $tmp['string'] : '';
-                if (preg_match('/^[A-Za-z0-9]{40}$/', $decryptedValue) === 1) {
-                    return [
-                        'success' => true,
-                        'clear_key' => $decryptedValue,
-                        'stored_value' => $storedValue,
-                        'source' => 'encrypted',
-                        'message' => '',
-                    ];
-                }
-            } catch (Throwable $e) {
-                // Continue below to check legacy clear-text values.
-            }
-
-            if (preg_match('/^[A-Za-z0-9]{40}$/', $storedValue) === 1) {
+            if (tpBackupScriptPasskeyIsClear($storedValue)) {
                 if ($autoHeal === true) {
-                    $stored = tpStoreBackupScriptPasskey($storedValue, $SETTINGS);
+                    tpArchiveBackupScriptPasskeyCandidate($storedValue, $SETTINGS);
+
+                    $stored = tpStoreBackupScriptPasskey($storedValue, $SETTINGS, false);
                     if (!empty($stored['success'])) {
+                        tpArchiveBackupScriptPasskeyCandidate((string) $stored['encrypted_key'], $SETTINGS);
                         return [
                             'success' => true,
                             'clear_key' => $storedValue,
                             'stored_value' => (string) $stored['encrypted_key'],
                             'source' => 'legacy_clear_migrated',
-                            'message' => '',
+                            'message_code' => '',
                         ];
                     }
-
-                    return [
-                        'success' => false,
-                        'clear_key' => '',
-                        'stored_value' => $storedValue,
-                        'source' => 'legacy_clear',
-                        'message' => (string) $stored['message'],
-                    ];
                 }
 
                 return [
@@ -568,8 +784,29 @@ if (function_exists('tpResolveBackupScriptPasskey') === false) {
                     'clear_key' => $storedValue,
                     'stored_value' => $storedValue,
                     'source' => 'legacy_clear',
-                    'message' => '',
+                    'message_code' => '',
                 ];
+            }
+
+            try {
+                $tmp = cryption($storedValue, '', 'decrypt', $SETTINGS);
+                $decryptedValue = isset($tmp['string']) ? (string) $tmp['string'] : '';
+                if (tpBackupScriptPasskeyIsClear($decryptedValue)) {
+                    if ($autoHeal === true) {
+                        tpArchiveBackupScriptPasskeyCandidate($storedValue, $SETTINGS);
+                        tpArchiveBackupScriptPasskeyCandidate($decryptedValue, $SETTINGS);
+                    }
+
+                    return [
+                        'success' => true,
+                        'clear_key' => $decryptedValue,
+                        'stored_value' => $storedValue,
+                        'source' => 'encrypted',
+                        'message_code' => '',
+                    ];
+                }
+            } catch (Throwable $e) {
+                // Continue below for invalid non-empty values.
             }
 
             return [
@@ -577,30 +814,22 @@ if (function_exists('tpResolveBackupScriptPasskey') === false) {
                 'clear_key' => '',
                 'stored_value' => $storedValue,
                 'source' => 'invalid',
-                'message' => 'Invalid backup script passkey format',
+                'message_code' => 'invalid_format',
             ];
         }
 
         if ($autoHeal === true) {
             $generatedKey = tpGenerateBackupScriptPasskey();
-            $stored = tpStoreBackupScriptPasskey($generatedKey, $SETTINGS);
+            $stored = tpStoreBackupScriptPasskey($generatedKey, $SETTINGS, false);
             if (!empty($stored['success'])) {
                 return [
                     'success' => true,
                     'clear_key' => $generatedKey,
                     'stored_value' => (string) $stored['encrypted_key'],
                     'source' => 'generated',
-                    'message' => '',
+                    'message_code' => '',
                 ];
             }
-
-            return [
-                'success' => false,
-                'clear_key' => '',
-                'stored_value' => '',
-                'source' => 'empty',
-                'message' => (string) $stored['message'],
-            ];
         }
 
         return [
@@ -608,7 +837,7 @@ if (function_exists('tpResolveBackupScriptPasskey') === false) {
             'clear_key' => '',
             'stored_value' => '',
             'source' => 'empty',
-            'message' => 'Backup script passkey is not set',
+            'message_code' => 'not_set',
         ];
     }
 }
@@ -622,8 +851,9 @@ if (function_exists('tpGetBackupScriptPasskeyCandidates') === false) {
     function tpGetBackupScriptPasskeyCandidates(array &$SETTINGS, bool $autoHeal = false): array
     {
         $keys = [];
+
         $resolved = tpResolveBackupScriptPasskey($SETTINGS, $autoHeal);
-        if (!empty($resolved['success']) && $resolved['clear_key'] !== '') {
+        if (!empty($resolved['success']) && !empty($resolved['clear_key'])) {
             $keys[] = (string) $resolved['clear_key'];
         }
 
@@ -631,16 +861,16 @@ if (function_exists('tpGetBackupScriptPasskeyCandidates') === false) {
         if ($storedValue === '') {
             $storedValue = isset($SETTINGS['bck_script_passkey']) ? (string) $SETTINGS['bck_script_passkey'] : '';
         }
-
-        if ($storedValue !== '' && !in_array($storedValue, $keys, true)) {
+        if ($storedValue !== '') {
             $keys[] = $storedValue;
         }
 
-        return array_values(array_unique(array_filter($keys, static function ($value): bool {
-            return is_string($value) && $value !== '';
-        })));
+        $keys = array_merge($keys, tpLoadBackupScriptPasskeyRestoreCandidates($SETTINGS));
+
+        return tpNormalizeBackupScriptPasskeyCandidates($keys);
     }
 }
+
 
 
 // -----------------------------------------------------------------------------

--- a/sources/backups.queries.php
+++ b/sources/backups.queries.php
@@ -704,8 +704,10 @@ try {
                 break;
             }
 
-            $backupScriptPasskey = tpResolveBackupScriptPasskey($SETTINGS, true);
-            $instanceKey = !empty($backupScriptPasskey['success']) ? (string) $backupScriptPasskey['clear_key'] : '';
+            $resolvedBackupScriptPasskey = tpResolveBackupScriptPasskey($SETTINGS, true);
+            $instanceKey = !empty($resolvedBackupScriptPasskey['success'])
+                ? (string) ($resolvedBackupScriptPasskey['clear_key'] ?? '')
+                : '';
             if ($instanceKey === '') {
                 echo prepareExchangedData(
                     array('error' => true, 'message' => $lang->get('bck_instance_key_not_set')),
@@ -1434,15 +1436,18 @@ try {
                     $keysToTry = [];
 
                     // Build candidate keys depending on restore source
-                    // - scheduled: uses the instance key (stored in bck_script_passkey) + optional override key
+                    // - scheduled: uses the instance key candidates + optional override key
                     // - on-the-fly: uses the key provided by the UI
-                    // - upload (serverScope empty): can be either, so also try instance key candidates
+                    // - upload (serverScope empty): can be either, so also try archived instance key candidates
                     if ($serverScope === 'scheduled') {
                         if ($overrideKey !== '') {
                             $keysToTry[] = $overrideKey;
                         }
 
-                        $keysToTry = array_merge($keysToTry, tpGetBackupScriptPasskeyCandidates($SETTINGS, false));
+                        $keysToTry = array_merge(
+                            $keysToTry,
+                            tpGetBackupScriptPasskeyCandidates($SETTINGS, false)
+                        );
                     } else {
                         if ($encryptionKey !== '') {
                             $keysToTry[] = $encryptionKey;
@@ -1451,10 +1456,11 @@ try {
                             $keysToTry[] = $overrideKey;
                         }
 
-                        // For uploaded restores (serverScope is empty), also try the instance key candidates.
-                        // This allows restoring scheduled backups uploaded manually (they are encrypted using bck_script_passkey).
                         if ($serverScope === '') {
-                            $keysToTry = array_merge($keysToTry, tpGetBackupScriptPasskeyCandidates($SETTINGS, false));
+                            $keysToTry = array_merge(
+                                $keysToTry,
+                                tpGetBackupScriptPasskeyCandidates($SETTINGS, false)
+                            );
                         }
                     }
 

--- a/sources/backups.queries.php
+++ b/sources/backups.queries.php
@@ -704,16 +704,8 @@ try {
                 break;
             }
 
-            if (empty($SETTINGS['bck_script_passkey'] ?? '') === true) {
-                echo prepareExchangedData(
-                    array('error' => true, 'message' => $lang->get('bck_instance_key_not_set')),
-                    'encode'
-                );
-                break;
-            }
-
-            $tmp = cryption($SETTINGS['bck_script_passkey'], '', 'decrypt', $SETTINGS);
-            $instanceKey = isset($tmp['string']) ? (string) $tmp['string'] : '';
+            $backupScriptPasskey = tpResolveBackupScriptPasskey($SETTINGS, true);
+            $instanceKey = !empty($backupScriptPasskey['success']) ? (string) $backupScriptPasskey['clear_key'] : '';
             if ($instanceKey === '') {
                 echo prepareExchangedData(
                     array('error' => true, 'message' => $lang->get('bck_instance_key_not_set')),
@@ -1450,19 +1442,7 @@ try {
                             $keysToTry[] = $overrideKey;
                         }
 
-                        if (!empty($SETTINGS['bck_script_passkey'] ?? '')) {
-                            $rawInstanceKey = (string) $SETTINGS['bck_script_passkey'];
-                            $tmp = cryption($rawInstanceKey, '', 'decrypt', $SETTINGS);
-                            $decInstanceKey = isset($tmp['string']) ? (string) $tmp['string'] : '';
-
-                            if ($decInstanceKey !== '') {
-                                $keysToTry[] = $decInstanceKey;
-                            }
-                            // Some environments store bck_script_passkey already decrypted (or in another format)
-                            if ($rawInstanceKey !== '' && $rawInstanceKey !== $decInstanceKey) {
-                                $keysToTry[] = $rawInstanceKey;
-                            }
-                        }
+                        $keysToTry = array_merge($keysToTry, tpGetBackupScriptPasskeyCandidates($SETTINGS, false));
                     } else {
                         if ($encryptionKey !== '') {
                             $keysToTry[] = $encryptionKey;
@@ -1473,17 +1453,8 @@ try {
 
                         // For uploaded restores (serverScope is empty), also try the instance key candidates.
                         // This allows restoring scheduled backups uploaded manually (they are encrypted using bck_script_passkey).
-                        if ($serverScope === '' && !empty($SETTINGS['bck_script_passkey'] ?? '')) {
-                            $rawInstanceKey = (string) $SETTINGS['bck_script_passkey'];
-                            $tmp = cryption($rawInstanceKey, '', 'decrypt', $SETTINGS);
-                            $decInstanceKey = isset($tmp['string']) ? (string) $tmp['string'] : '';
-
-                            if ($decInstanceKey !== '') {
-                                $keysToTry[] = $decInstanceKey;
-                            }
-                            if ($rawInstanceKey !== '' && $rawInstanceKey !== $decInstanceKey) {
-                                $keysToTry[] = $rawInstanceKey;
-                            }
+                        if ($serverScope === '') {
+                            $keysToTry = array_merge($keysToTry, tpGetBackupScriptPasskeyCandidates($SETTINGS, false));
                         }
                     }
 


### PR DESCRIPTION
<h2>Summary</h2> <p> This PR fixes the backup script passkey lifecycle end-to-end. It addresses the regression where some fresh installs created an empty <code>bck_script_passkey</code>, which caused: </p> <ul> <li>an empty key field in the <strong>On-the-fly backup</strong> tab,</li> <li><code>Instance Key Not Set</code> when using the copy action in <strong>Scheduled backups</strong>,</li> <li>scheduled backups failing because the backup encryption key was missing,</li> <li>restore inconsistencies due to historical differences between the key format used by the UI, the worker and restore paths.</li> </ul> <h2>Root cause</h2> <p> On branch <code>fix/3.1.7.4</code>, the install flow was creating the <code>bck_script_passkey</code> entry in <code>misc</code> with an empty value while still marking it as encrypted. As a consequence, fresh installs could end up with a present-but-empty backup passkey. </p> <p> In parallel, the historical runtime logic was inconsistent: </p> <ul> <li>the Backups UI expected a decryptable value and displayed the clear key,</li> <li>the scheduled backup worker was using the raw stored value directly,</li> <li>restore already had partial fallback logic and could try multiple candidates.</li> </ul> <h2>What is fixed</h2> <h3>1. Fresh install fix</h3> <p> The install step now creates a real backup script passkey instead of storing an empty value. The value is generated and stored in the expected encrypted format from the start. </p> <h3>2. Upgrade/self-heal for already impacted instances</h3> <p> A repair path was added for existing instances where <code>bck_script_passkey</code> is: </p> <ul> <li>missing,</li> <li>empty,</li> <li>stored in a legacy clear format.</li> </ul> <p> When needed, the code now regenerates or migrates the backup script passkey safely and stores it in the expected format. </p> <h3>3. Centralized backup key resolution</h3> <p> The backup script passkey handling is now centralized in <code>backup.functions.php</code>. This avoids duplicated and divergent logic between UI, backup worker and restore flows. </p> <p> The helper now resolves: </p> <ul> <li>the current clear backup key,</li> <li>legacy compatible candidates,</li> <li>automatic self-heal when the current value is empty or invalid.</li> </ul> <h3>4. Scheduled backup worker fix</h3> <p> The scheduled backup worker now uses the resolved clear backup key instead of directly using the raw stored value. This aligns the worker behavior with the UI and with the intended meaning of the backup key. </p> <h3>5. Legacy restore compatibility preserved</h3> <p> This PR also preserves restore compatibility for older scheduled backups created before this fix. Those backups may have been encrypted with historical key candidates depending on how the raw value was consumed at the time. </p> <p> To handle that safely: </p> <ul> <li>legacy restore candidates are archived,</li> <li>restore paths now automatically try the current key and archived legacy candidates,</li> <li>manual key entry is only needed if none of the known candidates match.</li> </ul> <p> This allows restoring older scheduled backups even after the current instance backup key has been regenerated later. </p> <h3>6. UI consistency improvements</h3> <p> The following runtime paths now rely on the same centralized key resolution logic: </p> <ul> <li>On-the-fly backup key prefill,</li> <li>copy instance key action from Scheduled backups,</li> <li>scheduled backup worker,</li> <li>restore candidate resolution.</li> </ul> <h2>Files updated</h2> <ul> <li><code>install/install-steps/run.step5.php</code></li> <li><code>install/upgrade_run_3.1.7.php</code></li> <li><code>sources/backup.functions.php</code></li> <li><code>pages/backups.php</code></li> <li><code>sources/backups.queries.php</code></li> <li><code>scripts/background_tasks___worker.php</code></li> <li><code>scripts/restore.php</code></li> <li><code>sources/admin.queries.php</code></li> </ul> <h2>Behavior after this PR</h2> <ul> <li>Fresh installs get a valid backup script passkey immediately.</li> <li>Broken existing instances self-repair when needed.</li> <li>The key is displayed again in On-the-fly backup.</li> <li>The Scheduled backup copy action works again.</li> <li>Scheduled backups run with the correct resolved key.</li> <li>Older scheduled backups remain restorable through archived legacy candidates.</li> </ul> <h2>Tests performed</h2> <ul> <li>Upgrade test on an existing instance: OK</li> <li>Fresh-install logic review for passkey creation: OK</li> <li>Repair test after clearing <code>bck_script_passkey</code>: key regenerated correctly</li> <li>Restore of an older scheduled backup after upgrade with unchanged DB key: OK</li> <li>Restore of an older scheduled backup after later key loss/regeneration, using archived legacy candidates: OK</li> <li>Schema-level incompatibility check still blocks mismatched restores as expected: OK</li> </ul> <h2>Notes</h2> <ul> <li>No new language strings were required.</li> <li>The implementation keeps backward compatibility for legacy scheduled backup restore scenarios.</li> </ul>