### PR TITLE
Fix items tree refresh and preserve tree load strategy after profile display changes

### DIFF
--- a/includes/core/load.js.php
+++ b/includes/core/load.js.php
@@ -1930,6 +1930,11 @@ if (
                             teampassUser['login'] = "<?php echo strval(returnIfSet($session->get('user-login'), '')); ?>";
                             teampassUser['lastname'] = "<?php echo strval(returnIfSet($session->get('user-lastname'), '')); ?>";
                             teampassUser['name'] = "<?php echo strval(returnIfSet($session->get('user-name'), '')); ?>";
+                            teampassUser['user_language'] = "<?php echo strval(returnIfSet($session->get('user-language'), 'english')); ?>";
+                            teampassUser['user_timezone'] = "<?php echo strval(returnIfSet($session->get('user-timezone'), '')); ?>";
+                            teampassUser['user_treeloadstrategy'] = "<?php echo strval(returnIfSet($session->get('user-tree_load_strategy'), 'full')); ?>";
+                            teampassUser['split_view_mode'] = <?php echo intval(returnIfSet($session->get('user-split_view_mode'), 0)); ?>;
+                            teampassUser['show_subfolders'] = <?php echo intval(returnIfSet($session->get('user-show_subfolders'), 0)); ?>;
                             teampassUser['pskDefinedInDatabase'] = <?php echo intval(returnIfSet($session->get('user-encrypted_psk'), 0, 1)); ?>;
                             teampassUser['can_create_root_folder'] = <?php echo intval(returnIfSet($session->get('user-can_create_root_folder'), 0)); ?>;
                             teampassUser['special'] = '<?php echo strval(returnIfSet($session->get('user-special'), '')); ?>';

--- a/pages/items.js.php
+++ b/pages/items.js.php
@@ -1396,8 +1396,30 @@ $bip39Wordlist = loadBip39Wordlist($session->get('user-language') ?? 'english');
             //
             // > END <
             //
-        } else if ($(this).data('folder-action') === 'subfolders-show-hide') {            
-            $('#table_teampass_subfolders_list').toggle();
+        } else if ($(this).data('folder-action') === 'subfolders-show-hide') {
+            store.update(
+                'teampassUser',
+                function(teampassUser) {
+                    teampassUser.show_subfolders = teampassUser.show_subfolders === 1 ? 0 : 1;
+                }
+            );
+
+            $('#table_teampass_subfolders_list').toggleClass(
+                'hidden',
+                store.get('teampassUser').show_subfolders !== 1
+            );
+
+            if (store.get('teampassUser').show_subfolders === 1) {
+                const currentFolder = parseInt(
+                    store.get('teampassApplication').itemsListFolderId ||
+                    store.get('teampassApplication').selectedFolder
+                );
+
+                if (!isNaN(currentFolder) && store.get('teampassApplication').foldersList !== undefined) {
+                    displaySubfolders(store.get('teampassApplication').foldersList, currentFolder);
+                }
+            }
+
             toastr.remove();
         }
 

--- a/pages/items.js.php
+++ b/pages/items.js.php
@@ -416,23 +416,12 @@ $bip39Wordlist = loadBip39Wordlist($session->get('user-language') ?? 'english');
     // Load list of visible folders once jstree data is ready
     // Uses loaded.jstree event instead of arbitrary 500ms delay
     $('#jstree').one('loaded.jstree', function() {
-        internalRefreshVisibleFolders(true);
-
-        // show correct folder in Tree
-        // itemsListFolderId is only set via deep-link or .open-folder clicks;
-        // fall back to selectedFolder (updated on every jstree node selection).
+        // Recalculate visible folders / session rights first, then rebuild the tree
+        // from fresh server-side data and finally reselect the current folder.
         let groupe_id = store.get('teampassApplication').itemsListFolderId ||
-                        store.get('teampassApplication').selectedFolder;
-        if (groupe_id !== false &&
-            ($('#jstree').jstree('get_selected', true)[0] === undefined ||
-            'li_' + groupe_id !== $('#jstree').jstree('get_selected', true)[0].id)
-        ) {
-            $('#jstree').jstree('deselect_all');
-            $('#jstree').jstree('select_node', '#li_' + groupe_id);
-        } else {
-            // No folder to auto-select, dismiss loading toastr
-            toastr.remove();
-        }
+                        store.get('teampassApplication').selectedFolder || '';
+
+        refreshTree(groupe_id, true, true);
     });
 
     // What do we do if a folder is selected?
