### PR TITLE
Fix item edition lock lifecycle and add read only consultation presence

### DIFF
--- a/app/config/include.php
+++ b/app/config/include.php
@@ -45,7 +45,7 @@ define('WIP', (bool) getenv('TEAMPASS_DEBUG'));
 define('UPGRADE_SEND_EMAILS', true);
 define('KEY_LENGTH', 16);
 define('EDITION_LOCK_PERIOD', 86400);   // Defines the delay for which an item edition lock is active
-define('EDITION_LOCK_HEARTBEAT_TIMEOUT', 600);  // Lock expires after 5 minutes without heartbeat renewal
+define('EDITION_LOCK_HEARTBEAT_TIMEOUT', 300);  // Lock expires after 5 minutes without heartbeat renewal
 define('LOG_TO_SERVER', (bool) getenv('TEAMPASS_DEBUG'));         // Defines if logs are sent to the server
 define('OAUTH2_REDIRECTURI', 'index.php?post_type=oauth2');
 define('FORCE_PHPSECLIBV3_MIGRATION', true); // Set to true to force phpseclib v1 to v3 migration on user login

--- a/app/includes/js/teampass-websocket-init.js
+++ b/app/includes/js/teampass-websocket-init.js
@@ -107,6 +107,7 @@
 
   // Current folder tracking
   var currentFolderId = null
