### PR TITLE
Fix API personal folder resolution when folder ID collides with role ID

### DIFF
--- a/api/Model/AuthModel.php
+++ b/api/Model/AuthModel.php
@@ -344,10 +344,8 @@ class AuthModel
         $rows = DB::queryFirstRow(
             'SELECT id 
             FROM ' . prefixTable('nested_tree') . '
-            WHERE title = %i AND personal_folder = 1'.
-            (count($userFunctionId) > 0 ? ' AND id NOT IN %li' : ''),
-            $userInfo['id'],
-            count($userFunctionId) > 0 ? $userFunctionId : DB::sqleval('0')
+            WHERE title = %i AND personal_folder = 1',
+            $userInfo['id']
         );
         if (empty($rows['id']) === false) {
             array_push($personalFolders, $rows['id']);


### PR DESCRIPTION
## Summary

This PR fixes an API-side issue where a user's personal folder could be excluded from the API `folders_list` when the personal folder ID happened to match one of the user's role IDs.

The issue was observed with the browser extension, which relies on the TeamPass API endpoint:

```http
GET /api/index.php/folder/writableFolders
```

When the personal folder was missing from the API folder cache, the extension could not display or use the user's personal folder, even though the folder existed and worked correctly in the TeamPass web UI.

## Root Cause

In `api/Model/AuthModel.php`, `AuthModel::buildUserFoldersList()` attempted to load the user's personal folder with this condition:

```sql
WHERE title = %i
  AND personal_folder = 1
  AND id NOT IN %li
```

However, the `NOT IN` list was populated with `$userFunctionId`, which contains role IDs, not folder IDs.

This caused an invalid comparison between:

- `nested_tree.id`, a folder ID
- `users_roles.role_id`, a role ID

If both values happened to be numerically equal, the user's own personal folder was excluded from the API-accessible folders list.

## Example

On one affected instance:

```text
personal folder ID: 2
manual role ID:     2
```

Because of the incorrect `id NOT IN (...)` condition, the API excluded folder `2`, even though it was the user's personal folder.

The generated `cache_tree.folders` value therefore did not contain the personal folder ID, and API consumers such as the browser extension could not see it.

On another instance, the same code worked because the user's personal folder ID was `4120`, and no role had that same ID. So the bug existed but was not triggered by the data.

## Fix

The personal folder lookup now only matches the actual personal folder ownership criteria:

```sql
WHERE title = %i
  AND personal_folder = 1
```

The incorrect role-based exclusion has been removed.

## Modified File

`api/Model/AuthModel.php`

Changed inside:

```php
AuthModel::buildUserFoldersList()
```

Specifically in the `// Add all personal folders` block.

## Why This Is Safe

The removed condition compared unrelated identifiers and could only incorrectly exclude a valid personal folder.

The personal folder is still restricted by the existing ownership rule:

```sql
title = user_id
AND personal_folder = 1
```

So this does not grant access to other users' personal folders.

## Validation

Validated on an affected instance where:

```text
user_id:            10000001
personal_folder_id: 2
role_id:            2
```

Before the fix, `teampass_cache_tree.folders` did not contain folder `2`.

After applying the patch and invalidating the user's folder cache, the extension successfully loaded the user's personal folder content.

Cache invalidation used for validation:

```sql
UPDATE teampass_cache_tree
SET invalidated_at = timestamp + 1
WHERE user_id = 10000001;
```

Then the cache was rebuilt by the next API call.

## Regression Check

The following SQL can identify users affected by the same collision:

```sql
SELECT
  u.id AS user_id,
  u.login,
  nt.id AS personal_folder_id,
  ur.role_id,
  rt.title AS role_name
FROM teampass_users u
JOIN teampass_nested_tree nt
  ON nt.title = CAST(u.id AS CHAR)
 AND nt.personal_folder = 1
JOIN teampass_users_roles ur
  ON ur.user_id = u.id
 AND ur.source = 'manual'
LEFT JOIN teampass_roles_title rt
  ON rt.id = ur.role_id
WHERE ur.role_id = nt.id;
```

## Notes

No database schema change is required.

Existing valid caches do not need to be rebuilt. Only users whose API folder cache was generated with the faulty exclusion may need their `cache_tree` entry invalidated so it can be rebuilt.