### PR TITLE
Fix Personal Folder Descendant Access in API

### DIFF
--- a/app/api/Controller/Api/FolderController.php
+++ b/app/api/Controller/Api/FolderController.php
@@ -156,39 +156,44 @@ class FolderController extends BaseController
 
         if (strtoupper($requestMethod) === 'GET') {
             try {
-                $userFolders = !empty($userData['folders_list']) ? explode(',', $userData['folders_list']) : [];
-                $rows = DB::query(
-                    'SELECT nt.id AS folder_id, nt.title, nt.nlevel, nt.parent_id
-                    FROM ' . prefixTable('nested_tree') . ' AS nt
-                    LEFT JOIN ' . prefixTable('nested_tree') . ' AS personal 
-                        ON personal.personal_folder = 1 
-                        AND personal.title = %s
-                    WHERE nt.id IN %li
-                    AND (
-                        nt.personal_folder = 0
-                        OR (
-                            personal.id IS NOT NULL
-                            AND nt.nleft >= personal.nleft 
-                            AND nt.nright <= personal.nright
-                        )
-                    )
-                    GROUP BY nt.id, nt.title, nt.nlevel, nt.parent_id
-                    ORDER BY nt.nlevel ASC, nt.title ASC',
-                    $userData['id'],
-                    $userFolders
+                $folderAccessModel = new FolderAccessModel();
+                $userFolders = $folderAccessModel->filterFoldersForUser(
+                    $folderAccessModel->normalizeFolderIds($userData['folders_list'] ?? []),
+                    (int) $userData['id']
                 );
 
                 $userId = (string) $userData['id'];
                 $username = $userData['username'];
                 $writableFolders = [];
-                foreach ($rows as $row) {
-                    $writableFolders[] = [
-                        'id' => (int) $row['folder_id'],
-                        'label' => $row['title'] === $userId ? $username : $row['title'],
-                        'level' => (int) $row['nlevel'],
-                        'parent_id' => (int) $row['parent_id'],
-                        'first_position' => $row['title'] === $userId ? 1 : 0,
-                    ];
+
+                if (empty($userFolders) === false) {
+                    $rows = DB::query(
+                        'SELECT nt.id AS folder_id, nt.title, nt.nlevel, nt.parent_id
+                        FROM ' . prefixTable('nested_tree') . ' AS nt
+                        WHERE nt.id IN %li
+                        AND NOT EXISTS (
+                            SELECT 1
+                            FROM ' . prefixTable('nested_tree') . ' AS other_personal
+                            WHERE other_personal.personal_folder = 1
+                            AND other_personal.title <> %s
+                            AND nt.nleft >= other_personal.nleft
+                            AND nt.nright <= other_personal.nright
+                        )
+                        GROUP BY nt.id, nt.title, nt.nlevel, nt.parent_id
+                        ORDER BY nt.nlevel ASC, nt.title ASC',
+                        $userFolders,
+                        $userId
+                    );
+
+                    foreach ($rows as $row) {
+                        $writableFolders[] = [
+                            'id' => (int) $row['folder_id'],
+                            'label' => $row['title'] === $userId ? $username : $row['title'],
+                            'level' => (int) $row['nlevel'],
+                            'parent_id' => (int) $row['parent_id'],
+                            'first_position' => $row['title'] === $userId ? 1 : 0,
+                        ];
+                    }
                 }
 
                 $responseData = json_encode($writableFolders);

--- a/app/api/Controller/Api/ItemController.php
+++ b/app/api/Controller/Api/ItemController.php
@@ -110,7 +110,7 @@ class ItemController extends BaseController
             // SQL LIMIT
             $intLimit = 0;
             if (isset($arrQueryStringParams['limit']) === true) {
-                $intLimit = $arrQueryStringParams['limit'];
+                $intLimit = (int) $arrQueryStringParams['limit'];
             }
 
             // send query
@@ -324,7 +324,7 @@ class ItemController extends BaseController
                     ? DB::escape('%' . $arrQueryStringParams['label'] . '%')
                     : DB::escape($arrQueryStringParams['label']);
                 $sqlExtra .= ' AND i.label ' . ($isLikeLabel ? 'LIKE ' : '= ') . $escapedLabel . $sql_constraint;
-                $sqlLimit = isset($arrQueryStringParams['limit']) === true && (int) $arrQueryStringParams['limit'] > 0 ? $arrQueryStringParams['limit'] : 50;   // let's limit to 50 by default
+                $sqlLimit = isset($arrQueryStringParams['limit']) === true && (int) $arrQueryStringParams['limit'] > 0 ? (int) $arrQueryStringParams['limit'] : 50;   // let's limit to 50 by default
             } else if (isset($arrQueryStringParams['description']) === true) {
                 // build sql where clause by DESCRIPTION
                 $isLikeDesc = isset($arrQueryStringParams['like']) && (int) $arrQueryStringParams['like'] === 1;

--- a/app/api/Controller/Api/ItemController.php
+++ b/app/api/Controller/Api/ItemController.php
@@ -79,6 +79,11 @@ class ItemController extends BaseController
             } else {
                 $userData['folders_list'] = [];
             }
+            $folderAccessModel = new FolderAccessModel();
+            $userData['folders_list'] = $folderAccessModel->filterFoldersForUser(
+                $folderAccessModel->normalizeFolderIds($userData['folders_list']),
+                (int) $userData['id']
+            );
 
             // SQL where clause with folders list
             if (isset($arrQueryStringParams['folders']) === true) {
@@ -98,6 +103,7 @@ class ItemController extends BaseController
                         json_encode(['error' => 'Folders are mandatory']),
                         ['Content-Type: application/json', 'HTTP/1.1 401 Expected parameters not provided']
                     );
+                    return;
                 }
             } else {
                 // Send error
@@ -105,6 +111,7 @@ class ItemController extends BaseController
                     json_encode(['error' => 'Folders are mandatory']),
                     ['Content-Type: application/json', 'HTTP/1.1 401 Expected parameters not provided']
                 );
+                return;
             }
 
             // SQL LIMIT