+  var activeItemView = null
 
   /**
    * Initialize WebSocket connection
@@ -153,6 +154,12 @@
    * Set up handlers for various WebSocket events
    */
   function setupEventHandlers() {
+    tpWs.on('connected', function(data) {
+      if (data && data.user_id) {
+        window.TeamPassCurrentUserId = parseInt(data.user_id, 10)
+      }
+    })
+
     // Item events
     tpWs.on('item_created', function(data) {
       if (parseInt(data.folder_id) === parseInt(currentFolderId)) {
@@ -243,6 +250,13 @@
       }
     })
 
+    tpWs.on('item_viewers_changed', function(data) {
+      if (parseInt(data.folder_id) === parseInt(currentFolderId)) {
+        setItemViewers(data.item_id, data.viewers || [])
+      }
+      updateItemViewersInDetailView(data.item_id, data.viewers || [])
+    })
+
     // Item moved event
     tpWs.on('item_moved', function(data) {
       var fromFolder = parseInt(data.from_folder_id)
@@ -259,6 +273,7 @@
           if (!$container.hasClass('hidden') &&
               parseInt($container.data('id')) === parseInt(data.item_id)) {
             $container.find('.edition-lock-detail-badge').remove()
+            $container.find('.item-view-detail-badge').remove()
             toastr.remove()
             toastr.warning(
               '"' + data.label + '" ' + (L.item_moved_away || 'has been moved to another folder by') + ' ' + data.moved_by,
@@ -381,6 +396,10 @@
   function subscribeToFolder(folderId) {
     if (!folderId || !tpWs.isConnectedNow()) return
 
+    if (activeItemView && parseInt(activeItemView.folderId) !== parseInt(folderId)) {
+      stopItemView()
+    }
+
     // Unsubscribe from previous folder and clear its lock indicators
     if (currentFolderId && currentFolderId !== folderId) {
       tpWs.unsubscribeFromFolder(currentFolderId).catch(function() {})
@@ -389,6 +408,13 @@
           removeEditionLockIndicator(itemId)
         })
         window.tpLockedItems = {}
+      }
+      if (window.tpViewingItems) {
+        Object.keys(window.tpViewingItems).forEach(function(itemId) {
+          removeItemViewIndicator(itemId)
+          removeItemViewFromDetailView(itemId)
+        })
+        window.tpViewingItems = {}
       }
     }
 
@@ -399,11 +425,32 @@
         tpWsDebug('[TeamPass WS] Subscribed to folder ' + folderId, 'log')
         // Sync initial lock state: show badges for items already locked in this folder
         if (response && Array.isArray(response.locked_items)) {
-          if (!window.tpLockedItems) window.tpLockedItems = {}
+          if (window.tpLockedItems) {
+            Object.keys(window.tpLockedItems).forEach(function(itemId) {
+              removeEditionLockIndicator(itemId)
+              removeEditionLockFromDetailView(itemId)
+            })
+          }
+          window.tpLockedItems = {}
           response.locked_items.forEach(function(lock) {
             window.tpLockedItems[lock.item_id] = lock.user_login
             showEditionLockIndicator(lock.item_id, lock.user_login)
           })
+        }
+        if (response && Array.isArray(response.viewing_items)) {
+          if (window.tpViewingItems) {
+            Object.keys(window.tpViewingItems).forEach(function(itemId) {
+              removeItemViewIndicator(itemId)
+              removeItemViewFromDetailView(itemId)
+            })
+          }
+          window.tpViewingItems = {}
+          response.viewing_items.forEach(function(itemView) {
+            setItemViewers(itemView.item_id, itemView.viewers || [])
+          })
+        }
+        if (activeItemView && parseInt(activeItemView.folderId) === parseInt(folderId)) {
+          sendStartItemView(activeItemView.itemId, activeItemView.folderId)
         }
       })
       .catch(function(err) {
@@ -576,6 +623,203 @@
     $container.find('.edition-lock-detail-badge').remove()
   }
 
+  function getCurrentUserId() {
+    if (window.TeamPassCurrentUserId) {
+      return parseInt(window.TeamPassCurrentUserId, 10)
+    }
+    if (typeof store !== 'undefined' && store.get('teampassUser')) {
+      var user = store.get('teampassUser')
+      return parseInt(user.id || user.user_id || user.userId || 0, 10)
+    }
+    return 0
+  }
+
+  function escapeHtml(value) {
+    if (typeof $ === 'undefined') return String(value || '')
+    return $('<span>').text(value || '').html()
+  }
+
+  function escapeAttribute(value) {
+    return escapeHtml(value).replace(/"/g, '&quot;').replace(/'/g, '&#39;')
+  }
+
+  function normalizeViewers(viewers) {
+    var currentUserId = getCurrentUserId()
+    var unique = {}
+
+    ;(viewers || []).forEach(function(viewer) {
+      var userId = parseInt(viewer.user_id || viewer.id || 0, 10)
+      if (!userId || userId === currentUserId) return
+      unique[userId] = {
+        user_id: userId,
+        user_login: viewer.user_login || viewer.login || ''
+      }
+    })
+
+    return Object.keys(unique).map(function(userId) {
+      return unique[userId]
+    })
+  }
+
+  function buildViewerLabel(viewers) {
+    if (viewers.length === 0) return ''
+    if (viewers.length === 1) return viewers[0].user_login
+    return viewers[0].user_login + ' +' + (viewers.length - 1)
+  }
+
+  function setItemViewers(itemId, viewers) {
+    itemId = parseInt(itemId, 10)
+    if (!itemId) return
+
+    var normalizedViewers = normalizeViewers(viewers)
+    if (!window.tpViewingItems) window.tpViewingItems = {}
+
+    if (normalizedViewers.length === 0) {
+      delete window.tpViewingItems[itemId]
+      removeItemViewIndicator(itemId)
+      removeItemViewFromDetailView(itemId)
+      return
+    }
+
+    window.tpViewingItems[itemId] = normalizedViewers
+    showItemViewIndicator(itemId, normalizedViewers)
+    updateItemViewersInDetailView(itemId, normalizedViewers)
+  }
+
+  function sendStartItemView(itemId, folderId) {
+    if (!tpWs.isConnectedNow()) return
+    tpWs.send({
+      action: 'start_item_view',
+      data: {
+        item_id: parseInt(itemId, 10),
+        folder_id: parseInt(folderId, 10)
+      }
+    }).catch(function(err) {
+      tpWsDebug('[TeamPass WS] Failed to start item view presence - ' + err, 'warn')
+    })
+  }
+
+  function startItemView(itemId, folderId) {
+    itemId = parseInt(itemId, 10)
+    folderId = parseInt(folderId || currentFolderId, 10)
+    if (!itemId || !folderId) return
+
+    if (activeItemView &&
+        parseInt(activeItemView.itemId) === itemId &&
+        parseInt(activeItemView.folderId) === folderId) {
+      return
+    }
+
+    var previousItemView = activeItemView
+    activeItemView = { itemId: itemId, folderId: folderId }
+
+    var start = function() {
+      sendStartItemView(itemId, folderId)
+    }
+
+    if (previousItemView && tpWs.isConnectedNow()) {
+      tpWs.send({
+        action: 'stop_item_view',
+        data: {
+          item_id: parseInt(previousItemView.itemId, 10),
+          folder_id: parseInt(previousItemView.folderId, 10)
+        }
+      }).then(start).catch(start)
+    } else {
+      start()
+    }
+  }
+
+  function stopItemView(itemId) {
+    itemId = itemId ? parseInt(itemId, 10) : null
+    if (!activeItemView) return
+    if (itemId && parseInt(activeItemView.itemId) !== itemId) return
+
+    var previousItemView = activeItemView
+    activeItemView = null
+
+    if (!tpWs.isConnectedNow()) return
+    tpWs.send({
+      action: 'stop_item_view',
+      data: {
+        item_id: parseInt(previousItemView.itemId, 10),
+        folder_id: parseInt(previousItemView.folderId, 10)
+      }
+    }).catch(function(err) {
+      tpWsDebug('[TeamPass WS] Failed to stop item view presence - ' + err, 'warn')
+    })
+  }
+
+  /**
+   * Show consultation presence on an item row in the items list.
+   */
+  function showItemViewIndicator(itemId, viewers) {
+    if (typeof $ === 'undefined') return
+
+    var $row = $('#list-item-row_' + itemId)
+    if ($row.length === 0) return
+
+    removeItemViewIndicator(itemId)
+
+    var names = viewers.map(function(viewer) {
+      return viewer.user_login
+    })
+    var label = buildViewerLabel(viewers)
+    var badge = $('<span class="item-view-badge badge badge-success ml-2" ' +
+      'title="' + escapeAttribute((L.item_viewed_by || 'Viewed by') + ' ' + names.join(', ')) + '">' +
+      '<i class="fa-regular fa-eye mr-1"></i>' + escapeHtml(label) +
+      '</span>')
+
+    $row.find('.list-item-row-description').first().after(badge)
+  }
+
+  function removeItemViewIndicator(itemId) {
+    if (typeof $ === 'undefined') return
+    $('#list-item-row_' + itemId).find('.item-view-badge').remove()
+  }
+
+  function updateItemViewersInDetailView(itemId, viewers) {
+    var normalizedViewers = normalizeViewers(viewers)
+    if (normalizedViewers.length === 0) {
+      removeItemViewFromDetailView(itemId)
+      return
+    }
+    showItemViewInDetailView(itemId, normalizedViewers)
+  }
+
+  /**
+   * Show consultation presence in the item detail panel.
+   */
+  function showItemViewInDetailView(itemId, viewers) {
+    if (typeof $ === 'undefined') return
+    var $container = $('#items-details-container')
+    if ($container.hasClass('hidden')) return
+    if (parseInt($container.data('id')) !== parseInt(itemId)) return
+
+    removeItemViewFromDetailView(itemId)
+
+    var names = viewers.map(function(viewer) {
+      return viewer.user_login
+    })
+    var badge = $('<div class="item-view-detail-badge alert alert-success py-1 px-2 mt-1 mb-0 ml-2 d-inline-block">' +
+      '<i class="fa-regular fa-eye mr-1"></i>' +
+      (L.item_viewed_by || 'Viewed by') + ' <strong>' + escapeHtml(names.join(', ')) + '</strong>' +
+      '</div>')
+    var $lockBadge = $container.find('.edition-lock-detail-badge').last()
+    if ($lockBadge.length > 0) {
+      $lockBadge.after(badge)
+    } else {
+      $('#card-item-label').after(badge)
+    }
+  }
+
+  function removeItemViewFromDetailView(itemId) {
+    if (typeof $ === 'undefined') return
+    var $container = $('#items-details-container')
+    if (itemId && parseInt($container.data('id')) !== parseInt(itemId)) return
+    $container.find('.item-view-detail-badge').remove()
+  }
+
   /**
    * Refresh user folders after a permission change
    *
@@ -596,6 +840,11 @@
   window.tpWsRemoveEditionLock = removeEditionLockIndicator
   window.tpWsShowEditionLockDetail = showEditionLockInDetailView
   window.tpWsRemoveEditionLockDetail = removeEditionLockFromDetailView
+  window.tpWsStartItemView = startItemView
+  window.tpWsStopItemView = stopItemView
+  window.tpWsSetItemViewers = setItemViewers
+  window.tpWsRemoveItemView = removeItemViewIndicator
+  window.tpWsRemoveItemViewDetail = removeItemViewFromDetailView
   window.refreshUserFolders = refreshUserFolders
 
   // Initialize when DOM is ready

--- a/app/pages/items.js.php
+++ b/app/pages/items.js.php
@@ -87,6 +87,8 @@ $bip39Wordlist = loadBip39Wordlist($session->get('user-language') ?? 'english');
 
 
 <script type="text/javascript">
+    window.TeamPassCurrentUserId = <?php echo (int) $session->get('user-id'); ?>;
+
     // BIP-39 wordlist for the passphrase generator (language: <?php echo htmlspecialchars($session->get('user-language') ?? 'english', ENT_QUOTES, 'UTF-8'); ?>)
     const TP_BIP39_WORDLIST = <?php echo json_encode($bip39Wordlist, JSON_UNESCAPED_UNICODE); ?>;
 
@@ -230,9 +232,31 @@ $bip39Wordlist = loadBip39Wordlist($session->get('user-language') ?? 'english');
         }
     }
 
+    function clearLocalEditionLock(itemId) {
+        itemId = parseInt(itemId, 10)
+        if (!itemId) return
+
+        if (window.tpLockedItems) {
+            delete window.tpLockedItems[itemId]
+        }
+        if (typeof window.tpWsRemoveEditionLock === 'function') {
+            window.tpWsRemoveEditionLock(itemId)
+        }
+        if (typeof window.tpWsRemoveEditionLockDetail === 'function') {
+            window.tpWsRemoveEditionLockDetail(itemId)
+        }
+    }
+
+    function stopConsultationPresence(itemId) {
+        if (typeof window.tpWsStopItemView === 'function') {
+            window.tpWsStopItemView(itemId)
+        }
+    }
+
     // Clean up edition lock on page unload (tab close, navigation away)
     $(window).on('beforeunload', function() {
         stopEditionLockHeartbeat()
+        stopConsultationPresence()
     })
 
     // Manage memory
@@ -910,6 +934,7 @@ $bip39Wordlist = loadBip39Wordlist($session->get('user-language') ?? 'english');
             // Mirrors what the "Back" button does when leaving edit mode.
             const previousItemId = store.get('teampassItem').id;
             if (previousItemId && parseInt(previousItemId) > 0) {
+                stopConsultationPresence(previousItemId);
                 stopEditionLockHeartbeat();
                 $.post(
                     'sources/items.queries.php', {
@@ -1084,6 +1109,7 @@ $bip39Wordlist = loadBip39Wordlist($session->get('user-language') ?? 'english');
                 }
 
                 // Permission confirmed — now show the form
+                stopConsultationPresence(store.get('teampassItem').id);
                 savePreviousView();
                 // Fields are already populated by Details('show') — only clear password
                 resetEditFormSkeleton(false);
@@ -2671,6 +2697,7 @@ $bip39Wordlist = loadBip39Wordlist($session->get('user-language') ?? 'english');
                 closeItemDetailsCard();
             });
         } else {
+            stopConsultationPresence(store.get('teampassItem').id);
             if (store.get('teampassUser').previousView === '.item-details-card' &&
                 $('.item-details-card').hasClass('hidden') === false
             ) {
@@ -2888,6 +2915,7 @@ $bip39Wordlist = loadBip39Wordlist($session->get('user-language') ?? 'english');
 
             // Refresh password visibility
             resetPasswordDisplay();
+            stopConsultationPresence(store.get('teampassItem').id);
 
             // Load item info
             Details(
@@ -2906,6 +2934,7 @@ $bip39Wordlist = loadBip39Wordlist($session->get('user-language') ?? 'english');
     $(document)
         .on('click', '.list-item-clicktoshow', function() {
             toastr.remove();
+            stopConsultationPresence(store.get('teampassItem').id);
             // Highlight the selected row persistently
             $('#teampass_items_list tr').removeClass('item-selected')
             $(this).closest('tr').addClass('item-selected')
@@ -2956,6 +2985,7 @@ $bip39Wordlist = loadBip39Wordlist($session->get('user-language') ?? 'english');
         })
         .on('click', '.list-item-clicktoedit', function() {
             toastr.remove();
+            stopConsultationPresence(store.get('teampassItem').id);
             // Capture previous view before the skeleton hides/shows panels
             savePreviousView();
             // Fields not yet loaded — show skeleton bars on all inputs
@@ -3942,6 +3972,7 @@ $bip39Wordlist = loadBip39Wordlist($session->get('user-language') ?? 'english');
                         } else {
                             // Stop edition lock heartbeat on successful save
                             stopEditionLockHeartbeat()
+                            clearLocalEditionLock(store.get('teampassItem').id)
 
                             // Refresh tree
                             if ($('#form-item-button-save').data('action') === 'update_item') {
@@ -4225,6 +4256,7 @@ $bip39Wordlist = loadBip39Wordlist($session->get('user-language') ?? 'english');
 
     function showItemEditForm(selectedFolderId, prefetchedPassword, skipPassword = false) {
         if (debugJavascript === true) console.info('SHOW EDIT ITEM ' + selectedFolderId);
+        stopConsultationPresence(store.get('teampassItem').id);
         // Reset item
         store.update(
             'teampassItem',
@@ -5420,6 +5452,11 @@ $bip39Wordlist = loadBip39Wordlist($session->get('user-language') ?? 'english');
                 window.tpWsShowEditionLock(parseInt(itemId), window.tpLockedItems[itemId])
             })
         }
+        if (window.tpViewingItems && typeof window.tpWsSetItemViewers === 'function') {
+            Object.keys(window.tpViewingItems).forEach(function(itemId) {
+                window.tpWsSetItemViewers(parseInt(itemId), window.tpViewingItems[itemId])
+            })
+        }
     }
 
     $(document).on('click', '.open-folder', function() {
@@ -5763,6 +5800,7 @@ $bip39Wordlist = loadBip39Wordlist($session->get('user-language') ?? 'english');
             
             // Start edition lock heartbeat when editing is allowed
             if (actionType === 'edit' && retData.edition_locked !== true) {
+                stopConsultationPresence(itemId)
                 startEditionLockHeartbeat(itemId)
             }
 
@@ -6199,12 +6237,19 @@ $bip39Wordlist = loadBip39Wordlist($session->get('user-language') ?? 'english');
                         }
                     }
 
-                    // Remove any stale edition lock badge from a previously viewed item
-                    $('#items-details-container').find('.edition-lock-detail-badge').remove();
+                    // Remove any stale real-time badges from a previously viewed item
+                    $('#items-details-container').find('.edition-lock-detail-badge, .item-view-detail-badge').remove();
                     // If this item is already being edited by another user, show the lock badge
                     if (window.tpLockedItems && window.tpLockedItems[data.id] &&
                         typeof window.tpWsShowEditionLockDetail === 'function') {
                         window.tpWsShowEditionLockDetail(data.id, window.tpLockedItems[data.id]);
+                    }
+                    if (window.tpViewingItems && window.tpViewingItems[data.id] &&
+                        typeof window.tpWsSetItemViewers === 'function') {
+                        window.tpWsSetItemViewers(data.id, window.tpViewingItems[data.id]);
+                    }
+                    if (actionType === 'show' && typeof window.tpWsStartItemView === 'function') {
+                        window.tpWsStartItemView(data.id, data.folder);
                     }
                     $('#form-item-label, #form-item-suggestion-label').val($('<div>').html(data.label).text());
                     $('#card-item-description, #form-item-suggestion-description').html(htmlDecode(data.description));

--- a/app/sources/items.queries.php
+++ b/app/sources/items.queries.php
@@ -1058,6 +1058,9 @@ switch ($inputData['type']) {
             'at_creation',
             $inputData['itemId']
         );
+        $originalFolderId = (int) ($dataItem['id_tree'] ?? $inputData['folderId']);
+        $targetFolderId = (int) $inputData['folderId'];
+        $editionLockForSave = getItemEditionLockSaveStatus((int) $inputData['itemId'], (int) $session->get('user-id'));
 
         // Always check what rights user has on requested folder
         $checkRights = getCurrentAccessRights(
@@ -1086,6 +1089,29 @@ switch ($inputData['type']) {
                 array(
                     'error' => true,
                     'message' => $lang->get('error_not_allowed_to'),
+                ),
+                'encode'
+            );
+            break;
+        }
+        if (($checkRights['edition_locked'] ?? false) === true) {
+            echo (string) prepareExchangedData(
+                array(
+                    'error' => true,
+                    'message' => $lang->get('error_item_currently_being_updated'),
+                    'delay' => $checkRights['edition_locked_delay'] ?? null,
+                ),
+                'encode'
+            );
+            break;
+        }
+
+        if ($editionLockForSave['allowed'] !== true) {
+            echo (string) prepareExchangedData(
+                array(
+                    'error' => true,
+                    'message' => $lang->get('error_item_currently_being_updated'),
+                    'delay' => $editionLockForSave['delay'] ?? null,
                 ),
                 'encode'
             );
@@ -2150,19 +2176,30 @@ switch ($inputData['type']) {
             // Remove the edition lock after a successful save
             DB::delete(
                 prefixTable('items_edition'),
-                'item_id = %i AND user_id = %i',
-                $inputData['itemId'],
-                $session->get('user-id')
+                'item_id = %i',
+                $inputData['itemId']
             );
 
-            // Notify other users via WebSocket that this item is now free
+            // Notify other users via WebSocket that this item is now free.
+            // If the item has been moved while editing, notify both folders so
+            // stale lock badges are cleared for users still subscribed to the
+            // original folder.
             emitEditionLockEvent(
                 'stopped',
                 (int) $inputData['itemId'],
-                (int) $inputData['folderId'],
+                $originalFolderId,
                 $session->get('user-login') ?? '',
                 (int) $session->get('user-id')
             );
+            if ($targetFolderId !== $originalFolderId) {
+                emitEditionLockEvent(
+                    'stopped',
+                    (int) $inputData['itemId'],
+                    $targetFolderId,
+                    $session->get('user-login') ?? '',
+                    (int) $session->get('user-id')
+                );
+            }
 
             // Notifiy changes to the users
             notifyChangesToSubscribers($inputData['itemId'], $inputData['label'], $arrayOfChanges, $SETTINGS);
@@ -7244,8 +7281,7 @@ switch ($inputData['type']) {
                 $deleteAccessRights = getCurrentAccessRights(
                     (int) $session->get('user-id'),
                     $inputData['itemId'],
-                    (int) $itemRowDelete['id_tree'],
-                    'edit'
+                    (int) $itemRowDelete['id_tree']
                 );
                 if ($deleteAccessRights['edit'] !== true) {
                     echo (string) prepareExchangedData(
@@ -7351,8 +7387,7 @@ switch ($inputData['type']) {
         $confirmAccessRights = getCurrentAccessRights(
             (int) $session->get('user-id'),
             $inputData['itemId'],
-            (int) $itemRow['id_tree'],
-            'edit'
+            (int) $itemRow['id_tree']
         );
         if ($confirmAccessRights['edit'] !== true) {
             echo (string) prepareExchangedData(
@@ -7807,8 +7842,10 @@ function getCurrentAccessRights(int $userId, int $itemId, int $treeId, string $a
 
     // Check if the folder is in the user's allowed folders list defined by admin
     if (in_array($treeId, $session->get('user-allowed_folders_by_definition'))) {
-        // User has full access — create/check the edition lock now that edit is confirmed
-        $editionLock = isItemLocked($itemId, $session, $userId, $action);
+        // Edition locks are only touched when the user actually enters edit mode.
+        $editionLock = $action === 'edit'
+            ? isItemLocked($itemId, $session, $userId, $action)
+            : ['status' => false];
         return getAccessResponse(false, true, true, true, $editionLock, true);
     }
 
@@ -7818,7 +7855,9 @@ function getCurrentAccessRights(int $userId, int $itemId, int $treeId, string $a
     // Check if the folder is personal to the user
     foreach ($visibleFolders as $folder) {
         if ($folder['id'] == $treeId && (int) $folder['perso'] === 1) {
-            $editionLock = isItemLocked($itemId, $session, $userId, $action);
+            $editionLock = $action === 'edit'
+                ? isItemLocked($itemId, $session, $userId, $action)
+                : ['status' => false];
             return getAccessResponse(false, true, true, true, $editionLock, true);
         }
     }
@@ -7836,9 +7875,11 @@ function getCurrentAccessRights(int $userId, int $itemId, int $treeId, string $a
         error_log("TEAMPASS - Folder: $treeId - User: $userId - edit: $edit - delete: $delete - create: $create");
     }
 
-    // Only create/check the edition lock when the user actually has edit rights.
-    // If edit=false, pass an empty status — no lock is acquired for a denied user.
-    $editionLock = $edit ? isItemLocked($itemId, $session, $userId, $action) : ['status' => false];
+    // Only create/check the edition lock when the user actually enters edit mode.
+    // If edit=false or the action is read-only, no lock is acquired or refreshed.
+    $editionLock = ($edit && $action === 'edit')
+        ? isItemLocked($itemId, $session, $userId, $action)
+        : ['status' => false];
 
     return getAccessResponse(false, true, $edit, $delete, $editionLock, $create);
 }
@@ -7899,6 +7940,71 @@ function getItemRestrictedUsersList(int $itemId, int $userId): bool
     return false;
 }
 
+function getEditionLockHeartbeatTimeout(): int
+{
+    $timeout = defined('EDITION_LOCK_HEARTBEAT_TIMEOUT')
+        ? (int) EDITION_LOCK_HEARTBEAT_TIMEOUT
+        : 300;
+
+    return $timeout > 0 ? $timeout : 300;
+}
+
+function getLatestItemEditionLock(int $itemId): ?array
+{
+    $lock = DB::queryFirstRow(
+        'SELECT timestamp, user_id, increment_id
+         FROM ' . prefixTable('items_edition') . '
+         WHERE item_id = %i
+         ORDER BY increment_id DESC',
+        $itemId
+    );
+
+    return $lock === null ? null : $lock;
+}
+
+function getItemEditionLockSaveStatus(int $itemId, int $userId): array
+{
+    if ($itemId <= 0 || $userId <= 0) {
+        return ['allowed' => false, 'reason' => 'invalid'];
+    }
+
+    $locks = DB::query(
+        'SELECT timestamp, user_id, increment_id
+         FROM ' . prefixTable('items_edition') . '
+         WHERE item_id = %i
+         ORDER BY increment_id DESC',
+        $itemId
+    );
+    if (count($locks) === 0) {
+        return ['allowed' => false, 'reason' => 'missing'];
+    }
+
+    $now = time();
+    $timeout = getEditionLockHeartbeatTimeout();
+    $hasOwnActiveLock = false;
+
+    foreach ($locks as $lock) {
+        $elapsed = abs($now - (int) $lock['timestamp']);
+        if ($elapsed > $timeout) {
+            continue;
+        }
+
+        if ((int) $lock['user_id'] !== $userId) {
+            return [
+                'allowed' => false,
+                'reason' => 'locked_by_other_user',
+                'delay' => max(0, $timeout - $elapsed),
+            ];
+        }
+
+        $hasOwnActiveLock = true;
+    }
+
+    return $hasOwnActiveLock === true
+        ? ['allowed' => true]
+        : ['allowed' => false, 'reason' => 'missing_active_lock'];
+}
+
 /**
  * Checks if the item is locked by another user or if there is an ongoing encryption process.
  * If the item is locked, the function determines if the lock has expired or not.
@@ -7920,16 +8026,10 @@ function isItemLocked(int $itemId, $session, int $userId, string $actionType = '
     }
 
     $now = time();
-    $editionLocks = DB::query(
-        'SELECT timestamp, user_id, increment_id
-         FROM ' . prefixTable('items_edition') . '
-         WHERE item_id = %i
-         ORDER BY increment_id DESC',
-        $itemId
-    );
+    $lastLock = getLatestItemEditionLock($itemId);
 
     // Check if there are any locks for this item
-    if (count($editionLocks) === 0) {
+    if ($lastLock === null) {
         // If no locks exist and the action is 'edit', create a new lock
         if ($actionType === 'edit') {
             createEditionLock($itemId, $userId, $now);
@@ -7943,17 +8043,17 @@ function isItemLocked(int $itemId, $session, int $userId, string $actionType = '
         return ['status' => false];
     }
 
-    // Check if the last lock is older than the defined period
-    $lastLock = $editionLocks[0];
-
-    // If the lock is for the current user, update the timestamp
+    // If the lock is for the current user, update the timestamp only while
+    // entering edit mode. Read-only access checks must never keep a lock alive.
     if (intval($lastLock['user_id']) === $userId) {
-        DB::update(
-            prefixTable('items_edition'),
-            ['timestamp' => $now],
-            'increment_id = %i',
-            $lastLock['increment_id']
-        );
+        if ($actionType === 'edit') {
+            DB::update(
+                prefixTable('items_edition'),
+                ['timestamp' => $now],
+                'increment_id = %i',
+                $lastLock['increment_id']
+            );
+        }
         return [
             'status' => false,
         ];
@@ -7962,9 +8062,7 @@ function isItemLocked(int $itemId, $session, int $userId, string $actionType = '
     // Use heartbeat-based timeout: lock expires only if no heartbeat renewal
     // was received within EDITION_LOCK_HEARTBEAT_TIMEOUT (default 5 minutes).
     // The client sends a WebSocket renew_item_lock every 60s while editing.
-    $heartbeatTimeout = defined('EDITION_LOCK_HEARTBEAT_TIMEOUT')
-        ? EDITION_LOCK_HEARTBEAT_TIMEOUT
-        : 300;
+    $heartbeatTimeout = getEditionLockHeartbeatTimeout();
 
     // Calculate the elapsed time since the last lock refresh (heartbeat or creation)
     $elapsed = abs($now - intval($lastLock['timestamp']));

--- a/app/websocket/src/ConnectionManager.php
+++ b/app/websocket/src/ConnectionManager.php
@@ -29,6 +29,13 @@ class ConnectionManager
      */
     private array $folderSubscriptions = [];
 
+    /**
+     * Item consultation presence by connection resource ID.
+     *
+     * @var array<int, array{folder_id: int, item_id: int, user_id: int, user_login: string}>
+     */
+    private array $itemViews = [];
+
     public function __construct()
     {
         $this->connections = new SplObjectStorage();
@@ -59,6 +66,7 @@ class ConnectionManager
     public function removeConnection(ConnectionInterface $conn): void
     {
         $this->connections->detach($conn);
+        $this->clearItemViewsForConnection($conn);
 
         // Get user ID from connection metadata
         $userId = $conn->userData['user_id'] ?? null;
@@ -189,6 +197,174 @@ class ConnectionManager
     public function getFolderSubscribers(int $folderId): array
     {
         return $this->folderSubscriptions[$folderId] ?? [];
+    }
+
+    /**
+     * Mark a connection as viewing an item in read-only mode.
+     *
+     * @return array<int, array{folder_id: int, item_id: int}> Presence targets whose viewer list changed
+     */
+    public function startItemView(ConnectionInterface $conn, int $folderId, int $itemId): array
+    {
+        $resourceId = (int) $conn->resourceId;
+        $affected = [];
+        $existing = $this->itemViews[$resourceId] ?? null;
+
+        if ($existing !== null
+            && (int) $existing['folder_id'] === $folderId
+            && (int) $existing['item_id'] === $itemId
+        ) {
+            return [];
+        }
+
+        if ($existing !== null) {
+            $affected[] = [
+                'folder_id' => (int) $existing['folder_id'],
+                'item_id' => (int) $existing['item_id'],
+            ];
+        }
+
+        $this->itemViews[$resourceId] = [
+            'folder_id' => $folderId,
+            'item_id' => $itemId,
+            'user_id' => (int) ($conn->userData['user_id'] ?? 0),
+            'user_login' => (string) ($conn->userData['user_login'] ?? ''),
+        ];
+
+        $affected[] = [
+            'folder_id' => $folderId,
+            'item_id' => $itemId,
+        ];
+
+        return $this->uniqueItemViewTargets($affected);
+    }
+
+    /**
+     * Stop read-only item viewing for a connection.
+     *
+     * @return array<int, array{folder_id: int, item_id: int}> Presence targets whose viewer list changed
+     */
+    public function stopItemView(ConnectionInterface $conn, ?int $folderId = null, ?int $itemId = null): array
+    {
+        $resourceId = (int) $conn->resourceId;
+        $existing = $this->itemViews[$resourceId] ?? null;
+
+        if ($existing === null) {
+            return [];
+        }
+
+        if ($folderId !== null && (int) $existing['folder_id'] !== $folderId) {
+            return [];
+        }
+
+        if ($itemId !== null && (int) $existing['item_id'] !== $itemId) {
+            return [];
+        }
+
+        unset($this->itemViews[$resourceId]);
+
+        return [[
+            'folder_id' => (int) $existing['folder_id'],
+            'item_id' => (int) $existing['item_id'],
+        ]];
+    }
+
+    /**
+     * Clear all read-only item views for a connection.
+     *
+     * @return array<int, array{folder_id: int, item_id: int}> Presence targets whose viewer list changed
+     */
+    public function clearItemViewsForConnection(ConnectionInterface $conn): array
+    {
+        return $this->stopItemView($conn);
+    }
+
+    /**
+     * Get unique users currently viewing an item.
+     *
+     * @return array<int, array{user_id: int, user_login: string}>
+     */
+    public function getItemViewers(int $folderId, int $itemId): array
+    {
+        $viewers = [];
+
+        foreach ($this->itemViews as $view) {
+            if ((int) $view['folder_id'] !== $folderId || (int) $view['item_id'] !== $itemId) {
+                continue;
+            }
+
+            $userId = (int) $view['user_id'];
+            if ($userId <= 0) {
+                continue;
+            }
+
+            $viewers[$userId] = [
+                'user_id' => $userId,
+                'user_login' => (string) $view['user_login'],
+            ];
+        }
+
+        return array_values($viewers);
+    }
+
+    /**
+     * Get the item consultation presence state for a folder.
+     *
+     * @return array<int, array{item_id: int, viewers: array<int, array{user_id: int, user_login: string}>}>
+     */
+    public function getItemViewersForFolder(int $folderId): array
+    {
+        $items = [];
+
+        foreach ($this->itemViews as $view) {
+            if ((int) $view['folder_id'] !== $folderId) {
+                continue;
+            }
+
+            $itemId = (int) $view['item_id'];
+            $userId = (int) $view['user_id'];
+            if ($itemId <= 0 || $userId <= 0) {
+                continue;
+            }
+
+            if (!isset($items[$itemId])) {
+                $items[$itemId] = [
+                    'item_id' => $itemId,
+                    'viewers' => [],
+                ];
+            }
+
+            $items[$itemId]['viewers'][$userId] = [
+                'user_id' => $userId,
+                'user_login' => (string) $view['user_login'],
+            ];
+        }
+
+        foreach ($items as &$item) {
+            $item['viewers'] = array_values($item['viewers']);
+        }
+        unset($item);
+
+        return array_values($items);
+    }
+
+    /**
+     * @param array<int, array{folder_id: int, item_id: int}> $targets
+     * @return array<int, array{folder_id: int, item_id: int}>
+     */
+    private function uniqueItemViewTargets(array $targets): array
+    {
+        $unique = [];
+
+        foreach ($targets as $target) {
+            $key = (int) $target['folder_id'] . ':' . (int) $target['item_id'];
+            $unique[$key] = [
+                'folder_id' => (int) $target['folder_id'],
+                'item_id' => (int) $target['item_id'],
+            ];
+        }
+
+        return array_values($unique);
     }
 
     /**

--- a/app/websocket/src/MessageHandler.php
+++ b/app/websocket/src/MessageHandler.php
@@ -29,6 +29,8 @@ class MessageHandler
         'get_status',         // Get connection status
         'get_stats',          // Get server stats (admin only)
         'renew_item_lock',    // Renew edition lock heartbeat
+        'start_item_view',    // Mark an item as opened in read-only consultation
+        'stop_item_view',     // Clear read-only consultation presence
     ];
 
     public function __construct(
@@ -88,6 +90,8 @@ class MessageHandler
             'get_status' => $this->handleGetStatus($conn, $requestId),
             'get_stats' => $this->handleGetStats($conn, $requestId),
             'renew_item_lock' => $this->handleRenewItemLock($conn, $message, $requestId),
+            'start_item_view' => $this->handleStartItemView($conn, $message, $requestId),
+            'stop_item_view' => $this->handleStopItemView($conn, $message, $requestId),
             default => null,
         };
     }
@@ -140,18 +144,21 @@ class MessageHandler
             $lockedItems = [];
             try {
                 $tablePrefix = defined('DB_PREFIX') ? DB_PREFIX : 'teampass_';
-                $heartbeatTimeout = 300; // must match EDITION_LOCK_HEARTBEAT_TIMEOUT
+                $heartbeatTimeout = defined('EDITION_LOCK_HEARTBEAT_TIMEOUT')
+                    ? (int) EDITION_LOCK_HEARTBEAT_TIMEOUT
+                    : 300;
                 $rows = \DB::query(
                     'SELECT ie.item_id, u.login AS user_login
                      FROM %l ie
                      JOIN %l i ON ie.item_id = i.id
                      JOIN %l u ON ie.user_id = u.id
-                     WHERE i.id_tree = %i AND ie.timestamp >= %i',
+                     WHERE i.id_tree = %i AND ie.timestamp >= %i AND ie.user_id <> %i',
                     $tablePrefix . 'items_edition',
                     $tablePrefix . 'items',
                     $tablePrefix . 'users',
                     $folderId,
-                    time() - $heartbeatTimeout
+                    time() - $heartbeatTimeout,
+                    (int) $userData['user_id']
                 );
                 foreach ($rows as $row) {
                     $lockedItems[] = [
@@ -173,6 +180,7 @@ class MessageHandler
                 'channel'      => 'folder',
                 'folder_id'    => $folderId,
                 'locked_items' => $lockedItems,
+                'viewing_items' => $this->connections->getItemViewersForFolder($folderId),
                 'request_id'   => $requestId,
             ];
         }
@@ -206,6 +214,11 @@ class MessageHandler
                 'user_id' => $userData['user_id'] ?? null,
                 'folder_id' => $folderId,
             ]);
+
+            $affectedViews = $this->connections->stopItemView($conn, $folderId);
+            foreach ($affectedViews as $target) {
+                $this->broadcastItemViewersChanged($target['folder_id'], $target['item_id']);
+            }
 
             return [
                 'type' => 'response',
@@ -351,6 +364,130 @@ class MessageHandler
 
             return $this->error('server_error', 'Failed to renew lock', $requestId);
         }
+    }
+
+    /**
+     * Handle start_item_view: track read-only consultation presence.
+     */
+    private function handleStartItemView(ConnectionInterface $conn, array $message, ?string $requestId): array
+    {
+        $userData = $conn->userData ?? [];
+        $userId = $userData['user_id'] ?? null;
+
+        if ($userId === null) {
+            return $this->error('unauthorized', 'Authentication required', $requestId);
+        }
+
+        $data = $message['data'] ?? [];
+        $itemId = isset($data['item_id']) ? (int) $data['item_id'] : 0;
+
+        if ($itemId <= 0) {
+            return $this->error('invalid_request', 'item_id is required', $requestId);
+        }
+
+        $folderId = $this->getItemFolderId($itemId);
+        if ($folderId === null) {
+            return $this->error('not_found', 'Item not found', $requestId);
+        }
+
+        if (!$this->authValidator->canAccessFolder($userData, $folderId)) {
+            return $this->error('forbidden', 'Access denied to this item folder', $requestId);
+        }
+
+        $affectedViews = $this->connections->startItemView($conn, $folderId, $itemId);
+        foreach ($affectedViews as $target) {
+            $this->broadcastItemViewersChanged($target['folder_id'], $target['item_id']);
+        }
+
+        return [
+            'type' => 'response',
+            'status' => 'success',
+            'action' => 'item_view_started',
+            'item_id' => $itemId,
+            'folder_id' => $folderId,
+            'viewers' => $this->connections->getItemViewers($folderId, $itemId),
+            'request_id' => $requestId,
+        ];
+    }
+
+    /**
+     * Handle stop_item_view: clear read-only consultation presence.
+     */
+    private function handleStopItemView(ConnectionInterface $conn, array $message, ?string $requestId): array
+    {
+        $userData = $conn->userData ?? [];
+        if (!isset($userData['user_id'])) {
+            return $this->error('unauthorized', 'Authentication required', $requestId);
+        }
+
+        $data = $message['data'] ?? [];
+        $itemId = isset($data['item_id']) ? (int) $data['item_id'] : null;
+        $folderId = isset($data['folder_id']) ? (int) $data['folder_id'] : null;
+        $itemId = $itemId !== null && $itemId > 0 ? $itemId : null;
+        $folderId = $folderId !== null && $folderId > 0 ? $folderId : null;
+
+        if ($itemId !== null) {
+            $actualFolderId = $this->getItemFolderId($itemId);
+            if ($actualFolderId !== null) {
+                $folderId = $actualFolderId;
+            }
+        }
+
+        $affectedViews = $this->connections->stopItemView($conn, $folderId, $itemId);
+        foreach ($affectedViews as $target) {
+            $this->broadcastItemViewersChanged($target['folder_id'], $target['item_id']);
+        }
+
+        return [
+            'type' => 'response',
+            'status' => 'success',
+            'action' => 'item_view_stopped',
+            'item_id' => $itemId,
+            'folder_id' => $folderId,
+            'request_id' => $requestId,
+        ];
+    }
+
+    /**
+     * Broadcast the current consultation viewer list for one item.
+     */
+    private function broadcastItemViewersChanged(int $folderId, int $itemId): void
+    {
+        $this->connections->broadcastToFolder($folderId, [
+            'type' => 'event',
+            'event' => 'item_viewers_changed',
+            'data' => [
+                'item_id' => $itemId,
+                'folder_id' => $folderId,
+                'viewers' => $this->connections->getItemViewers($folderId, $itemId),
+                'server_timestamp' => time(),
+            ],
+            'timestamp' => time(),
+        ]);
+    }
+
+    /**
+     * Resolve the current folder of an item from the database.
+     */
+    private function getItemFolderId(int $itemId): ?int
+    {
+        $tablePrefix = defined('DB_PREFIX') ? DB_PREFIX : 'teampass_';
+
+        try {
+            $folderId = \DB::queryFirstField(
+                'SELECT id_tree FROM %l WHERE id = %i',
+                $tablePrefix . 'items',
+                $itemId
+            );
+        } catch (\Exception $e) {
+            $this->logger->warning('Failed to resolve item folder for presence', [
+                'item_id' => $itemId,
+                'error' => $e->getMessage(),
+            ]);
+            return null;
+        }
+
+        return $folderId === null || $folderId === false ? null : (int) $folderId;
     }
 
     /**

--- a/app/websocket/src/WebSocketServer.php
+++ b/app/websocket/src/WebSocketServer.php
@@ -276,6 +276,12 @@ class WebSocketServer implements MessageComponentInterface
             }
         }
 
+        // Clear volatile consultation presence held by this browser tab.
+        $affectedViews = $this->connections->clearItemViewsForConnection($conn);
+        foreach ($affectedViews as $target) {
+            $this->broadcastItemViewersChanged($target['folder_id'], $target['item_id']);
+        }
+
         // Clean up
         $this->connections->removeConnection($conn);
         $this->rateLimiter->cleanup($conn);
@@ -366,6 +372,24 @@ class WebSocketServer implements MessageComponentInterface
                 'error' => $e->getMessage(),
             ]);
         }
+    }
+
+    /**
+     * Broadcast the current read-only consultation viewer list for one item.
+     */
+    private function broadcastItemViewersChanged(int $folderId, int $itemId): void
+    {
+        $this->connections->broadcastToFolder($folderId, [
+            'type' => 'event',
+            'event' => 'item_viewers_changed',
+            'data' => [
+                'item_id' => $itemId,
+                'folder_id' => $folderId,
+                'viewers' => $this->connections->getItemViewers($folderId, $itemId),
+                'server_timestamp' => time(),
+            ],
+            'timestamp' => time(),
+        ]);
     }
 
     /**

--- a/public/assets/js/teampass-websocket-init.js
+++ b/public/assets/js/teampass-websocket-init.js
@@ -107,6 +107,7 @@
 
   // Current folder tracking
   var currentFolderId = null
+  var activeItemView = null
 
   /**
    * Initialize WebSocket connection
@@ -153,6 +154,12 @@
    * Set up handlers for various WebSocket events
    */
   function setupEventHandlers() {
+    tpWs.on('connected', function(data) {
+      if (data && data.user_id) {
+        window.TeamPassCurrentUserId = parseInt(data.user_id, 10)
+      }
+    })
+
     // Item events
     tpWs.on('item_created', function(data) {
       if (parseInt(data.folder_id) === parseInt(currentFolderId)) {
@@ -243,6 +250,13 @@
       }
     })
 
+    tpWs.on('item_viewers_changed', function(data) {
+      if (parseInt(data.folder_id) === parseInt(currentFolderId)) {
+        setItemViewers(data.item_id, data.viewers || [])
+      }
+      updateItemViewersInDetailView(data.item_id, data.viewers || [])
+    })
+
     // Item moved event
     tpWs.on('item_moved', function(data) {
       var fromFolder = parseInt(data.from_folder_id)
@@ -259,6 +273,7 @@
           if (!$container.hasClass('hidden') &&
               parseInt($container.data('id')) === parseInt(data.item_id)) {
             $container.find('.edition-lock-detail-badge').remove()
+            $container.find('.item-view-detail-badge').remove()
             toastr.remove()
             toastr.warning(
               '"' + data.label + '" ' + (L.item_moved_away || 'has been moved to another folder by') + ' ' + data.moved_by,
@@ -381,6 +396,10 @@
   function subscribeToFolder(folderId) {
     if (!folderId || !tpWs.isConnectedNow()) return
 
+    if (activeItemView && parseInt(activeItemView.folderId) !== parseInt(folderId)) {
+      stopItemView()
+    }
+
     // Unsubscribe from previous folder and clear its lock indicators
     if (currentFolderId && currentFolderId !== folderId) {
       tpWs.unsubscribeFromFolder(currentFolderId).catch(function() {})
@@ -389,6 +408,13 @@
           removeEditionLockIndicator(itemId)
         })
         window.tpLockedItems = {}
+      }
+      if (window.tpViewingItems) {
+        Object.keys(window.tpViewingItems).forEach(function(itemId) {
+          removeItemViewIndicator(itemId)
+          removeItemViewFromDetailView(itemId)
+        })
+        window.tpViewingItems = {}
       }
     }
 
@@ -399,11 +425,32 @@
         tpWsDebug('[TeamPass WS] Subscribed to folder ' + folderId, 'log')
         // Sync initial lock state: show badges for items already locked in this folder
         if (response && Array.isArray(response.locked_items)) {
-          if (!window.tpLockedItems) window.tpLockedItems = {}
+          if (window.tpLockedItems) {
+            Object.keys(window.tpLockedItems).forEach(function(itemId) {
+              removeEditionLockIndicator(itemId)
+              removeEditionLockFromDetailView(itemId)
+            })
+          }
+          window.tpLockedItems = {}
           response.locked_items.forEach(function(lock) {
             window.tpLockedItems[lock.item_id] = lock.user_login
             showEditionLockIndicator(lock.item_id, lock.user_login)
           })
+        }
+        if (response && Array.isArray(response.viewing_items)) {
+          if (window.tpViewingItems) {
+            Object.keys(window.tpViewingItems).forEach(function(itemId) {
+              removeItemViewIndicator(itemId)
+              removeItemViewFromDetailView(itemId)
+            })
+          }
+          window.tpViewingItems = {}
+          response.viewing_items.forEach(function(itemView) {
+            setItemViewers(itemView.item_id, itemView.viewers || [])
+          })
+        }
+        if (activeItemView && parseInt(activeItemView.folderId) === parseInt(folderId)) {
+          sendStartItemView(activeItemView.itemId, activeItemView.folderId)
         }
       })
       .catch(function(err) {
@@ -576,6 +623,203 @@
     $container.find('.edition-lock-detail-badge').remove()
   }
 
+  function getCurrentUserId() {
+    if (window.TeamPassCurrentUserId) {
+      return parseInt(window.TeamPassCurrentUserId, 10)
+    }
+    if (typeof store !== 'undefined' && store.get('teampassUser')) {
+      var user = store.get('teampassUser')
+      return parseInt(user.id || user.user_id || user.userId || 0, 10)
+    }
+    return 0
+  }
+
+  function escapeHtml(value) {
+    if (typeof $ === 'undefined') return String(value || '')
+    return $('<span>').text(value || '').html()
+  }
+
+  function escapeAttribute(value) {
+    return escapeHtml(value).replace(/"/g, '&quot;').replace(/'/g, '&#39;')
+  }
+
+  function normalizeViewers(viewers) {
+    var currentUserId = getCurrentUserId()
+    var unique = {}
+
+    ;(viewers || []).forEach(function(viewer) {
+      var userId = parseInt(viewer.user_id || viewer.id || 0, 10)
+      if (!userId || userId === currentUserId) return
+      unique[userId] = {
+        user_id: userId,
+        user_login: viewer.user_login || viewer.login || ''
+      }
+    })
+
+    return Object.keys(unique).map(function(userId) {
+      return unique[userId]
+    })
+  }
+
+  function buildViewerLabel(viewers) {
+    if (viewers.length === 0) return ''
+    if (viewers.length === 1) return viewers[0].user_login
+    return viewers[0].user_login + ' +' + (viewers.length - 1)
+  }
+
+  function setItemViewers(itemId, viewers) {
+    itemId = parseInt(itemId, 10)
+    if (!itemId) return
+
+    var normalizedViewers = normalizeViewers(viewers)
+    if (!window.tpViewingItems) window.tpViewingItems = {}
+
+    if (normalizedViewers.length === 0) {
+      delete window.tpViewingItems[itemId]
+      removeItemViewIndicator(itemId)
+      removeItemViewFromDetailView(itemId)
+      return
+    }
+
+    window.tpViewingItems[itemId] = normalizedViewers
+    showItemViewIndicator(itemId, normalizedViewers)
+    updateItemViewersInDetailView(itemId, normalizedViewers)
+  }
+
+  function sendStartItemView(itemId, folderId) {
+    if (!tpWs.isConnectedNow()) return
+    tpWs.send({
+      action: 'start_item_view',
+      data: {
+        item_id: parseInt(itemId, 10),
+        folder_id: parseInt(folderId, 10)
+      }
+    }).catch(function(err) {
+      tpWsDebug('[TeamPass WS] Failed to start item view presence - ' + err, 'warn')
+    })
+  }
+
+  function startItemView(itemId, folderId) {
+    itemId = parseInt(itemId, 10)
+    folderId = parseInt(folderId || currentFolderId, 10)
+    if (!itemId || !folderId) return
+
+    if (activeItemView &&
+        parseInt(activeItemView.itemId) === itemId &&
+        parseInt(activeItemView.folderId) === folderId) {
+      return
+    }
+
+    var previousItemView = activeItemView
+    activeItemView = { itemId: itemId, folderId: folderId }
+
+    var start = function() {
+      sendStartItemView(itemId, folderId)
+    }
+
+    if (previousItemView && tpWs.isConnectedNow()) {
+      tpWs.send({
+        action: 'stop_item_view',
+        data: {
+          item_id: parseInt(previousItemView.itemId, 10),
+          folder_id: parseInt(previousItemView.folderId, 10)
+        }
+      }).then(start).catch(start)
+    } else {
+      start()
+    }
+  }
+
+  function stopItemView(itemId) {
+    itemId = itemId ? parseInt(itemId, 10) : null
+    if (!activeItemView) return
+    if (itemId && parseInt(activeItemView.itemId) !== itemId) return
+
+    var previousItemView = activeItemView
+    activeItemView = null
+
+    if (!tpWs.isConnectedNow()) return
+    tpWs.send({
+      action: 'stop_item_view',
+      data: {
+        item_id: parseInt(previousItemView.itemId, 10),
+        folder_id: parseInt(previousItemView.folderId, 10)
+      }
+    }).catch(function(err) {
+      tpWsDebug('[TeamPass WS] Failed to stop item view presence - ' + err, 'warn')
+    })
+  }
+
+  /**
+   * Show consultation presence on an item row in the items list.
+   */
+  function showItemViewIndicator(itemId, viewers) {
+    if (typeof $ === 'undefined') return
+
+    var $row = $('#list-item-row_' + itemId)
+    if ($row.length === 0) return
+
+    removeItemViewIndicator(itemId)
+
+    var names = viewers.map(function(viewer) {
+      return viewer.user_login
+    })
+    var label = buildViewerLabel(viewers)
+    var badge = $('<span class="item-view-badge badge badge-success ml-2" ' +
+      'title="' + escapeAttribute((L.item_viewed_by || 'Viewed by') + ' ' + names.join(', ')) + '">' +
+      '<i class="fa-regular fa-eye mr-1"></i>' + escapeHtml(label) +
+      '</span>')
+
+    $row.find('.list-item-row-description').first().after(badge)
+  }
+
+  function removeItemViewIndicator(itemId) {
+    if (typeof $ === 'undefined') return
+    $('#list-item-row_' + itemId).find('.item-view-badge').remove()
+  }
+
+  function updateItemViewersInDetailView(itemId, viewers) {
+    var normalizedViewers = normalizeViewers(viewers)
+    if (normalizedViewers.length === 0) {
+      removeItemViewFromDetailView(itemId)
+      return
+    }
+    showItemViewInDetailView(itemId, normalizedViewers)
+  }
+
+  /**
+   * Show consultation presence in the item detail panel.
+   */
+  function showItemViewInDetailView(itemId, viewers) {
+    if (typeof $ === 'undefined') return
+    var $container = $('#items-details-container')
+    if ($container.hasClass('hidden')) return
+    if (parseInt($container.data('id')) !== parseInt(itemId)) return
+
+    removeItemViewFromDetailView(itemId)
+
+    var names = viewers.map(function(viewer) {
+      return viewer.user_login
+    })
+    var badge = $('<div class="item-view-detail-badge alert alert-success py-1 px-2 mt-1 mb-0 ml-2 d-inline-block">' +
+      '<i class="fa-regular fa-eye mr-1"></i>' +
+      (L.item_viewed_by || 'Viewed by') + ' <strong>' + escapeHtml(names.join(', ')) + '</strong>' +
+      '</div>')
+    var $lockBadge = $container.find('.edition-lock-detail-badge').last()
+    if ($lockBadge.length > 0) {
+      $lockBadge.after(badge)
+    } else {
+      $('#card-item-label').after(badge)
+    }
+  }
+
+  function removeItemViewFromDetailView(itemId) {
+    if (typeof $ === 'undefined') return
+    var $container = $('#items-details-container')
+    if (itemId && parseInt($container.data('id')) !== parseInt(itemId)) return
+    $container.find('.item-view-detail-badge').remove()
+  }
+
   /**
    * Refresh user folders after a permission change
    *
@@ -596,6 +840,11 @@
   window.tpWsRemoveEditionLock = removeEditionLockIndicator
   window.tpWsShowEditionLockDetail = showEditionLockInDetailView
   window.tpWsRemoveEditionLockDetail = removeEditionLockFromDetailView
+  window.tpWsStartItemView = startItemView
+  window.tpWsStopItemView = stopItemView
+  window.tpWsSetItemViewers = setItemViewers
+  window.tpWsRemoveItemView = removeItemViewIndicator
+  window.tpWsRemoveItemViewDetail = removeItemViewFromDetailView
   window.refreshUserFolders = refreshUserFolders
 
   // Initialize when DOM is ready


### PR DESCRIPTION
## Summary

This pull request improves TeamPass item real-time collaboration behavior around edition locks and item consultation.

It fixes cases where an item could stay locked after save or become locked while the user was only viewing it, then adds a lightweight read-only presence indicator so users can see when another connected user is consulting the same item.

The implementation keeps the existing edition lock model for write protection, uses WebSocket for live UI synchronization, and does not introduce any database migration.

## Context

The initial issue was observed while testing item edition with WebSocket enabled:

- an item was not always released after saving;
- the automatic lock cleanup delay felt too long for real-world usage;
- simply opening an item in read-only mode could create or refresh an edition lock;
- navigating through items with close, previous, next, or list clicks could therefore leave several items locked even though no edit was actually in progress;
- the final effect was that a user could progressively lock a whole folder just by consulting items.

The expected behavior is now:

1. Opening an item in consultation must not create an edition lock.
2. Entering edit mode must acquire the edition lock.
3. Saving, cancelling, leaving edit mode, or disconnecting must release the edition lock as soon as possible.
4. Other users should see the edition lock in real time.
5. Other users should also see a green read-only consultation badge when someone is only viewing an item.

## Root Cause Analysis

Several code paths were mixing permission checks and lock acquisition.

`getCurrentAccessRights()` could call `isItemLocked()` even when the caller only needed to know whether the user had edit rights. Because `isItemLocked()` creates or refreshes a lock when used in an edit context, some non-edit flows ended up touching the edition lock table.

Two specific AJAX flows were problematic:

- `confirm_attachments`
- `delete_uploaded_files_but_not_saved`

Both need to verify that the user has edit permission, but they should not acquire or renew an edition lock by themselves. `delete_uploaded_files_but_not_saved` is also used during item details loading, so it was able to create lock side effects while the user was simply viewing an item.

Another issue was that save completion removed the local heartbeat on the client, but the server-side lock release and real-time badge cleanup needed to be made more deterministic, especially when the item had moved between folders during edition.

## Implementation Details

### Edition lock lifecycle

The edition lock heartbeat timeout was shortened:

- `app/config/include.php`
  - `EDITION_LOCK_HEARTBEAT_TIMEOUT` is now `300` seconds.

The WebSocket folder subscription now uses the same heartbeat timeout when returning already locked items:

- `app/websocket/src/MessageHandler.php`
  - stale locks are filtered using `EDITION_LOCK_HEARTBEAT_TIMEOUT`;
  - locks owned by the current user are excluded from the returned lock list.

Saving an existing item now validates that the current user still owns an active edition lock before accepting the update:

- `app/sources/items.queries.php`
  - added active-lock save validation through `getItemEditionLockSaveStatus()`;
  - save is rejected if another user owns an active lock;
  - save is rejected if the user no longer has an active own lock.

After a successful save, all edition locks for the item are deleted and a real-time `item_edition_stopped` event is emitted:

- for the original folder;
- and, if the item was moved, for the target folder as well.

This prevents stale lock badges for users still subscribed to the old folder.

The client now clears local lock state immediately after a successful save:

- `app/pages/items.js.php`
  - stops the edition lock heartbeat;
  - removes the item from `window.tpLockedItems`;
  - removes the list and detail lock badges through the existing WebSocket UI helpers.

### Read-only access must not lock an item

`getCurrentAccessRights()` now only touches the edition lock when the requested action is explicitly `edit`.

This applies to:

- admin-defined allowed folders;
- personal folders;
- role-based write access.

Read-only calls now receive normal access/edit/delete metadata without acquiring or refreshing a lock.

`isItemLocked()` was also adjusted so that a lock owned by the current user is only refreshed while entering edit mode. Read-only permission checks no longer keep a stale lock alive.

The attachment-related permission checks were updated:

- `confirm_attachments` checks edit permission without requesting the `edit` lock action;
- `delete_uploaded_files_but_not_saved` checks edit permission without requesting the `edit` lock action.

This removes the hidden lock creation that happened while opening or leaving the item details view.

### Read-only consultation presence

A new volatile WebSocket presence state was added for users who are viewing an item without editing it.

This state is intentionally kept in memory on the WebSocket server:

- no new SQL table;
- no migration;
- automatically cleared when the connection closes;
- suitable for live UI presence, not for audit/history.

Changed files:

- `app/websocket/src/ConnectionManager.php`
- `app/websocket/src/MessageHandler.php`
- `app/websocket/src/WebSocketServer.php`

New WebSocket actions:

- `start_item_view`
- `stop_item_view`

New WebSocket event:

- `item_viewers_changed`

The server now:

- records one active read-only item view per WebSocket connection;
- resolves the real current folder of the item from the database;
- validates folder access before accepting presence;
- broadcasts viewer changes to folder subscribers;
- includes `viewing_items` in the folder subscribe response;
- clears presence on folder unsubscribe;
- clears presence on WebSocket disconnect.

### Client-side presence UI

Changed files:

- `app/includes/js/teampass-websocket-init.js`
- `public/assets/js/teampass-websocket-init.js`
- `app/pages/items.js.php`

The two WebSocket init files were kept synchronized.

The client now tracks `window.tpViewingItems` and displays read-only consultation presence:

- in the item list, as a green badge with an eye icon;
- in the item details panel, as a green inline alert below the item title.

The badge is intentionally shown only for other users. A user does not see their own consultation presence.

The client starts consultation presence when an item is opened in read-only mode and stops it when:

- the item details card is closed;
- the user navigates to previous or next item;
- another item is opened from the list;
- the user enters edit mode;
- the page is unloaded;
- the folder subscription changes.

When the item list is re-rendered, known edition locks and consultation presence are reapplied to the newly created DOM rows. This avoids race conditions where WebSocket state arrives before the AJAX-rendered item rows exist.

When reconnecting or resubscribing to a folder, the client also resends its active read-only presence if needed.

## Behavior After This Change

### Consultation mode

Opening an item in read-only mode no longer creates an edition lock.

Other users subscribed to the same folder see a green consultation badge on the item row. If they open the same item, they also see the green consultation indicator in the item details panel.

The viewer does not see their own green badge.

### Edition mode

Entering edit mode acquires the existing edition lock.

Other users see the regular edition lock badge, using the existing lock color/style.

The read-only consultation presence is stopped when the same user enters edit mode, so the UI clearly separates:

- green badge: another user is viewing the item;
- edition lock badge: another user is editing the item.

### Save and release

On successful save:

- the client stops the heartbeat;
- local lock badges are cleared;
- the server deletes the item lock;
- folder subscribers receive `item_edition_stopped`;
- stale lock indicators are removed from list and detail views.

### Disconnect and stale lock handling

On WebSocket disconnect, volatile read-only consultation presence is cleared immediately.

Edition locks still have heartbeat-based cleanup as a fallback. The timeout is now 5 minutes, which keeps abandoned locks from lasting too long if a client disappears without a clean release.

## Operational Notes

Because this pull request changes WebSocket server-side message handling, the WebSocket daemon must be restarted after deployment.

Without a restart, the browser may send `start_item_view` / `stop_item_view`, but the running WebSocket process will still be using the old code and will not broadcast `item_viewers_changed`.

A hard browser refresh is also recommended after deployment because `teampass-websocket-init.js` is loaded with the TeamPass version query string. If the application version number is unchanged, browsers may keep an older cached copy of the JavaScript asset.

## Files Changed

- `app/config/include.php`
- `app/sources/items.queries.php`
- `app/pages/items.js.php`
- `app/includes/js/teampass-websocket-init.js`
- `public/assets/js/teampass-websocket-init.js`
- `app/websocket/src/ConnectionManager.php`
- `app/websocket/src/MessageHandler.php`
- `app/websocket/src/WebSocketServer.php`

## Testing

Manual validation was performed with WebSocket enabled and two simultaneously connected users consulting the same folder.

Validated scenarios:

1. Opening an item in read-only mode no longer creates an edition lock.
2. Moving through several items in read-only mode no longer locks the whole folder.
3. Closing an item details view releases the read-only consultation presence.
4. Previous/next navigation clears the old item presence and starts presence on the newly opened item.
5. Entering edit mode stops read-only presence and uses the regular edition lock.
6. Saving an edited item releases the edition lock.
7. Other users see the edition lock badge while an item is edited.
8. Other users see the green consultation badge while an item is opened in read-only mode.
9. Restarting the WebSocket daemon correctly enables the new presence events.

Local automated validation could not be run in this workspace because the `php` and `node` executables are not available in the local PATH.

## Risk Assessment

Risk is moderate because this touches the item edition lifecycle and the real-time WebSocket layer.

The change is scoped to item locks and presence:

- no database schema change;
- no new persistent table;
- no change to item encryption logic;
- no change to folder permission semantics;
- read-only presence is volatile and disappears on disconnect or WebSocket restart.

The main operational risk is deployment-related: the WebSocket daemon must be restarted, otherwise connected clients will not receive the new consultation presence behavior.

The main behavioral tradeoff is that saving now requires the editor to still own an active edition lock. This is intentional: it prevents a late save from overwriting another user's work after the original lock expired or was taken over.

## What This PR Does Not Do

This pull request does not:

- add persistent audit history for item consultation;
- show a user's own consultation badge;
- replace the existing edition lock table;
- add a database migration;
- implement multi-user collaborative editing;
- change the existing folder and item rights model.

