### PR TITLE
Align Password Security Badge With TeamPass Complexity Levels

### DIFF
--- a/app/pages/items.js.php
+++ b/app/pages/items.js.php
@@ -6226,7 +6226,7 @@ $bip39Wordlist = loadBip39Wordlist($session->get('user-language') ?? 'english');
                         $pwBadge
                             .removeClass('hidden badge-success')
                             .addClass('badge-danger')
-                            .html('<i class="fa-solid fa-shield-halved mr-1" infotip" title="<?php echo $lang->get('not_secure'); ?>"></i>')
+                            .html('<i class="fa-solid fa-shield-halved mr-1 infotip" title="<?php echo $lang->get('not_secure'); ?>"></i>')
                     } else {
                         $pwBadge.addClass('hidden').removeClass('badge-success badge-danger')
                     }

--- a/app/sources/admin.queries.php
+++ b/app/sources/admin.queries.php
@@ -3389,7 +3389,7 @@ case 'get_operational_statistics':
 
         // ---- ITEMS (password security - OWASP ASVS aligned policy)
         $pwMinLen = 12;
-        $pwMinComplexity = 70;
+        $pwMinComplexity = TP_PW_STRENGTH_5;
 
         $passwordSecurityRow = DB::queryFirstRow(
             "SELECT

--- a/app/sources/items.queries.php
+++ b/app/sources/items.queries.php
@@ -3003,11 +3003,11 @@ switch ($inputData['type']) {
 
             $arrData['label'] = $dataItem['label'] === '' ? '' : $dataItem['label'];
             $arrData['pw_length'] = strlen($passwordForMetrics);
-            // Password security badge: OWASP ASVS aligned policy (min length 12, min complexity score 70)
+            // Password security badge: OWASP ASVS aligned policy (min length 12, max TeamPass complexity level)
             if (strlen($passwordForMetrics) === 0) {
                 $arrData['pw_is_secure'] = null; // empty password → no badge
             } else {
-                $arrData['pw_is_secure'] = strlen($passwordForMetrics) >= 12 && intval($dataItem['complexity_level']) >= 70;
+                $arrData['pw_is_secure'] = strlen($passwordForMetrics) >= 12 && intval($dataItem['complexity_level']) >= TP_PW_STRENGTH_5;
             }
 
             // HIBP cached status (no API call here — async check is triggered by the JS)


### PR DESCRIPTION
## Summary

This PR fixes the password security badge logic on item details and aligns the statistics password compliance calculation with the TeamPass password complexity model.

The password complexity stored in `items.complexity_level` is not a 0-100 score. It is the TeamPass discrete scale produced by `convertPasswordStrength()`:

- `0`
- `20`
- `38`
- `48`
- `60`

Recent changes by Nils already confirmed this model by computing the password complexity server-side from the plaintext password, then storing the converted TeamPass complexity level. The item badge and statistics compliance logic still used a threshold of `70`, which made the "secure" state unreachable through normal application flows.

## Changes

- Updated the item password security badge condition to use `TP_PW_STRENGTH_5` instead of the unreachable hardcoded threshold `70`.
- Updated the statistics password compliance policy to use `TP_PW_STRENGTH_5` for consistency with the stored complexity scale.
- Fixed the `infotip` class markup on the non-secure password badge icon so its tooltip is initialized correctly.

## Why

Before this change, even a password with the maximum zxcvbn score was stored as complexity level `60`, while the badge required `>= 70`.

As a result:

- Secure passwords could never display the green "Secure" badge.
- The statistics password compliance score could never count a password as compliant based on complexity.

Using `TP_PW_STRENGTH_5` keeps the badge, statistics, API, and web item flows aligned with the same TeamPass complexity model.

## Testing

Manual testing was performed after the change:

- Verified that a strong password can now display the green secure badge.
- Verified that a weaker password still displays the red non-secure badge.
- Verified that both badge types render correctly on the item details page.

Additional local check:

- Confirmed no remaining hardcoded `70` threshold in the adjusted badge/statistics scope.