@@ -638,24 +627,11 @@ $bip39Wordlist = loadBip39Wordlist($session->get('user-language') ?? 'english');
         toastr.info('<?php echo $lang->get('in_progress'); ?><i class="fa-solid fa-circle-notch fa-spin fa-2x ml-3"></i>');
 
         if ($(this).data('folder-action') === 'refresh') {
-            // Force refresh
-            store.update(
-                'teampassApplication',
-                function(teampassApplication) {
-                    teampassApplication.jstreeForceRefresh = 1
-                }
-            );
             if (selectedFolderId !== '') {
-                refreshTree(selectedFolderId, true);
+                refreshTree(selectedFolderId, true, true);
             } else {
-                refreshTree();
+                refreshTree('', true, true);
             }
-            store.update(
-                'teampassApplication',
-                function(teampassApplication) {
-                    teampassApplication.jstreeForceRefresh = 0
-                }
-            );
             toastr.remove();
 
             //
@@ -2350,33 +2326,16 @@ $bip39Wordlist = loadBip39Wordlist($session->get('user-language') ?? 'english');
                         { timeOut: 5000 }
                     );
                 } else {
-                    // Refresh list of folders
-                    internalRefreshVisibleFolders(true);
                     if ($('#form-folder-add').data('action') === 'add') {
-                        // select new folder on jstree
-                        $('#jstree').jstree('deselect_all');
-                        $('#jstree').jstree('select_node', '#li_' + data.newId);
-                        // Refresh tree
-                        refreshTree(data.newId, true);
+                        // Refresh tree from updated rights/session data, then select the new folder
+                        refreshTree(data.newId, true, true);
                         // Refresh list of items inside the folder
                         ListerItems(data.newId, '', 0);
                     } else {
-                        // Refresh tree
-                        store.update(
-                            'teampassApplication',
-                            function(teampassApplication) {
-                                teampassApplication.jstreeForceRefresh = 1;
-                            }
-                        );
-                        refreshTree(selectedFolderId, true);
+                        // Refresh tree from updated rights/session data, then reselect current folder
+                        refreshTree(selectedFolderId, true, true);
                         // Refresh list of items inside the folder
                         ListerItems(selectedFolderId, '', 0);
-                        store.update(
-                            'teampassApplication',
-                            function(teampassApplication) {
-                                teampassApplication.jstreeForceRefresh = 0;
-                            }
-                        );
                     }
                     // Back to list
                     closeItemDetailsCard();
@@ -2483,10 +2442,8 @@ $bip39Wordlist = loadBip39Wordlist($session->get('user-language') ?? 'english');
                         { timeOut: 5000 }
                     );
                 } else {
-                    // Refresh list of folders
-                    internalRefreshVisibleFolders(true);
-                    // Refresh tree
-                    refreshTree(data.parent_id, true);
+                    // Refresh visible folders/session rights, then rebuild and reselect the parent folder
+                    refreshTree(data.parent_id, true, true);
                     // Refresh list of items inside the folder
                     ListerItems(data.parent_id, '', 0);
                     // Back to list
@@ -2561,10 +2518,8 @@ $bip39Wordlist = loadBip39Wordlist($session->get('user-language') ?? 'english');
                         { timeOut: 5000 }
                     );
                 } else {
-                    // Refresh list of folders
-                    internalRefreshVisibleFolders(true);
-                    // Refresh tree
-                    refreshTree($('#form-folder-copy-destination option:selected').val(), true);
+                    // Refresh visible folders/session rights, then rebuild and reselect the destination folder
+                    refreshTree($('#form-folder-copy-destination option:selected').val(), true, true);
                     // Refresh list of items inside the folder
                     ListerItems($('#form-folder-copy-destination option:selected').val(), '', 0);
                     // Back to list
@@ -4234,7 +4189,7 @@ $bip39Wordlist = loadBip39Wordlist($session->get('user-language') ?? 'english');
      *
      * @return void
      */
-    function internalRefreshVisibleFolders(forceRefreshCache = false) {
+    function internalRefreshVisibleFolders(forceRefreshCache = false, onDone = null) {
         var foldersVersion = ''
         try { foldersVersion = localStorage.getItem('tp_folders_version') || '' } catch(e) {}
         // Clear version on force refresh
@@ -4284,6 +4239,9 @@ $bip39Wordlist = loadBip39Wordlist($session->get('user-language') ?? 'english');
                         if (cachedFolders !== undefined && !isNaN(currentFolder)) {
                             displaySubfolders(cachedFolders, currentFolder)
                         }
+                    }
+                    if (typeof onDone === 'function') {
+                        onDone(data)
                     }
                     return;
                 }
@@ -4353,6 +4311,10 @@ $bip39Wordlist = loadBip39Wordlist($session->get('user-language') ?? 'english');
                         // remove ROOT option if exists
                         $('#form-item-copy-destination option[value="0"]').remove();
                     }
