### PR TITLE
Reduce Encrypted PHP Session Payload for Tree Cache Data

### DIFF
--- a/app/sources/identify.php
+++ b/app/sources/identify.php
@@ -950,15 +950,25 @@ function performPostLoginTasks(
     // Get some more elements
     $session->set('system-screen_height', $dataReceived['screenHeight']);
 
-    // Get cache tree info
+    // Get cache tree metadata without loading the full visible_folders payload into session.
     $cacheTreeData = DB::queryFirstRow(
-        'SELECT visible_folders
+        'SELECT increment_id, timestamp, IFNULL(invalidated_at, 0) AS invalidated_at,
+            COALESCE(CHAR_LENGTH(visible_folders), 0) AS visible_folders_size
         FROM ' . prefixTable('cache_tree') . '
         WHERE user_id=%i',
         (int) $session->get('user-id')
     );
-    if (DB::count() > 0 && empty($cacheTreeData['visible_folders']) === true) {
-        $session->set('user-cache_tree', '');
+
+    // Drop the legacy heavy session entry if it exists; cache_tree remains the server-side source.
+    $session->remove('user-cache_tree');
+    $session->set('user-cache_tree_meta', [
+        'cache_id' => (int) ($cacheTreeData['increment_id'] ?? 0),
+        'timestamp' => (int) ($cacheTreeData['timestamp'] ?? 0),
+        'invalidated_at' => (int) ($cacheTreeData['invalidated_at'] ?? 0),
+        'visible_folders_size' => (int) ($cacheTreeData['visible_folders_size'] ?? 0),
+    ]);
+
+    if (empty($cacheTreeData) === true || (int) ($cacheTreeData['visible_folders_size'] ?? 0) === 0) {
         // Prepare new task
         DB::insert(
             prefixTable('background_tasks'),
@@ -976,8 +986,6 @@ function performPostLoginTasks(
 
         // Trigger background handler to process tasks
         triggerBackgroundHandler();
-    } else {
-        $session->set('user-cache_tree', $cacheTreeData['visible_folders']);
     }
 
     // Send email notification if enabled

--- a/app/sources/tree.php
+++ b/app/sources/tree.php
@@ -136,11 +136,16 @@ if (DB::count() === 0) {
 /** @var int|string $lastFolderChangeValeur */
 $lastFolderChangeValeur = $lastFolderChange['valeur'] ?? 0;
 
+// Drop legacy heavy session entries if they exist; cache_tree is the server-side source.
+foreach (['user-tree_structure', 'user-cache_tree'] as $legacyTreeSessionKey) {
+    if ($session->has($legacyTreeSessionKey) === true) {
+        $session->remove($legacyTreeSessionKey);
+    }
+}
+
 // Should we use a cache or refresh the tree
 $goTreeRefresh = loadTreeStrategy(
     (int) $lastFolderChangeValeur,
-    (int) $inputData['userTreeLastRefresh'],
-    (null === $session->get('user-tree_structure') || empty($session->get('user-tree_structure')) === true) ? [] : $session->get('user-tree_structure'),
     (int) $inputData['userId'],
     (int) $inputData['forceRefresh']
 );
@@ -190,9 +195,9 @@ if ($goTreeRefresh['state'] === true || empty($inputData['nodeId']) === false) {
         }
     }
 
-    // Save in SESSION
-    $session->set('user-tree_structure', $ret_json);
-    $session->set('user-tree_last_refresh_timestamp', time());
+    // Keep only lightweight tree metadata in SESSION.
+    $treeBuiltAt = time();
+    $session->set('user-tree_last_refresh_timestamp', $treeBuiltAt);
 
     // Build visible_folders synchronously from the same tree data
     $visibleFoldersArray = buildVisibleFoldersFromTree($ret_json, $completTree, $inputData);
@@ -211,6 +216,11 @@ if ($goTreeRefresh['state'] === true || empty($inputData['nodeId']) === false) {
 
     // Send back with version for client-side caching
     $treeVersion = md5($ret_json);
+    $session->set('user-tree_cache_meta', [
+        'timestamp' => $treeBuiltAt,
+        'version' => $treeVersion,
+        'source' => 'rebuilt',
+    ]);
     if (!empty($inputData['treeVersion']) && $inputData['treeVersion'] === $treeVersion) {
         echo json_encode(['unchanged' => true, 'version' => $treeVersion]);
     } else {
@@ -220,6 +230,13 @@ if ($goTreeRefresh['state'] === true || empty($inputData['nodeId']) === false) {
     // Cached data path — also version it
     $cachedData = $goTreeRefresh['data'];
     $treeVersion = md5($cachedData);
+    $cacheTimestamp = (int) ($goTreeRefresh['timestamp'] ?? time());
+    $session->set('user-tree_last_refresh_timestamp', $cacheTimestamp);
+    $session->set('user-tree_cache_meta', [
+        'timestamp' => $cacheTimestamp,
+        'version' => $treeVersion,
+        'source' => 'cache_tree',
+    ]);
     if (!empty($inputData['treeVersion']) && $inputData['treeVersion'] === $treeVersion) {
         echo json_encode(['unchanged' => true, 'version' => $treeVersion]);
     } else {
@@ -800,16 +817,12 @@ function buildVisibleFoldersFromTree(
  * Permits to check if we can user a cache instead of loading from DB
  *
  * @param integer $lastTreeChange
- * @param integer $userTreeLastRefresh
- * @param array $userSessionTreeStructure
  * @param integer $userId
  * @param integer $forceRefresh
  * @return array
  */
 function loadTreeStrategy(
     int $lastTreeChange,
-    int $userTreeLastRefresh,
-    array $userSessionTreeStructure,
     int $userId,
     int $forceRefresh
 ): array
@@ -819,24 +832,6 @@ function loadTreeStrategy(
         return [
             'state' => true,
             'data' => [],
-        ];
-    }
-
-    // Case when an update in the tree has been done
-    // Refresh is then mandatory
-    if ((int) $lastTreeChange > (int) $userTreeLastRefresh) {
-        return [
-            'state' => true,
-            'data' => [],
-        ];
-    }
-
-    // Does this user has the tree structure in session?
-    // If yes then use it
-    if (count($userSessionTreeStructure) > 0) {
-        return [
-            'state' => false,
-            'data' => json_encode($userSessionTreeStructure),
         ];
     }
 
@@ -859,9 +854,17 @@ function loadTreeStrategy(
                 'data' => [],
             ];
         }
+        if ((int) $lastTreeChange > (int) $cacheTimestamp) {
+            return [
+                'state' => true,
+                'data' => [],
+            ];
+        }
         return [
             'state' => false,
             'data' => $userCacheTree['data'],
+            'timestamp' => (int) $cacheTimestamp,
+            'invalidated_at' => (int) $invalidatedAt,
         ];
     }
 


### PR DESCRIPTION
## Summary

This PR reduces the amount of folder tree cache data stored in the encrypted PHP session.

It addresses a performance issue initially reported on TeamPass 3.1.7.6: requests to `sources/items.queries.php` were slow while MariaDB stayed lightly loaded. The reported environment showed PHP sessions growing to roughly 500-700 KB, with two large session entries suspected:

- `user-cache_tree`, written from `sources/identify.php`;
- `user-tree_structure`, written from `sources/tree.php`.

TeamPass wraps the PHP session handler with `EncryptedSessionProxy`, so the full serialized session payload is decrypted when the session is opened and encrypted again when it is written. Large JSON tree data in session therefore adds CPU and I/O overhead to every authenticated request, including requests that do not directly use the tree payload.

## Changes

### `app/sources/identify.php`

- Stop loading the full `cache_tree.visible_folders` LONGTEXT payload into the PHP session.
- Remove the legacy heavy `user-cache_tree` session key when present.
- Store only lightweight metadata in `user-cache_tree_meta`:
  - cache row id;
  - cache timestamp;
  - invalidation timestamp;
  - `visible_folders` payload size.
- Keep the existing `user_build_cache_tree` background task behavior when the cache row is missing or when `visible_folders` is empty.

### `app/sources/tree.php`

- Stop using `user-tree_structure` as a session-level cache for the jstree payload.
- Remove legacy heavy session entries when `tree.php` runs:
  - `user-tree_structure`;
  - `user-cache_tree`.
- Use `cache_tree.data` as the server-side source of cached tree data.
- Keep only lightweight tree metadata in session through `user-tree_cache_meta`:
  - cache timestamp;
  - tree version hash;
  - source (`rebuilt` or `cache_tree`).
- Keep `user-tree_last_refresh_timestamp`, but no longer store the full tree array in session.
- Preserve the existing cache invalidation model:
  - `cache_tree.invalidated_at`;
  - `cache_tree.timestamp`;
  - global `last_folder_change` fallback.

## Why

The previous flow duplicated large tree payloads in multiple places:

- server-side DB cache: `cache_tree.data`;
- server-side DB cache: `cache_tree.visible_folders`;
- encrypted PHP session: `user-tree_structure`;
- encrypted PHP session: `user-cache_tree`.

The database cache is already the appropriate server-side storage layer for this data. The PHP session only needs lightweight markers allowing TeamPass to know which cache version is being used.

Keeping the heavy JSON payloads out of the encrypted PHP session reduces the fixed cost paid by every authenticated request.

## Security and Access Control

This change does not relax folder or item access checks.

The existing access model is preserved:

- session rights are still built through `identifyUserRights()`;
- folder visibility still relies on `user-accessible_folders`, `user-personal_visible_folders`, read-only folders, forbidden personal folders, and role data;
- `items.queries.php` still validates access through its existing permission checks;
- tree data remains server-side in `cache_tree` and is only sent to the client through the existing tree endpoint behavior.

No additional folder tree data is exposed to the client.

## Performance Notes

The network response size is not expected to drop significantly for normal tree or item responses. The main gain is server-side: the encrypted session payload is smaller, so PHP has less data to decrypt, serialize, encrypt, and write for each request.

This is especially visible on small responses such as `tree.php` returning an unchanged tree marker. Before this change, even a tiny `tree.php` response still paid the cost of loading and writing the large encrypted session.

## Manual Testing

Manual A/B testing was performed on `evol/3.2.0.0` using Microsoft Edge private browsing:

- user login with a standard account;
- `Preserve log` enabled in DevTools;
- `No throttling`;
- browser cache enabled;
- tests focused on `index.php?page=items`;
- same folders selected before and after the change.

### Observed Session Size

On the items page, the server-side session payload dropped from approximately:

```text
480 KB before
114 KB after
```

The UI was also observed to be noticeably more responsive after the change.

### Broad Page Load Comparison

Without the correction:

```text
First folder (personal, 17 items):
86 requests
2,131 KB transferred
6,159 KB resources
Finish: 4.78 s
DOMContentLoaded: 898 ms
Load: 906 ms

Second folder (shared, 2 items):
89 requests
2,136 KB transferred
6,167 KB resources
Finish: 1.3 min

Third folder (shared, 3 items):
91 requests
2,142 KB transferred
6,174 KB resources
Finish: 1.7 min
```

With the correction:

```text
First folder (personal, 17 items):
86 requests
2.1 MB transferred
6.2 MB resources
Finish: 2.62 s
DOMContentLoaded: 1.51 s
Load: 1.51 s

Second folder (shared, 2 items):
89 requests
2.1 MB transferred
6.2 MB resources
Finish: 1.1 min

Third folder (shared, 3 items):
92 requests
2.1 MB transferred
6.2 MB resources
Finish: 1.8 min
```

The global `Finish` value is not the most reliable signal here because it can be affected by preserved requests, WebSocket activity, and long-running/pending XHRs. The more relevant measurements are the server-side session size and isolated XHR timings.

### Isolated `tree.php` Test

The most meaningful comparison was an isolated `tree.php` request filtered in DevTools.

Without the correction:

```text
tree.php?tree_version=...
Status: 200
Size: 113 B
Time: 838 ms
```

With the correction:

```text
tree.php?tree_version=...
Status: 200
Size: 113 B
Time: 30 ms
```

The response size remained identical, but the time dropped from about 838 ms to 30 ms. This confirms that the improvement comes from lower server-side processing overhead, not from reduced HTTP transfer size.

Approximate gain on this isolated request:

```text
838 ms -> 30 ms
about 808 ms faster
about 96% lower latency
about 28x faster
```

## Additional Validation Recommended

Before merging, it is recommended to validate the following scenarios on a larger TeamPass instance:

- user with many visible folders;
- administrator account on `page=items`;
- personal folders;
- read-only folders;
- forbidden/non-visible folders;
- folder rights changed by an administrator, followed by refresh on the user session;
- role changes;
- logout/login;
- cold tree cache;
- warm tree cache;
- dashboard/admin pages, to confirm whether the reduced fixed session cost also improves heavy admin pages.

The admin dashboard may benefit from the smaller encrypted session because all authenticated requests pay the session open/write cost. However, if dashboard latency is caused by SQL queries, statistics, logs, or datatable processing, those paths should be profiled separately.