@@ -167,8 +174,10 @@ class ItemController extends BaseController
             && isset($arrQueryStringParams['tags']) === true
             && isset($arrQueryStringParams['anyone_can_modify']) === true
         ) {
-            //
-            if (in_array($arrQueryStringParams['folder_id'], $userData['folders_list']) === false && $userData['user_can_create_root_folder'] === 0) {
+            $folderAccessModel = new FolderAccessModel();
+            $folderId = (int) $arrQueryStringParams['folder_id'];
+
+            if ($folderAccessModel->canUseFolder($userData, $folderId, true) === false) {
                 return [
                     'error' => true,
                     'strErrorDesc' => 'User is not allowed in this folder',
@@ -218,6 +227,11 @@ class ItemController extends BaseController
                 } else {
                     $userData['folders_list'] = [];
                 }
+                $folderAccessModel = new FolderAccessModel();
+                $userData['folders_list'] = $folderAccessModel->filterFoldersForUser(
+                    $folderAccessModel->normalizeFolderIds($userData['folders_list']),
+                    (int) $userData['id']
+                );
 
                 // get parameters
                 $arrQueryStringParams = $this->getQueryStringParams();
@@ -300,13 +314,20 @@ class ItemController extends BaseController
         $responseData = '';
         $strErrorHeader = '';
         // Sanitize folder/item IDs from JWT claims as strict integers before SQL interpolation
-        $safeFolders = implode(',', array_filter(array_map('intval', explode(',', (string) $userData['folders_list'])))) ?: '0';
+        $folderAccessModel = new FolderAccessModel();
+        $safeFolders = implode(
+            ',',
+            $folderAccessModel->filterFoldersForUser(
+                $folderAccessModel->normalizeFolderIds($userData['folders_list'] ?? ''),
+                (int) $userData['id']
+            )
+        ) ?: '0';
         $sql_constraint = ' AND (i.id_tree IN (' . $safeFolders . ')';
         if (!empty($userData['restricted_items_list'])) {
             $safeRestricted = implode(',', array_filter(array_map('intval', explode(',', (string) $userData['restricted_items_list'])))) ?: '0';
             $sql_constraint .= ' OR i.id IN (' . $safeRestricted . ')';
         }
-        $sql_constraint .= ')';
+        $sql_constraint .= ')' . $folderAccessModel->getItemFolderSqlConstraint('i.id_tree', (int) $userData['id']);
 
         // get parameters
         $arrQueryStringParams = $this->getQueryStringParams();
@@ -336,6 +357,7 @@ class ItemController extends BaseController
                     json_encode(['error' => 'Item id, label or description is mandatory']),
                     ['Content-Type: application/json', 'HTTP/1.1 401 Expected parameters not provided']
                 );
+                return;
             }
 
             // send query
@@ -410,13 +432,20 @@ class ItemController extends BaseController
             }*/
 
             // Build SQL constraint for accessible folders — sanitize JWT claims as strict integers
