### PR TITLE
Fix API item limit query parameter type casting

### DIFF
--- a/app/api/Controller/Api/ItemController.php
+++ b/app/api/Controller/Api/ItemController.php
@@ -110,7 +110,7 @@ class ItemController extends BaseController
             // SQL LIMIT
             $intLimit = 0;
             if (isset($arrQueryStringParams['limit']) === true) {
-                $intLimit = $arrQueryStringParams['limit'];
+                $intLimit = (int) $arrQueryStringParams['limit'];
             }
 
             // send query
@@ -324,7 +324,7 @@ class ItemController extends BaseController
                     ? DB::escape('%' . $arrQueryStringParams['label'] . '%')
                     : DB::escape($arrQueryStringParams['label']);
                 $sqlExtra .= ' AND i.label ' . ($isLikeLabel ? 'LIKE ' : '= ') . $escapedLabel . $sql_constraint;
-                $sqlLimit = isset($arrQueryStringParams['limit']) === true && (int) $arrQueryStringParams['limit'] > 0 ? $arrQueryStringParams['limit'] : 50;   // let's limit to 50 by default
+                $sqlLimit = isset($arrQueryStringParams['limit']) === true && (int) $arrQueryStringParams['limit'] > 0 ? (int) $arrQueryStringParams['limit'] : 50;   // let's limit to 50 by default
             } else if (isset($arrQueryStringParams['description']) === true) {
                 // build sql where clause by DESCRIPTION
                 $isLikeDesc = isset($arrQueryStringParams['like']) && (int) $arrQueryStringParams['like'] === 1;


### PR DESCRIPTION
This PR fixes a TypeError in the API item endpoints when the optional `limit`
query parameter is provided.

`limit` is read from query string parameters as a string, but
ItemModel::getItems() expects an integer for its `$limit` argument.

Changes:
- Cast `limit` to int in ItemController::inFoldersAction()
- Apply the same cast in ItemController::getAction() for label searches

Test:
- php -l api/Controller/Api/ItemController.php