### PR TITLE
Fix install folder cleanup after upgrade and keep cleanup flag on failure

### DIFF
--- a/sources/core.php
+++ b/sources/core.php
@@ -145,7 +145,7 @@ if (
         'install',
         'clear_install_folder'
     );
-    if (DB::count() > 0 && $row['valeur'] === 'true') {
+    if (DB::count() > 0 && isset($row['valeur']) === true && $row['valeur'] === 'true') {
         /**
          * Permits to delete files and folders recursively.
          *
@@ -153,46 +153,51 @@ if (
          *
          * @return bool
          */
-        function delTree($dir)
-        {
-            $directories = scandir($dir);
-            if ($directories !== false) {
-                $files = array_diff($directories, ['.', '..']);
-                foreach ($files as $file) {
-                    if (is_dir($dir . '/' . $file)) {
-                        delTree($dir . '/' . $file);
-                    } else {
-                        try {
-                            unlink($dir . '/' . $file);
-                        } catch (Exception $e) {
-                            // do nothing... php will ignore and continue
+        if (function_exists('delTree') === false) {
+            function delTree(string $dir): bool
+            {
+                $directories = scandir($dir);
+                if ($directories !== false) {
+                    $files = array_diff($directories, ['.', '..']);
+                    foreach ($files as $file) {
+                        $path = $dir . '/' . $file;
+                        if (is_dir($path) === true) {
+                            delTree($path);
+                        } else {
+                            try {
+                                unlink($path);
+                            } catch (Exception $e) {
+                                // do nothing... php will ignore and continue
+                            }
                         }
                     }
+
+                    return @rmdir($dir);
                 }
 
-                return @rmdir($dir);
+                return false;
             }
-
-            // else return false
-            return false;
         }
 
         // Set the permissions on the install directory and delete
         // is server Windows or Linux?
         if (strtoupper(substr(PHP_OS, 0, 3)) !== 'WIN') {
-            recursiveChmod($SETTINGS['cpassman_dir'] . '/install', 0755, 0440);
+            recursiveChmod($SETTINGS['cpassman_dir'] . '/install', 0440, 0755);
         }
-        delTree($SETTINGS['cpassman_dir'] . '/install');
 
-        // Delete temporary install table
-        DB::query('DROP TABLE IF EXISTS `_install`');
-        // Delete tag
-        DB::delete(
-            prefixTable('misc'),
-            'type=%s AND intitule=%s',
-            'install',
-            'clear_install_folder'
-        );
+        $installFolderDeleted = delTree($SETTINGS['cpassman_dir'] . '/install');
+
+        if ($installFolderDeleted === true) {
+            // Delete temporary install table
+            DB::query('DROP TABLE IF EXISTS `_install`');
+            // Delete tag
+            DB::delete(
+                prefixTable('misc'),
+                'type=%s AND intitule=%s',
+                'install',
+                'clear_install_folder'
+            );
+        }
     }
 }
 


### PR DESCRIPTION
<h2>Summary</h2>
<p>
This PR fixes the post-upgrade cleanup flow responsible for removing the <code>/install</code> folder on the next normal application load.
</p>

<h2>Initial problem</h2>
<p>
The upgrade itself completed successfully, but the <code>/install</code> folder could remain on disk afterwards.
In that situation, TeamPass could still block the admin login because the install directory was still present.
</p>

<p>
The root cause was in <code>sources/core.php</code>, inside the cleanup logic executed when the
<code>install / clear_install_folder</code> flag is present. The code called
<code>recursiveChmod($path, 0755, 0440)</code> even though <code>recursiveChmod()</code> expects
<code>(path, filePerm, dirPerm)</code>. As a result, file and directory permissions were applied in the wrong order:
directories could receive <code>0440</code>, which can prevent recursive deletion from succeeding. 
</p>

<p>
There was also a second issue: the cleanup flag was deleted even when the folder deletion failed.
This meant the cleanup attempt was considered done although <code>/install</code> was still present, preventing a later retry.
</p>

<h2>What this PR changes</h2>
<ul>
  <li>
    Fix the <code>recursiveChmod()</code> call in <code>sources/core.php</code> by passing permissions in the correct order:
    file permissions first, directory permissions second.
  </li>
  <li>
    Delete the <code>clear_install_folder</code> flag only when the recursive deletion of <code>/install</code> actually succeeds.
  </li>
  <li>
    Guard the local <code>delTree()</code> helper declaration to avoid a possible fatal redeclaration during cleanup retries.
  </li>
</ul>

<h2>Why this fix is minimal and safe</h2>
<ul>
  <li>No upgrade flow change is introduced.</li>
  <li>No database schema change is introduced.</li>
  <li>The change is limited to the install cleanup logic in <code>sources/core.php</code>.</li>
  <li>The existing upgrade flag creation in <code>install/upgrade_ajax.php</code> remains unchanged. 
  </li>
</ul>

<h2>Validation performed</h2>
<ul>
  <li>Ran the upgrade process successfully through <code>/install/upgrade.php</code>.</li>
  <li>Verified the redirection back to the login page after upgrade.</li>
  <li>Verified that the <code>/install</code> folder is removed after the upgrade flow completes.</li>
  <li>Verified that the <code>install / clear_install_folder</code> flag is no longer present once cleanup succeeds.</li>
  <li>Verified that admin login works again once the install folder has been removed.</li>
  <li>Replayed the full upgrade scenario multiple times successfully.</li>
</ul>

<h2>Technical note</h2>
<p>
This preserves the intended behavior:
<code>install/upgrade_ajax.php</code> sets the cleanup marker at the end of the upgrade,
and <code>sources/core.php</code> performs the actual removal during the next normal bootstrap. 
</p>

<h2>Possible follow-up improvement</h2>
<p>
As a follow-up, it could be useful to display a clear warning message whenever the <code>/install</code> directory is still present.
</p>

<p>
Today, the cleanup is expected to happen after the upgrade flow completes, through the marker set during upgrade and consumed later during the normal bootstrap. When this cleanup does not happen as expected, the current behavior can be confusing for administrators because the upgrade itself appears successful, but access may still be blocked until the install directory is removed.
</p>

<p>
There is already a user-facing warning pattern in TeamPass when an upgrade is required because of a database schema change. Applying a similar logic when the <code>/install</code> directory is still detected could make troubleshooting much easier and give administrators a more explicit explanation of why access is restricted.
</p>

<p>
This is not included in this PR because the goal here is to keep the fix minimal and focused on the cleanup issue itself, but it may be a useful UX/security improvement for a separate follow-up change.
</p>