-            $safeFoldersFbu = implode(',', array_filter(array_map('intval', explode(',', (string) $userData['folders_list'])))) ?: '0';
+            $folderAccessModel = new FolderAccessModel();
+            $safeFoldersFbu = implode(
+                ',',
+                $folderAccessModel->filterFoldersForUser(
+                    $folderAccessModel->normalizeFolderIds($userData['folders_list'] ?? ''),
+                    (int) $userData['id']
+                )
+            ) ?: '0';
             $sql_constraint = ' AND (i.id_tree IN (' . $safeFoldersFbu . ')';
             if (!empty($userData['restricted_items_list'])) {
                 $safeRestrictedFbu = implode(',', array_filter(array_map('intval', explode(',', (string) $userData['restricted_items_list'])))) ?: '0';
                 $sql_constraint .= ' OR i.id IN (' . $safeRestrictedFbu . ')';
             }
-            $sql_constraint .= ')';
+            $sql_constraint .= ')' . $folderAccessModel->getItemFolderSqlConstraint('i.id_tree', (int) $userData['id']);
 
             // Decode URL if needed
             $searchUrl = urldecode($arrQueryStringParams['url']);
@@ -550,15 +579,12 @@ class ItemController extends BaseController
                     $strErrorDesc = 'Item not found';
                     $strErrorHeader = 'HTTP/1.1 404 Not Found';
                 } else {
-                    // Check if user has access to the folder
-                    $userFolders = !empty($userData['folders_list']) ? explode(',', $userData['folders_list']) : [];
-                    $hasAccess = in_array((string) $itemInfo['id_tree'], $userFolders, true);
-
-                    // Also check restricted items if applicable
-                    if (!$hasAccess && !empty($userData['restricted_items_list'])) {
-                        $restrictedItems = explode(',', $userData['restricted_items_list']);
-                        $hasAccess = in_array((string) $itemId, $restrictedItems, true);
-                    }
+                    $folderAccessModel = new FolderAccessModel();
+                    $hasAccess = $folderAccessModel->canAccessItemInFolder(
+                        $userData,
+                        (int) $itemInfo['id_tree'],
+                        $itemId
+                    );
 
                     if (!$hasAccess) {
                         $strErrorDesc = 'Access denied to this item';
@@ -706,6 +732,11 @@ class ItemController extends BaseController
                 } else {
                     $userData['folders_list'] = [];
                 }
+                $folderAccessModel = new FolderAccessModel();
+                $userData['folders_list'] = $folderAccessModel->filterFoldersForUser(
+                    $folderAccessModel->normalizeFolderIds($userData['folders_list']),
+                    (int) $userData['id']
+                );
 
                 // Get parameters
                 $arrQueryStringParams = $this->getQueryStringParams();
@@ -730,14 +761,11 @@ class ItemController extends BaseController
                                 $strErrorDesc = 'Item not found';
                                 $strErrorHeader = 'HTTP/1.1 404 Not Found';
                             } else {
-                                // Check if user has access to the folder
-                                $hasAccess = in_array((string) $itemInfo['id_tree'], $userData['folders_list'], true);
-
-                                // Also check restricted items if applicable
-                                if (!$hasAccess && !empty($userData['restricted_items_list'])) {
-                                    $restrictedItems = explode(',', $userData['restricted_items_list']);
-                                    $hasAccess = in_array((string) $itemId, $restrictedItems, true);
-                                }
+                                $hasAccess = $folderAccessModel->canAccessItemInFolder(
+                                    $userData,
+                                    (int) $itemInfo['id_tree'],
+                                    $itemId
+                                );
 
                                 if (!$hasAccess) {
                                     $strErrorDesc = 'Access denied to this item';
@@ -855,15 +883,12 @@ class ItemController extends BaseController
                                 $strErrorDesc = 'Item not found';
                                 $strErrorHeader = 'HTTP/1.1 404 Not Found';
                             } else {
-                                // Check if user has access to the folder
-                                $userFolders = explode(',', $userData['folders_list']);
-                                $hasAccess = in_array((string) $itemInfo['id_tree'], $userFolders, true);
-
-                                // Also check restricted items if applicable
-                                if (!$hasAccess && !empty($userData['restricted_items_list'])) {
-                                    $restrictedItems = explode(',', $userData['restricted_items_list']);
-                                    $hasAccess = in_array((string) $itemId, $restrictedItems, true);
-                                }
+                                $folderAccessModel = new FolderAccessModel();
+                                $hasAccess = $folderAccessModel->canAccessItemInFolder(
+                                    $userData,
+                                    (int) $itemInfo['id_tree'],
+                                    $itemId
+                                );
 
                                 if (!$hasAccess) {
                                     $strErrorDesc = 'Access denied to this item';

--- a/app/api/Model/AuthModel.php
+++ b/app/api/Model/AuthModel.php
@@ -350,18 +350,26 @@ class AuthModel
             }
         }
 
+        if (class_exists('FolderAccessModel') === false) {
+            require_once API_ROOT_PATH . '/Model/FolderAccessModel.php';
+        }
+        $folderAccessModel = new FolderAccessModel();
+
         // All accessible folders
         return [
-            'folders' => array_values(array_unique(
-                array_filter(
-                    array_merge(
-                        $allowedFolders,
-                        $allowedFoldersByRoles,
-                        $readOnlyFolders,
-                        $personalFolders
+            'folders' => $folderAccessModel->filterFoldersForUser(
+                array_values(array_unique(
+                    array_filter(
+                        array_merge(
+                            $allowedFolders,
+                            $allowedFoldersByRoles,
+                            $readOnlyFolders,
+                            $personalFolders
+                        )
                     )
-                )
-            )),
+                )),
+                (int) $userInfo['id']
+            ),
         ];
     }
     //end buildUserFoldersList

--- a/app/api/Model/FolderAccessModel.php
+++ b/app/api/Model/FolderAccessModel.php
@@ -1,0 +1,211 @@
+<?php
+/**
+ * Teampass - a collaborative passwords manager.
+ * ---
+ * This file is part of the TeamPass project.
+ * 
+ * TeamPass is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ * 
+ * TeamPass is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ * 
+ * Certain components of this file may be under different licenses. For
+ * details, see the `licenses` directory or individual file headers.
+ * ---
+ * @version    API
+ *
+ * @file      FolderAccessModel.php
+ * @author    Nils Laumaillé (nils@teampass.net)
+ * @copyright 2009-2026 Teampass.net
+ * @license   GPL-3.0
+ * @see       https://www.teampass.net
+ */
+
+declare(strict_types=1);
+
+/**
+ * TeamPass API folder access checks.
+ */
+class FolderAccessModel
+{
+    /**
+     * @param mixed $folderIds
+     * @return array<int>
+     */
+    public function normalizeFolderIds($folderIds): array
+    {
+        if (is_string($folderIds)) {
+            $folderIds = explode(',', $folderIds);
+        }
+
+        if (is_array($folderIds) === false) {
+            return [];
+        }
+
+        $normalized = [];
+        foreach ($folderIds as $folderId) {
+            if (is_array($folderId) === true || is_object($folderId) === true) {
+                continue;
+            }
+
+            $id = (int) $folderId;
+            if ($id > 0) {
+                $normalized[$id] = $id;
+            }
+        }
+
+        return array_values($normalized);
+    }
+
+    /**
+     * @param mixed $itemIds
+     * @return array<int>
+     */
+    public function normalizeItemIds($itemIds): array
+    {
+        if (is_string($itemIds)) {
+            $itemIds = explode(',', $itemIds);
+        }
+
+        if (is_array($itemIds) === false) {
+            return [];
+        }
+
+        $normalized = [];
+        foreach ($itemIds as $itemId) {
+            if (is_array($itemId) === true || is_object($itemId) === true) {
+                continue;
+            }
+
+            $id = (int) $itemId;
+            if ($id > 0) {
+                $normalized[$id] = $id;
+            }
+        }
+
+        return array_values($normalized);
+    }
+
+    /**
+     * Keep shared folders and folders under the current user's personal root.
+     *
+     * @param array<int|string> $folderIds
+     * @return array<int>
+     */
+    public function filterFoldersForUser(array $folderIds, int $userId): array
+    {
+        $folderIds = $this->normalizeFolderIds($folderIds);
+        if (empty($folderIds) === true || $userId <= 0) {
+            return [];
+        }
+
+        $rows = DB::query(
+            'SELECT nt.id
+            FROM ' . prefixTable('nested_tree') . ' AS nt
+            WHERE nt.id IN %li
+            AND NOT EXISTS (
+                SELECT 1
+                FROM ' . prefixTable('nested_tree') . ' AS other_personal
+                WHERE other_personal.personal_folder = 1
+                AND other_personal.title <> %s
+                AND nt.nleft >= other_personal.nleft
+                AND nt.nright <= other_personal.nright
+            )',
+            $folderIds,
+            (string) $userId
+        );
+
+        $allowedFolders = [];
+        foreach ($rows as $row) {
+            $allowedFolders[(int) $row['id']] = true;
+        }
+
+        return array_values(
+            array_filter(
+                $folderIds,
+                static fn (int $folderId): bool => isset($allowedFolders[$folderId]) === true
+            )
+        );
+    }
+
+    public function isFolderInsideAllowedPersonalRoot(int $folderId, int $userId): bool
+    {
+        if ($folderId <= 0 || $userId <= 0) {
+            return false;
+        }
+
+        $allowedCount = DB::queryFirstField(
+            'SELECT COUNT(*)
+            FROM ' . prefixTable('nested_tree') . ' AS nt
+            WHERE nt.id = %i
+            AND NOT EXISTS (
+                SELECT 1
+                FROM ' . prefixTable('nested_tree') . ' AS other_personal
+                WHERE other_personal.personal_folder = 1
+                AND other_personal.title <> %s
+                AND nt.nleft >= other_personal.nleft
+                AND nt.nright <= other_personal.nright
+            )',
+            $folderId,
+            (string) $userId
+        );
+
+        return (int) $allowedCount > 0;
+    }
+
+    public function canUseFolder(array $userData, int $folderId, bool $allowCreateRootBypass = false): bool
+    {
+        if ($this->isFolderInsideAllowedPersonalRoot($folderId, (int) ($userData['id'] ?? 0)) === false) {
+            return false;
+        }
+
+        $userFolders = $this->normalizeFolderIds($userData['folders_list'] ?? []);
+        if (in_array($folderId, $userFolders, true) === true) {
+            return true;
+        }
+
+        return $allowCreateRootBypass === true
+            && (int) ($userData['user_can_create_root_folder'] ?? 0) === 1;
+    }
+
+    public function canAccessItemInFolder(array $userData, int $folderId, int $itemId): bool
+    {
+        if ($this->isFolderInsideAllowedPersonalRoot($folderId, (int) ($userData['id'] ?? 0)) === false) {
+            return false;
+        }
+
+        $userFolders = $this->normalizeFolderIds($userData['folders_list'] ?? []);
+        if (in_array($folderId, $userFolders, true) === true) {
+            return true;
+        }
+
+        $restrictedItems = $this->normalizeItemIds($userData['restricted_items_list'] ?? []);
+
+        return in_array($itemId, $restrictedItems, true) === true;
+    }
+
+    public function getItemFolderSqlConstraint(string $itemFolderColumn, int $userId): string
+    {
+        if (preg_match('/^[A-Za-z0-9_.]+$/', $itemFolderColumn) !== 1 || $userId <= 0) {
+            return ' AND 1 = 0';
+        }
+
+        return ' AND NOT EXISTS (
+            SELECT 1
+            FROM ' . prefixTable('nested_tree') . ' AS nt_access
+            INNER JOIN ' . prefixTable('nested_tree') . ' AS other_personal
+                ON other_personal.personal_folder = 1
+                AND nt_access.nleft >= other_personal.nleft
+                AND nt_access.nright <= other_personal.nright
+            WHERE nt_access.id = ' . $itemFolderColumn . '
+            AND other_personal.title <> ' . DB::escape((string) $userId) . '
+        )';
+    }
+}

