### PR TITLE
Clarify pre-migration filesystem permissions for 3.2.x upgrades

### DIFF
--- a/docs/install/upgrade.md
+++ b/docs/install/upgrade.md
@@ -95,9 +95,44 @@ composer install --no-dev --optimize-autoloader
 TeamPass 3.2.0 moves user data from the old flat layout to the new `app/` / `storage/` structure.
 This migration **must** be done from the command line before the web-based upgrade wizard is launched.
 
+#### Before running the script — set a safe permission baseline
+
+Do **not** recursively make the whole TeamPass tree owned by, or writable by, the web server user.
+In particular, avoid commands such as:
+
+```bash
+chown -R www-data:www-data /path/to/teampass
+chmod -R 775 /path/to/teampass
+```
+
+With the 3.2.0 layout, `app/` and `public/` must remain non-writable by the web server user.
+Only runtime/configuration locations such as `storage/`, `secrets/`, `app/config/`, the CSRF configuration directory and avatars should be writable/readable as required.
+
+Before running the migration script, apply a conservative baseline so the code directories are readable/traversable but not web-writable:
+
 ```bash
 cd /path/to/teampass
-php migrate_3.2.x.php
+
+# Replace www-data if your web server/PHP-FPM runs under another user.
+WEB_USER=www-data
+
+# Keep the code roots outside of the web server write scope.
+sudo chown root:root . app public
+sudo chmod 0755 . app public
+
+# If these legacy data directories exist, ensure the migration command can read/move them.
+sudo chmod -R u+rwX files upload backups includes/config includes/avatars 2>/dev/null || true
+```
+
+> **Important:** these are only pre-migration baseline permissions.
+> The migration script prints a more precise set of `chown` / `chmod` commands at the end.
+> Apply those commands before launching the web-based upgrade wizard.
+
+Then run the migration script. Running it as `root` or with `sudo` is recommended on packaged web-server deployments, because the script needs to move existing runtime data and prepare filesystem permissions.
+
+```bash
+cd /path/to/teampass
+sudo php migrate_3.2.x.php --web-user="$WEB_USER"
 ```
 
 **Available options:**
@@ -119,13 +154,16 @@ php migrate_3.2.x.php
 3. Moves `upload/` → `storage/upload/`
 4. Moves `backups/` → `storage/backups/`
 5. Copies user avatars to `public/assets/avatars/`
-6. Adjusts file ownership and permissions for `www-data`
+6. Prepares filesystem permissions and prints the final `chown` / `chmod` commands to run for the web server user
 
 > **Tip:** Run with `--dry-run` first to preview all operations, then run again without the flag to apply them.
 
+At the end of the migration, copy and run the permission commands displayed by the script.
+They are intentionally more precise than a global recursive `chown` / `chmod`: `storage/` and `secrets/` are prepared for runtime access, while `app/` and `public/` remain protected from web-server writes.
+
 > **Important:** If the upgrade page detects that the database version is still below 3.2.0 while the code is already at 3.2.0, it will display a blocking warning and refuse to start until this script has been executed.
 
-Once the script completes successfully, refresh the upgrade page and proceed to Step 4.
+Once the script completes successfully and the displayed permission commands have been applied, refresh the upgrade page and proceed to Step 4.
 
 ---
 


### PR DESCRIPTION
<h2>Summary</h2>

<p>
This PR clarifies the filesystem permission steps required during an upgrade to TeamPass 3.2.x.
</p>

<p>
It adds a dedicated permission baseline step before running <code>migrate_3.2.x.php</code>, and clarifies that the more restrictive, final permissions must still be applied using the instructions printed by the migration script before launching the web upgrade wizard.
</p>

<h2>Context</h2>

<p>
While testing the upcoming TeamPass 3.2.0.0 release, I followed the current <code>upgrade.md</code> process and the recommendations printed by <code>migrate_3.2.x.php</code>.
</p>

<p>
However, I initially reused the filesystem permissions I had applied during older TeamPass upgrades. Those permissions were based on a previous upgrade procedure and consisted of applying broad ownership and write permissions to the whole TeamPass directory, for example:
</p>

<pre><code>sudo chmod -R 775 /path/to/teampass
sudo chown -R www-data:www-data /path/to/teampass
</code></pre>

<p>
This was previously a practical way to avoid permission issues during upgrades, but it is no longer appropriate with the new 3.2.x directory layout.
</p>

<h2>Issue observed</h2>

<p>
With the new 3.2.x layout, the application is split into dedicated directories:
</p>

<ul>
  <li><code>app/</code> contains application source code and must not be writable by the web server user.</li>
  <li><code>public/</code> is the webroot and must not be globally writable by the web server user.</li>
  <li><code>storage/</code> must be writable because it contains runtime data.</li>
  <li><code>secrets/</code> must be readable by the web server user, but should remain tightly restricted.</li>
</ul>

<p>
Applying a global <code>chown -R www-data:www-data</code> and <code>chmod -R 775</code> before or during the upgrade makes <code>app/</code> and <code>public/</code> writable by the web server.
</p>

<p>
This then causes warnings in the web upgrade wizard because those directories are correctly detected as writable by the web server, which does not match the expected security posture.
</p>

<p>
In my test case, permissions on <code>secrets/</code> were also involved in an HTTP 500 error when accessing <code>/install/upgrade.php</code>, because the encryption key file was not readable by PHP-FPM at that point.
</p>

<h2>Why this documentation change is useful</h2>

<p>
The current documentation explains how to copy the new files and then run <code>migrate_3.2.x.php</code>, but it does not explicitly warn administrators not to apply broad legacy permissions to the whole TeamPass tree before migration.
</p>

<p>
This is important because administrators upgrading from older versions may naturally reuse permission commands from previous procedures. That can unintentionally break the expected 3.2.x permission model.
</p>

<p>
The added documentation makes the intended workflow clearer:
</p>

<ol>
  <li>Copy the new 3.2.x sources into the existing TeamPass directory.</li>
  <li>Apply a safe, coarse permission baseline before running the filesystem migration script.</li>
  <li>Run <code>migrate_3.2.x.php</code>.</li>
  <li>Apply the precise permission commands printed by the migration script.</li>
  <li>Only then launch the web-based upgrade wizard.</li>
</ol>

<h2>What this PR changes</h2>

<ul>
  <li>Adds a pre-migration permission baseline section to <code>upgrade.md</code>.</li>
  <li>Explicitly warns against applying global <code>chmod -R 775</code> and <code>chown -R www-data:www-data</code> on the full TeamPass tree.</li>
  <li>Clarifies that the pre-migration permissions are only a temporary safe baseline.</li>
  <li>Clarifies that the final permission adjustment must still be done using the commands printed by <code>migrate_3.2.x.php</code>.</li>
  <li>Helps avoid confusion between legacy upgrade permission habits and the new 3.2.x security posture.</li>
</ul>

<h2>Testing / validation</h2>

<ul>
  <li>Tested during a 3.2.0.0 upgrade scenario.</li>
  <li>Confirmed that broad legacy permissions can make <code>app/</code> and <code>public/</code> writable by the web server.</li>
  <li>Confirmed that the web upgrade wizard reports warnings when those directories are writable.</li>
  <li>Confirmed that applying targeted permissions resolves the access issue and allows the upgrade wizard to continue.</li>
</ul>

<h2>Notes</h2>

<p>
This PR does not change the migration script behavior.
</p>

<p>
It only improves the upgrade documentation so administrators know which permissions to apply before running the migration script, and why they should avoid applying legacy global write permissions to the whole TeamPass directory.
</p>