### PR TITLE
Enhance user restoration process with timestamps

### DIFF
--- a/app/sources/users.queries.php
+++ b/app/sources/users.queries.php
@@ -3876,16 +3876,33 @@ break;
                 break;
             }
             
-            // Restore user
+            // Restore user and give the account a fresh inactivity baseline.
+            $now = time();
             DB::update(
                 prefixTable('users'),
                 array(
                     'login' => $originalLogin,
                     'deleted_at' => null,
                     'disabled' => 0,
+                    'last_connexion' => $now,
+                    'timestamp' => $now,
+                    'updated_at' => $now,
+                    'inactivity_warned_at' => null,
+                    'inactivity_action_at' => null,
+                    'inactivity_action' => null,
+                    'inactivity_no_email' => 0,
                 ),
                 'id = %i',
                 $userId
+            );
+
+            logEvents(
+                $SETTINGS,
+                'user_mngt',
+                'at_restored',
+                (string) $session->get('user-id'),
+                $session->get('user-login'),
+                (string) $userId
             );
             
             echo prepareExchangedData(


### PR DESCRIPTION
## Summary

This pull request updates the user restoration flow so that a soft-deleted user restored from the Deleted users panel is no longer immediately picked up again by the inactive users management process.

When an account is restored, TeamPass now gives it a fresh inactivity baseline using the existing user table fields:

- `last_connexion` is set to the current timestamp.
- `timestamp` and `updated_at` are refreshed.
- Existing inactive-users management markers are cleared:
  - `inactivity_warned_at`
  - `inactivity_action_at`
  - `inactivity_action`
  - `inactivity_no_email`
- A restoration audit event is written with `at_restored`.

No database migration, new column, or versioning change is included.

## Context

The inactive users management feature determines whether an account is inactive from the user's last activity. For users who have already logged in, this is based on `last_connexion`; for users who never logged in, the logic falls back to `created_at`.

Before this change, restoring a soft-deleted user only:

- restored the original login,
- cleared `deleted_at`,
- set `disabled` back to `0`.

As a result, if the account had been soft-deleted because of inactivity, restoring it did not change the old `last_connexion` value or clear the inactive-users management state. The restored user could therefore immediately appear again as inactive, or still carry warning/action metadata from the previous inactive-users workflow.

## Why This Approach

The ideal long-term model would be to introduce a dedicated inactivity override or grace timestamp, but that would require a schema update. This change is intended for the 3.2.0.0 development branch close to release, where avoiding a late database migration is preferable.

This implementation deliberately reuses existing fields only. It keeps the fix focused on the observed production issue: a user restored from soft delete should receive a fresh inactivity period and should not be immediately processed again by the automatic inactive users job.

Setting `last_connexion` to the restoration time is a pragmatic choice. It treats the administrative restoration as the new inactivity baseline without changing the inactive-users scheduler, worker, user list, install scripts, or upgrade scripts.

Clearing the `inactivity_*` fields at the same time keeps the account state coherent. Updating `last_connexion` alone would prevent most immediate reprocessing, but could leave stale badges such as "warned" or "action scheduled" visible in the user management UI until a later background run.

## Implementation Details

The change is contained in:

- `app/sources/users.queries.php`

In the `restore_user` case, the update payload now includes:

```php
'last_connexion' => $now,
'timestamp' => $now,
'updated_at' => $now,
'inactivity_warned_at' => null,
'inactivity_action_at' => null,
'inactivity_action' => null,
'inactivity_no_email' => 0,
```

The existing restore behavior is preserved:

- the `_deleted_<timestamp>` login suffix is removed,
- duplicate active login checks still run,
- `deleted_at` is cleared,
- `disabled` is reset to `0`.

An audit event is also added:

```php
logEvents(
    $SETTINGS,
    'user_mngt',
    'at_restored',
    (string) $session->get('user-id'),
    $session->get('user-login'),
    (string) $userId
);
```

## Behavior After This Change

When an administrator restores a soft-deleted user:

1. The account becomes active again.
2. The account receives a new inactivity baseline at restoration time.
3. The inactive users management worker will not immediately warn, disable, or delete the same account again based on its pre-deletion inactivity.
4. Stale inactive-users UI badges are removed because the underlying tracking fields are cleared.
5. The restoration is visible in the audit log.

## What This PR Does Not Do

This PR does not:

- add a new database column,
- add a per-user grace period UI,
- change the inactive-users scheduler,
- change the inactive-users worker thresholds,
- change the global inactive-users management settings,
- alter hard-delete behavior.

Those larger improvements can be considered after 3.2.0.0 if a more explicit per-user grace mechanism is desired.

## Testing

Recommended validation before merge:

1. Soft-delete an inactive user.
2. Restore the user from the Deleted users panel.
3. Confirm in the database that:
   - `deleted_at` is `NULL`,
   - `disabled` is `0`,
   - `last_connexion` is close to the restoration timestamp,
   - `inactivity_warned_at` is `NULL`,
   - `inactivity_action_at` is `NULL`,
   - `inactivity_action` is `NULL`,
   - `inactivity_no_email` is `0`.
4. Open the inactive users list and confirm the restored user is no longer immediately listed because of the old inactivity date.
5. Confirm an `at_restored` audit entry is written for the operation.

## Risk Assessment

Risk is low because the change is limited to the restore-user code path and only updates columns that already exist in the current schema.

The main semantic tradeoff is that `last_connexion` becomes the restoration timestamp for restored users. This is intentional for the 3.2.0.0 scope: it provides a clean inactivity reset without introducing a schema change shortly before release.