--- a/app/api/Model/ItemModel.php
+++ b/app/api/Model/ItemModel.php
@@ -357,9 +357,15 @@ class ItemModel
     private function getFolderSettings(int $folderId) : array
     {
         $dataFolderSettings = DB::queryFirstRow(
-            'SELECT bloquer_creation, bloquer_modification, personal_folder
-            FROM ' . prefixTable('nested_tree') . ' 
-            WHERE id = %i',
+            'SELECT nt.bloquer_creation, nt.bloquer_modification,
+            CASE WHEN COUNT(personal_root.id) > 0 THEN 1 ELSE nt.personal_folder END AS personal_folder
+            FROM ' . prefixTable('nested_tree') . ' AS nt
+            LEFT JOIN ' . prefixTable('nested_tree') . ' AS personal_root
+                ON personal_root.personal_folder = 1
+                AND nt.nleft >= personal_root.nleft
+                AND nt.nright <= personal_root.nright
+            WHERE nt.id = %i
+            GROUP BY nt.id, nt.bloquer_creation, nt.bloquer_modification, nt.personal_folder',
             $folderId
         );
 
@@ -655,9 +661,17 @@ class ItemModel
             // Handle folder_id change
             if (isset($params['folder_id'])) {
                 $newFolderId = (int) $params['folder_id'];
+                $folderAccessModel = new FolderAccessModel();
 
-                // Check if user has access to the new folder
-                if (!in_array((string) $newFolderId, $userData['folders_list'], true)) {
+                if ($folderAccessModel->canUseFolder($userData, (int) $currentItem['id_tree']) === false) {
+                    return [
+                        'error' => true,
+                        'error_message' => 'Access denied to the source folder',
+                        'error_header' => 'HTTP/1.1 403 Forbidden',
+                    ];
+                }
+
+                if ($folderAccessModel->canUseFolder($userData, $newFolderId) === false) {
                     return [
                         'error' => true,
                         'error_message' => 'Access denied to the target folder',
@@ -665,7 +679,9 @@ class ItemModel
                     ];
                 }
 
+                $targetItemInfos = $this->getFolderSettings($newFolderId);
                 $updateData['id_tree'] = $newFolderId;
+                $updateData['perso'] = (int) $targetItemInfos['personal_folder'];
             }
 
             // Generate favicon URL if URL is provided and favicon_url is empty

--- a/app/api/inc/bootstrap.php
+++ b/app/api/inc/bootstrap.php
@@ -48,6 +48,7 @@ require API_ROOT_PATH . "/Controller/Api/BaseController.php";
 require API_ROOT_PATH . "/Model/UserModel.php";
 require API_ROOT_PATH . "/Model/ItemModel.php";
 require API_ROOT_PATH . "/Model/FolderModel.php";
+require API_ROOT_PATH . "/Model/FolderAccessModel.php";
 
 /**
  * Launch expected action for ITEM

--- a/app/api/index.php
+++ b/app/api/index.php
@@ -179,6 +179,24 @@ if (isset($uri[0]) && $uri[0] === 'authorize') {
         }
     }
 
+    $userId = (int) ($userData['data']['id'] ?? 0);
+    if ($userId > 0) {
+        $folderAccessModel = new FolderAccessModel();
+        $currentFolders = $folderAccessModel->normalizeFolderIds($userData['data']['folders_list'] ?? '');
+        $filteredFolders = $folderAccessModel->filterFoldersForUser($currentFolders, $userId);
+
+        if ($filteredFolders !== $currentFolders) {
+            DB::update(
+                prefixTable('cache_tree'),
+                ['folders' => json_encode($filteredFolders), 'timestamp' => time(), 'invalidated_at' => 0],
+                'user_id = %i',
+                $userId
+            );
+        }
+
+        $userData['data']['folders_list'] = implode(',', $filteredFolders);
+    }
+
 
 
     // define the position of controller in $uri

--- a/tests/Unit/FolderAccessModelTest.php
+++ b/tests/Unit/FolderAccessModelTest.php
@@ -1,0 +1,37 @@
+<?php
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../app/api/Model/FolderAccessModel.php';
+
+class FolderAccessModelTest extends TestCase
+{
+    public function testNormalizeFolderIdsFromCsv(): void
+    {
+        $model = new FolderAccessModel();
+
+        self::assertSame([1, 2, 3], $model->normalizeFolderIds('1,2,2,abc,3'));
+    }
+
+    public function testNormalizeFolderIdsDropsNonPositiveValues(): void
+    {
+        $model = new FolderAccessModel();
+
+        self::assertSame([4, 9], $model->normalizeFolderIds(['4', 0, -3, '', '9']));
+    }
+
+    public function testNormalizeItemIdsFromArray(): void
+    {
+        $model = new FolderAccessModel();
+
+        self::assertSame([8, 12], $model->normalizeItemIds(['8', '12', '12', 'not-an-id']));
+    }
+
+    public function testInvalidItemFolderSqlColumnFailsClosed(): void
+    {
+        $model = new FolderAccessModel();
+
+        self::assertSame(' AND 1 = 0', $model->getItemFolderSqlConstraint('i.id_tree;DROP', 7));
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -2,4 +2,9 @@
 
 declare(strict_types=1);
 
-require_once __DIR__ . '/../vendor/autoload.php';
+$autoload = __DIR__ . '/../vendor/autoload.php';
+if (is_file($autoload) === false) {
+    $autoload = __DIR__ . '/../app/vendor/autoload.php';
+}
+
+require_once $autoload;


### PR DESCRIPTION
## Summary

This PR completes the API security fix around personal folder visibility and folder usage validation.

It builds on the existing API hardening from PR #5210 and adds server-side checks to prevent API users from seeing or using folders located under another user's personal folder, including descendant folders where `personal_folder` is not directly set.

## Bug

Personal folder descendants may have `personal_folder = 0` in `nested_tree`.

The API was previously relying too much on direct checks such as:

```sql
nt.personal_folder = 1
```

or treating folders with `personal_folder = 0` as non-personal.

As a result, a descendant folder located under another user's personal folder could still be considered visible or usable by the API if it appeared in the accessible folder list through roles or cached folder data.

This could affect:

- `folder/writableFolders`
- item creation
- item update
- item folder changes / moves
- moves between shared folders and personal folders
- moves between personal folders owned by different users

## Root Cause

The ownership check was based on the folder row itself, instead of determining whether the folder is located inside a personal folder root.

For descendants, the direct `personal_folder` flag is not reliable enough. The correct check must use the nested tree boundaries:

- `nleft`
- `nright`

A folder must be allowed only if:

- it is outside any personal folder root, or
- it is inside the current user's personal folder root.

It must be rejected if it is inside anoather user's personal folder root.

## Changes

This PR adds a centralized API folder access validator.

The new validation:

- normalizes folder and item ID lists before access checks;
- filters API folder lists using `nested_tree.nleft` / `nested_tree.nright`;
- allows shared and non-personal folders according to existing permissions;
- allows the current user's personal folder and descendants;
- rejects folders located under another user's personal folder root;
- applies the same server-side validation to item creation and update flows;
- validates both source and target folders during item moves;
- prevents moves into another user's personal folder;
- prevents moves from personal folders to unauthorized destinations;
- prevents moves between personal folders owned by different users;
- keeps folder lookup requests fail-closed when parameters are missing or unauthorized.

`writableFolders` no longer relies only on the direct `personal_folder` value of the folder row. It now checks whether the folder is under a personal root owned by another user.

Item creation and item moves now also treat descendants of personal folders as personal, even when the descendant row itself has `personal_folder = 0`.

## Security Impact

After this change:

- an API user cannot see descendants of another user's personal folder;
- an API user cannot create an item in another user's personal folder descendant;
- an API user cannot move an item into another user's personal folder descendant;
- an API user cannot move items between personal folder trees owned by different users;
- shared folders and regular non-personal folders keep their existing behavior;
- legitimate operations inside the current user's own personal folder tree remain allowed.

## PR #5210 Compatibility

The existing API behavior introduced by PR #5210 is preserved.

In particular:

- `folders_list` is still kept out of the JWT payload;
- the API still relies on `cache_tree` to store and reload accessible folders;
- `inFoldersAction()` still intersects requested folders with the authorized folder list;
- folder IDs used in API constraints are still normalized as strict integers.

This PR adds the missing personal-root ownership validation on top of that behavior.

## Testing Status

Testing is currently in progress on my side.

I am opening this PR early so the work can already be reviewed and so the testing session can be shared.

Initial checks performed:

- reviewed API folder visibility logic;
- reviewed item creation and update folder validation;
- reviewed item move source and target validation;
- confirmed the existing PR #5210 API behavior is preserved;
- added focused unit coverage for the new folder access helper behavior.

Further functional testing is still ongoing, especially around:

- `folder/writableFolders`;
- item creation in shared folders;
- item creation in the current user's personal folder descendants;
- item creation rejection in another user's personal folder descendants;
- item moves between shared and personal folders;
- item moves between personal folders owned by different users.