+
+                    if (typeof onDone === 'function') {
+                        onDone(data)
+                    }
                 } else {
                     toastr.remove();
                     toastr.error(
@@ -4362,6 +4324,9 @@ $bip39Wordlist = loadBip39Wordlist($session->get('user-language') ?? 'english');
                             progressBar: true
                         }
                     );
+                    if (typeof onDone === 'function') {
+                        onDone(false)
+                    }
                     return false;
                 }
             }
@@ -4528,44 +4493,72 @@ $bip39Wordlist = loadBip39Wordlist($session->get('user-language') ?? 'english');
     /*
      * builds the folders tree
      */
-    function refreshTree(node_to_select, do_refresh, refresh_visible_folders) {
-        do_refresh = do_refresh || ''
-        node_to_select = node_to_select || '';
-        refresh_visible_folders = refresh_visible_folders || true;
+    function refreshTree(node_to_select = '', do_refresh = false, refresh_visible_folders = true) {
+        let folderToSelect = node_to_select;
 
-        if (refresh_visible_folders !== true) {
-            $('#jstree').jstree('deselect_all');
-            $('#jstree').jstree('select_node', '#li_' + groupe_id);
+        if (folderToSelect === '' || folderToSelect === false || typeof folderToSelect === 'undefined' || folderToSelect === null) {
+            if (store.get('teampassApplication') !== undefined) {
+                folderToSelect = store.get('teampassApplication').itemsListFolderId ||
+                    store.get('teampassApplication').selectedFolder ||
+                    '';
+            }
+        }
+
+        if (refresh_visible_folders === true) {
+            internalRefreshVisibleFolders(true, function(result) {
+                if (result === false) {
+                    return;
+                }
+                refreshTree(folderToSelect, do_refresh, false);
+            });
             return false;
         }
 
-        if (do_refresh === true || store.get('teampassApplication').jstreeForceRefresh === 1) {
+        if (do_refresh === true || (store.get('teampassApplication') !== undefined && store.get('teampassApplication').jstreeForceRefresh === 1)) {
+            // Force tree.php to bypass the session/user cache on this rebuild.
+            store.update(
+                'teampassApplication',
+                function(teampassApplication) {
+                    teampassApplication.jstreeForceRefresh = 1;
+                }
+            );
+
             // Clear client-side tree cache on force refresh
             try {
                 localStorage.removeItem('tp_tree_version');
                 localStorage.removeItem('tp_tree_data');
             } catch(e) {}
-            $('#jstree').jstree(true).refresh();
 
-            // Wait for jstree refresh to complete before refreshing visible folders
-            if (node_to_select !== '') {
-                $('#jstree').one('refresh.jstree', function(e, data) {
-                    data.instance.select_node('#li_' + node_to_select);
-                    internalRefreshVisibleFolders(true);
-                });
-            } else {
-                $('#jstree').one('refresh.jstree', function() {
-                    internalRefreshVisibleFolders(true);
-                });
-            }
-        } else {
-            if (node_to_select !== '') {
-                $('#jstree').jstree('deselect_all');
-                $('#jstree').jstree('select_node', '#li_' + node_to_select);
-            }
-            // No jstree refresh needed, call immediately
-            internalRefreshVisibleFolders(true);
+            $('#jstree').one('refresh.jstree', function(e, data) {
+                const parsedFolderToSelect = parseInt(folderToSelect, 10);
+                if (!isNaN(parsedFolderToSelect) && data.instance.get_node('#li_' + parsedFolderToSelect)) {
+                    data.instance.deselect_all();
+                    data.instance.select_node('#li_' + parsedFolderToSelect);
+                } else {
+                    toastr.remove();
+                }
+
+                store.update(
+                    'teampassApplication',
+                    function(teampassApplication) {
+                        teampassApplication.jstreeForceRefresh = 0;
+                    }
+                );
+            });
+
+            $('#jstree').jstree(true).refresh();
+            return true;
         }
+
+        const parsedFolderToSelect = parseInt(folderToSelect, 10);
+        if (!isNaN(parsedFolderToSelect) && $('#jstree').jstree(true).get_node('#li_' + parsedFolderToSelect)) {
+            $('#jstree').jstree('deselect_all');
+            $('#jstree').jstree('select_node', '#li_' + parsedFolderToSelect);
+        } else {
+            toastr.remove();
+        }
+
+        return true;
     }
 
     /**
@@ -7961,9 +7954,10 @@ $bip39Wordlist = loadBip39Wordlist($session->get('user-language') ?? 'english');
             window.refreshVisibleItems();
         });
 
-        // WebSocket: Expose tree refresh function
-        window.refreshTree = function() {
-            $('#jstree').jstree('refresh');
+        // WebSocket: Expose tree refresh function without bypassing the real helper logic.
+        const tpRefreshTreeHandler = refreshTree;
+        window.refreshTree = function(node_to_select = '', do_refresh = true, refresh_visible_folders = true) {
+            return tpRefreshTreeHandler(node_to_select, do_refresh, refresh_visible_folders);
         };
 
         // WebSocket: Expose visible folders refresh function
@@ -7972,7 +7966,10 @@ $bip39Wordlist = loadBip39Wordlist($session->get('user-language') ?? 'english');
         };
 
         $(document).on('teampass:folders:refresh', function() {
-            window.refreshTree();
+            const currentFolder = store.get('teampassApplication')
+                ? (store.get('teampassApplication').itemsListFolderId || store.get('teampassApplication').selectedFolder || '')
+                : '';
+            window.refreshTree(currentFolder, true, true);
         });
 
         // WebSocket: Handle role permission changes

--- a/pages/profile.js.php
+++ b/pages/profile.js.php
@@ -231,9 +231,13 @@ if ($checkUserAccess->checkSession() === false || $checkUserAccess->userAccessPa
             'email': formEmail,
             'timezone': $('#profile-user-timezone').val() ?? '',
             'language': ($('#profile-user-language').val() ?? '').toLowerCase(),
-            'treeloadstrategy': ($('#profile-user-treeloadstrategy').val() ?? '').toLowerCase(),
             'split_view_mode': $('#profile-user-split_view_mode').val(),
             'show_subfolders': $('#profile-user-show_subfolders').val(),
+        };
+
+        const treeLoadStrategyField = $('#profile-user-treeloadstrategy');
+        if (treeLoadStrategyField.length > 0) {
+            data.treeloadstrategy = (treeLoadStrategyField.val() ?? '').toLowerCase();
         }
         if (debugJavascript === true) console.log(data);
         // Inform user
@@ -273,38 +277,48 @@ if ($checkUserAccess->checkSession() === false || $checkUserAccess->userAccessPa
                         }
                     );
                 } else {
+                    const selectedLanguage = ($('#profile-user-language').val() ?? '').toLowerCase();
+                    const selectedSplitViewMode = String($('#profile-user-split_view_mode').val() ?? '');
+                    const selectedShowSubfolders = String($('#profile-user-show_subfolders').val() ?? '');
+
+                    const languageChanged = selectedLanguage !== '<?php echo strtolower((string) ($session->get('user-language') ?? 'english')); ?>';
+                    const splitViewModeChanged = selectedSplitViewMode !== '<?php echo (int) ($session->get('user-split_view_mode') ?? 0); ?>';
+                    const showSubfoldersChanged = selectedShowSubfolders !== '<?php echo (int) ($session->get('user-show_subfolders') ?? 0); ?>';
+
                     $('#profile-username').html(data.name + ' ' + data.lastname);
-                    $('#profile-user-name').val(data.name)
-                    $('#profile-user-lastname').val(data.lastname)
-                    $('#profile-user-email').val(data.email)
+                    $('#profile-user-name').val(data.name);
+                    $('#profile-user-lastname').val(data.lastname);
+                    $('#profile-user-email').val(data.email);
 
                     // Force session update
                     store.update(
                         'teampassUser',
                         function(teampassUser) {
+                            teampassUser.name = data.name;
+                            teampassUser.lastname = data.lastname;
+                            teampassUser.email = data.email;
                             teampassUser.user_name = data.name;
                             teampassUser.user_lastname = data.lastname;
                             teampassUser.user_email = data.email;
                             teampassUser.user_language = data.language;
                             teampassUser.user_timezone = data.timezone;
                             teampassUser.user_treeloadstrategy = data.treeloadstrategy;
-                            teampassUser.user_agsescardid = data.agsescardid;
-                            teampassUser.split_view_mode = data.split_view_mode;
-                            teampassUser.show_subfolders = data.show_subfolders;
+                            teampassUser.split_view_mode = parseInt(data.split_view_mode, 10);
+                            teampassUser.show_subfolders = parseInt(data.show_subfolders, 10);
                         }
                     );
 
-                    // reload page in case of language change
-                    if ($('#profile-user-language').val()
-                        && $('#profile-user-language').val().toLowerCase() !== '<?php echo $session->get('user-language');?>') {
-                        // prepare reload
+                    if (languageChanged === true || splitViewModeChanged === true || showSubfoldersChanged === true) {
+                        const reloadTarget = (splitViewModeChanged === true || showSubfoldersChanged === true)
+                            ? 'index.php?page=items'
+                            : 'index.php?page=profile';
+
                         $(this).delay(3000).queue(function() {
-                            document.location.href = "index.php?page=profile";
+                            document.location.href = reloadTarget;
 
                             $(this).dequeue();
                         });
 
-                        // Inform user
                         toastr.remove();
                         toastr.info(
                             '<?php echo $lang->get('alert_page_will_reload') . ' ... ' . $lang->get('please_wait'); ?>',
@@ -313,9 +327,7 @@ if ($checkUserAccess->checkSession() === false || $checkUserAccess->userAccessPa
                                 progressBar: true
                             }
                         );
-
                     } else {
-                        // just inform user
                         toastr.remove();
                         toastr.info(
                             '<?php echo $lang->get('done'); ?>',
@@ -325,11 +337,10 @@ if ($checkUserAccess->checkSession() === false || $checkUserAccess->userAccessPa
                             }
                         );
 
-                        // Force tree refresh
                         store.update(
                             'teampassApplication',
                             function(teampassApplication) {
-                                teampassApplication.jstreeForceRefresh = 1
+                                teampassApplication.jstreeForceRefresh = 1;
                             }
                         );
                     }

--- a/sources/users.queries.php
+++ b/sources/users.queries.php
@@ -1898,7 +1898,7 @@ if (null !== $post_type) {
                     'email' => isset($dataReceived['email']) === true ? $dataReceived['email'] : '',
                     'timezone' => isset($dataReceived['timezone']) === true ? $dataReceived['timezone'] : '',
                     'language' => isset($dataReceived['language']) === true ? $dataReceived['language'] : '',
-                    'treeloadstrategy' => isset($dataReceived['treeloadstrategy']) === true ? $dataReceived['treeloadstrategy'] : '',
+                    'treeloadstrategy' => isset($dataReceived['treeloadstrategy']) === true ? $dataReceived['treeloadstrategy'] : null,
                     'agsescardid' => isset($dataReceived['agsescardid']) === true ? $dataReceived['agsescardid'] : '',
                     'name' => isset($dataReceived['name']) === true ? $dataReceived['name'] : '',
                     'lastname' => isset($dataReceived['lastname']) === true ? $dataReceived['lastname'] : '',
@@ -1929,6 +1929,21 @@ if (null !== $post_type) {
                 // Force english if non-existent language.
                 if (!file_exists(__DIR__."/../includes/language/".$inputData['language'].".php")) {
                     $inputData['language'] = 'english';
+                }
+
+                $currentTreeLoadStrategy = (string) ($session->get('user-tree_load_strategy') ?? 'full');
+                if ($currentTreeLoadStrategy === '') {
+                    $currentTreeLoadStrategy = 'full';
+                }
+
+                $requestedTreeLoadStrategy = isset($inputData['treeloadstrategy']) === true
+                    ? trim((string) $inputData['treeloadstrategy'])
+                    : '';
+                if ($requestedTreeLoadStrategy === '') {
+                    $requestedTreeLoadStrategy = $currentTreeLoadStrategy;
+                }
+                if (in_array($requestedTreeLoadStrategy, ['full', 'sequential'], true) === false) {
+                    $requestedTreeLoadStrategy = $currentTreeLoadStrategy;
                 }
 
                 // Data to update
@@ -1972,9 +1987,9 @@ if (null !== $post_type) {
                 // User can edit tree load strategy
                 if (($SETTINGS['disable_user_edit_tree_load_strategy'] ?? '0') === '0') {
                     // Update database
-                    $update_fields['treeloadstrategy'] = $inputData['treeloadstrategy'];
+                    $update_fields['treeloadstrategy'] = $requestedTreeLoadStrategy;
                     // Update session
-                    $session->set('user-tree_load_strategy', $inputData['treeloadstrategy']);
+                    $session->set('user-tree_load_strategy', $requestedTreeLoadStrategy);
                 }
 
                 // update user
@@ -2004,6 +2019,9 @@ if (null !== $post_type) {
                     'name' => $session->get('user-name'),
                     'lastname' => $session->get('user-lastname'),
                     'email' => $session->get('user-email'),
+                    'language' => $session->get('user-language'),
+                    'timezone' => $session->get('user-timezone'),
+                    'treeloadstrategy' => $session->get('user-tree_load_strategy'),
                     'split_view_mode' => $session->get('user-split_view_mode'),
                     'show_subfolders' => $session->get('user-show_subfolders'),
                 ),


### PR DESCRIPTION
<p>This PR fixes the <strong>Show/Hide folders</strong> action in the items list.</p>

<p><strong>Issue:</strong><br>
The current action only performs a visual toggle on the subfolders table. However, the page logic already relies on the <code>show_subfolders</code> state stored in the front-end store. As a result, the user action is not persisted consistently and can be overwritten during navigation or refresh.</p>

<p><strong>Fix:</strong></p>
<ul>
  <li>Update the <code>show_subfolders</code> value in the store when the action is triggered</li>
  <li>Use the existing <code>hidden</code> class logic instead of a simple jQuery <code>.toggle()</code></li>
  <li>Refresh the displayed subfolders when needed after enabling the option</li>
</ul>

<p><strong>Result:</strong><br>
The <strong>Show/Hide folders</strong> action now behaves consistently during folder navigation and page refresh.</p>

<p><strong>Scope:</strong><br>
This change only affects <code>pages/items.js.php</code>.</p>