### PR TITLE
Fix Item Change Notification Delivery and Status Indicator for 3.2.0.1

### DIFF
--- a/app/pages/items.js.php
+++ b/app/pages/items.js.php
@@ -91,6 +91,8 @@ $bip39Wordlist = loadBip39Wordlist($session->get('user-language') ?? 'english');
 
     // BIP-39 wordlist for the passphrase generator (language: <?php echo htmlspecialchars($session->get('user-language') ?? 'english', ENT_QUOTES, 'UTF-8'); ?>)
     const TP_BIP39_WORDLIST = <?php echo json_encode($bip39Wordlist, JSON_UNESCAPED_UNICODE); ?>;
+    const TP_NOTIFICATION_ENGAGED = <?php echo json_encode($lang->get('notification_engaged'), JSON_UNESCAPED_UNICODE); ?>;
+    const TP_NOTIFICATION_NOT_ENGAGED = <?php echo json_encode($lang->get('notification_not_engaged'), JSON_UNESCAPED_UNICODE); ?>;
 
     // Minimum word count and extra suffix requirements per folder complexity level
     const TP_PASSPHRASE_RULES = {
@@ -167,6 +169,48 @@ $bip39Wordlist = loadBip39Wordlist($session->get('user-language') ?? 'english');
         }
         return { start: start, update: update, done: done };
     }());
+
+    function tpEscapeHtmlAttribute(value) {
+        return String(value).replace(/[&<>"']/g, function(char) {
+            return {
+                '&': '&amp;',
+                '<': '&lt;',
+                '>': '&gt;',
+                '"': '&quot;',
+                "'": '&#039;'
+            }[char];
+        });
+    }
+
+    function itemNotificationIconHtml(isEnabled) {
+        const title = tpEscapeHtmlAttribute(isEnabled === true ? TP_NOTIFICATION_ENGAGED : TP_NOTIFICATION_NOT_ENGAGED);
+
+        if (isEnabled === true) {
+            return '<span class="fa-solid fa-bell infotip text-success" title="' + title + '"></span>';
+        }
+
+        return '<span class="fa-regular fa-bell-slash infotip text-warning" title="' + title + '"></span>';
+    }
+
+    function updateItemNotificationStatusVisual(isEnabled) {
+        const enabled = isEnabled === true;
+        const title = enabled === true ? TP_NOTIFICATION_ENGAGED : TP_NOTIFICATION_NOT_ENGAGED;
+
+        $('#item-action-notify')
+            .toggleClass('text-success', enabled)
+            .toggleClass('text-navy', enabled === false)
+            .attr('title', title);
+
+        $('#item-action-notify-icon')
+            .removeClass('fa-regular fa-solid fa-bell fa-bell-slash text-success text-warning')
+            .addClass(enabled === true ? 'fa-solid fa-bell text-success' : 'fa-regular fa-bell');
+
+        if ($('#card-item-misc-notification').length > 0) {
+            $('#card-item-misc-notification').html(itemNotificationIconHtml(enabled));
+        }
+
+        $('.infotip').tooltip();
+    }
 
     /**
      * Copy text to clipboard with fallback for non-HTTPS contexts.
@@ -1858,13 +1902,7 @@ $bip39Wordlist = loadBip39Wordlist($session->get('user-language') ?? 'english');
                     });
 
                     // Change the icon for Notification
-                    if (newNotifStatus) {
-                        $('#card-item-misc-notification')
-                            .html('<span class="fa-regular fa-bell infotip text-success" title="<?php echo $lang->get('notification_engaged'); ?>"></span>');
-                    } else {
-                        $('#card-item-misc-notification')
-                            .html('<span class="fa-regular fa-bell-slash infotip text-warning" title="<?php echo $lang->get('notification_not_engaged'); ?>"></span>');
-                    }
+                    updateItemNotificationStatusVisual(newNotifStatus);
 
                     $btn.prop('disabled', false).html('<?php echo $lang->get('confirm'); ?>');
                     // Close notify modal
@@ -6696,13 +6734,9 @@ $bip39Wordlist = loadBip39Wordlist($session->get('user-language') ?? 'english');
                     }
 
                     // Show Notification engaged
-                    if (data.notification_status === true) {
-                        $('#card-item-misc')
-                            .append('<span class="mr-4 icon-badge" id="card-item-misc-notification"><span class="fa-regular fa-bell infotip text-success" title="<?php echo $lang->get('notification_engaged'); ?>"></span></span>');
-                    } else {
-                        $('#card-item-misc')
-                            .append('<span class="mr-4 icon-badge" id="card-item-misc-notification"><span class="fa-regular fa-bell-slash infotip text-warning" title="<?php echo $lang->get('notification_not_engaged'); ?>"></span></span>');
-                    }
+                    $('#card-item-misc')
+                        .append('<span class="mr-4 icon-badge" id="card-item-misc-notification"></span>');
+                    updateItemNotificationStatusVisual(data.notification_status === true);
 
                     // Prepare counter
                     $('#card-item-misc')

--- a/app/pages/items.php
+++ b/app/pages/items.php
@@ -1175,7 +1175,7 @@ if ((int) $session_user_admin === 1) {
                                             <a class="text-navy tp-action ml-3" href="#" data-item-action="share"><i class="fa-regular fa-share-square mr-1"></i><small><?php echo $lang->get('share'); ?></small></a>
                                         </li>
                                         <li class="nav-item">
-                                            <a class="text-navy tp-action ml-3" href="#" data-item-action="notify"><i class="fa-regular fa-bell mr-1"></i><small><?php echo $lang->get('notify'); ?></small></a>
+                                            <a class="text-navy tp-action ml-3" href="#" data-item-action="notify" id="item-action-notify"><i class="fa-regular fa-bell mr-1" id="item-action-notify-icon"></i><small><?php echo $lang->get('notify'); ?></small></a>
                                         </li>
                                         <?php
                                         if (

--- a/app/sources/main.functions.php
+++ b/app/sources/main.functions.php
@@ -1688,42 +1688,92 @@ function notifyChangesToSubscribers(int $item_id, string $label, array $changes,
     $globalsLastname = $session->get('user-lastname');
     $globalsName = $session->get('user-name');
 
-    // Get all subscribers' emails as an array
-    $emails = DB::queryFirstColumn(
-        'SELECT u.email
+    $subscribers = DB::query(
+        'SELECT u.email, u.name, u.lastname, u.login
         FROM ' . prefixTable('notification') . ' AS n
         INNER JOIN ' . prefixTable('users') . ' AS u ON (n.user_id = u.id)
-        WHERE n.item_id = %i AND n.user_id != %i',
+        WHERE n.item_id = %i
+        AND n.user_id != %i
+        AND u.email IS NOT NULL
+        AND u.email != %s',
         $item_id,
-        $globalsUserId
+        $globalsUserId,
+        ''
     );
 
-    if (DB::count() > 0) {
-        // Prepare path
-        $path = geItemReadablePath($item_id, '', $SETTINGS);
+    if (DB::count() === 0) {
+        return;
+    }
 
-        // Get list of changes
+    $item = DB::queryFirstRow(
+        'SELECT id_tree FROM ' . prefixTable('items') . ' WHERE id = %i',
+        $item_id
+    );
+    $folderId = (int) ($item['id_tree'] ?? 0);
+    $folderName = geItemReadablePath($folderId, '', $SETTINGS);
+    $baseUrl = rtrim((string) ($SETTINGS['cpassman_url'] ?? ''), '/');
+    $itemUrl = $baseUrl . '/index.php?page=items&group=' . $folderId . '&id=' . $item_id;
+
+    $htmlChanges = '';
+    if (count($changes) > 0) {
         $htmlChanges = '<ul>';
         foreach ($changes as $change) {
-            $htmlChanges .= '<li>' . $change . '</li>';
+            $htmlChanges .= '<li>' . htmlspecialchars((string) $change, ENT_QUOTES, 'UTF-8') . '</li>';
         }
         $htmlChanges .= '</ul>';
+    }
 
-        // send email
-        DB::insert(
-            prefixTable('emails'),
-            [
-                'timestamp' => time(),
-                'subject' => $lang->get('email_subject_item_updated'),
-                'body' => str_replace(
-                    ['#item_label#', '#folder_name#', '#item_id#', '#url#', '#name#', '#lastname#', '#changes#'],
-                    [$label, $path, (string) $item_id, $SETTINGS['cpassman_url'], $globalsName, $globalsLastname, $htmlChanges],
-                    $lang->get('email_body_item_updated')
-                ),
-                'receivers' => implode(',', $emails),
-                'status' => '',
-            ]
+    $body = html_entity_decode((string) $lang->get('email_body_item_updated'), ENT_QUOTES | ENT_HTML5, 'UTF-8');
+    $body = str_replace(
+        ['#item_label#', '#folder_name#', '#item_id#', '#item_category#', '#url#', '#name#', '#lastname#', '#changes#'],
+        [
+            htmlspecialchars($label, ENT_QUOTES, 'UTF-8'),
+            $folderName,
+            (string) $item_id,
+            (string) $folderId,
+            htmlspecialchars($baseUrl, ENT_QUOTES, 'UTF-8'),
+            htmlspecialchars((string) $globalsName, ENT_QUOTES, 'UTF-8'),
+            htmlspecialchars((string) $globalsLastname, ENT_QUOTES, 'UTF-8'),
+            $htmlChanges,
+        ],
+        $body
+    );
+    $body = str_replace('<br >', '<br>', $body);
+
+    $normalizedBody = preg_replace_callback(
+        '/<a\b[^>]*>(.*?)<\/a>/is',
+        static function (array $matches) use ($itemUrl): string {
+            return '<a href="' . htmlspecialchars($itemUrl, ENT_QUOTES, 'UTF-8') . '">' . $matches[1] . '</a>';
+        },
+        $body
+    );
+    if ($normalizedBody !== null) {
+        $body = $normalizedBody;
+    }
+
+    $emailQueued = false;
+    foreach ($subscribers as $subscriber) {
+        $email = trim((string) ($subscriber['email'] ?? ''));
+        if ($email === '') {
+            continue;
+        }
+
+        $receiverName = trim((string) ($subscriber['name'] ?? '') . ' ' . (string) ($subscriber['lastname'] ?? ''));
+        if ($receiverName === '') {
+            $receiverName = (string) ($subscriber['login'] ?? '');
+        }
+
+        prepareSendingEmail(
+            $lang->get('email_subject_item_updated'),
+            $body,
+            $email,
+            $receiverName
         );
+        $emailQueued = true;
+    }
+
+    if ($emailQueued === true) {
+        triggerBackgroundHandler();
     }
 }
 

--- a/public/install/install-steps/run.step5.php
+++ b/public/install/install-steps/run.step5.php
@@ -267,7 +267,7 @@ class DatabaseInstaller
     {
         DB::query(
             "CREATE TABLE IF NOT EXISTS " . $this->inputData['tablePrefix'] . "notification (
-                `increment_id` int(12) NOT NULL,
+                `increment_id` int(12) NOT NULL AUTO_INCREMENT,
                 `item_id` int(12) NOT NULL,
                 `user_id` int(12) NOT NULL,
                 PRIMARY KEY (`increment_id`)

--- a/public/install/upgrade_run_3.2.0.php
+++ b/public/install/upgrade_run_3.2.0.php
@@ -83,6 +83,48 @@ $lang = new Language();
 
 //--->BEGIN 3.2.0
 
+// Ensure item notification subscriptions can be inserted on upgraded instances.
+$res = mysqli_query(
+    $db_link,
+    'CREATE TABLE IF NOT EXISTS `' . $pre . 'notification` (
+        `increment_id` INT(12) NOT NULL AUTO_INCREMENT,
+        `item_id` INT(12) NOT NULL,
+        `user_id` INT(12) NOT NULL,
+        PRIMARY KEY (`increment_id`)
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;'
+);
+if ($res === false) {
+    echo '[{"finish":"1", "msg":"", "error":"Error creating notification table: ' . addslashes(mysqli_error($db_link)) . '"}]';
+    mysqli_close($db_link);
+    exit();
+}
+
+$notificationIncrementColumnResult = mysqli_query(
+    $db_link,
+    "SHOW COLUMNS FROM `" . $pre . "notification` LIKE 'increment_id'"
+);
+if ($notificationIncrementColumnResult === false) {
+    echo '[{"finish":"1", "msg":"", "error":"Error reading notification increment_id column: ' . addslashes(mysqli_error($db_link)) . '"}]';
+    mysqli_close($db_link);
+    exit();
+}
+$notificationIncrementColumn = mysqli_fetch_assoc($notificationIncrementColumnResult);
+if (
+    $notificationIncrementColumn !== null
+    && $notificationIncrementColumn !== false
+    && stripos((string) ($notificationIncrementColumn['Extra'] ?? ''), 'auto_increment') === false
+) {
+    $res = mysqli_query(
+        $db_link,
+        "ALTER TABLE `" . $pre . "notification` MODIFY `increment_id` INT(12) NOT NULL AUTO_INCREMENT"
+    );
+    if ($res === false) {
+        echo '[{"finish":"1", "msg":"", "error":"Error updating notification increment_id column: ' . addslashes(mysqli_error($db_link)) . '"}]';
+        mysqli_close($db_link);
+        exit();
+    }
+}
+
 // Add server-side AES key column to teampass_api (session_aes_key is no longer stored in JWT)
 $res = addColumnIfNotExist(
     $pre . 'api',
@@ -271,7 +313,7 @@ checkIndexExist(
 // if they still point to the old root-level locations ({root}/upload and {root}/files).
 $row = mysqli_fetch_assoc(mysqli_query($db_link, "SELECT valeur FROM `" . $pre . "misc` WHERE type='admin' AND intitule='cpassman_dir'"));
 if ($row && !empty($row['valeur'])) {
-    $cpassmanDir = rtrim((string) $row['valeur'], '/');
+    $cpassmanDir = rtrim((string) $row['valeur'], '/\\');
 
     $rowUpload = mysqli_fetch_assoc(mysqli_query($db_link, "SELECT valeur FROM `" . $pre . "misc` WHERE type='admin' AND intitule='path_to_upload_folder'"));
     if ($rowUpload && strpos((string) $rowUpload['valeur'], '/storage/upload') === false) {
@@ -281,6 +323,29 @@ if ($row && !empty($row['valeur'])) {
     $rowFiles = mysqli_fetch_assoc(mysqli_query($db_link, "SELECT valeur FROM `" . $pre . "misc` WHERE type='admin' AND intitule='path_to_files_folder'"));
     if ($rowFiles && strpos((string) $rowFiles['valeur'], '/storage/files') === false) {
         mysqli_query($db_link, "UPDATE `" . $pre . "misc` SET valeur='" . addslashes($cpassmanDir . '/storage/files') . "' WHERE type='admin' AND intitule='path_to_files_folder'");
+    }
+
+    // Scheduled backups now default to storage/backups. Migrate only empty or
+    // known legacy root-level backup/files locations; explicit storage/files
+    // locations remain accepted by the runtime as legacy-compatible paths.
+    $newScheduledBackupDir = $cpassmanDir . '/storage/backups';
+    $legacyFilesDir = rtrim(str_replace('\\', '/', $cpassmanDir . '/files'), '/');
+    $legacyBackupsDir = rtrim(str_replace('\\', '/', $cpassmanDir . '/backups'), '/');
+    $rowScheduled = mysqli_fetch_assoc(mysqli_query($db_link, "SELECT valeur FROM `" . $pre . "misc` WHERE type='admin' AND intitule='bck_scheduled_output_dir'"));
+    if ($rowScheduled === null || $rowScheduled === false) {
+        mysqli_query($db_link, "INSERT INTO `" . $pre . "misc` (`type`, `intitule`, `valeur`) VALUES ('admin', 'bck_scheduled_output_dir', '" . addslashes($newScheduledBackupDir) . "')");
+    } else {
+        $scheduledDir = trim((string) ($rowScheduled['valeur'] ?? ''));
+        $scheduledDirNormalized = rtrim(str_replace('\\', '/', $scheduledDir), '/');
+        $isLegacyScheduledDir = $scheduledDir === ''
+            || $scheduledDirNormalized === $legacyFilesDir
+            || strpos($scheduledDirNormalized, $legacyFilesDir . '/') === 0
+            || $scheduledDirNormalized === $legacyBackupsDir
+            || strpos($scheduledDirNormalized, $legacyBackupsDir . '/') === 0;
+
+        if ($isLegacyScheduledDir === true) {
+            mysqli_query($db_link, "UPDATE `" . $pre . "misc` SET valeur='" . addslashes($newScheduledBackupDir) . "' WHERE type='admin' AND intitule='bck_scheduled_output_dir'");
+        }
     }
 
     $rowUrl = mysqli_fetch_assoc(mysqli_query($db_link, "SELECT valeur FROM `" . $pre . "misc` WHERE type='admin' AND intitule='url_to_files_folder'"));


### PR DESCRIPTION
## Summary

This PR fixes the item change notification subscription workflow on top of the `3.2.0.1` pre-release.

Users can subscribe to changes on an item from the item details view, but the current behavior is incomplete:

- The notification email is queued in the legacy admin email backlog instead of being sent through the background task handler.
- The email body can be rendered as escaped HTML in mail clients when the translated template contains unsafe or non-standard link markup.
- The main "Notify" action does not clearly show whether the current user is subscribed to the selected item.
- Fresh installations may create the `notification` table without `AUTO_INCREMENT` on `increment_id`, which can break subscription inserts.

This PR restores a coherent workflow: the subscription remains user-specific, the notification email is sent automatically through the standard background email task, the item link is normalized in the generated email body, and the notify icon reflects the current user's subscription state.

## Context

The issue was reproduced on a production `3.1.7.6` instance: after subscribing to an item and modifying it from another user, the notification email was present in the admin "unsent emails" backlog. Manually sending that pending email from the admin screen delivered the notification, which confirmed that the subscription data was present but the delivery path was wrong.

The same code path is still present in `3.2.0.1`, so this PR applies the fix to the current pre-release branch before opening the updated pull request.

`files_reference.txt` and `app/files_reference.txt` are intentionally left untouched in this PR. They can be refreshed during the release packaging step.

## Problems Found

- `notifyChangesToSubscribers()` inserted notification emails directly into the legacy `emails` table.
- Emails inserted into the legacy backlog require an admin-side send action or a separate backlog process, which is not natural for a user-triggered item notification.
- The item notification email template includes `#item_category#`, but this placeholder was not replaced by `notifyChangesToSubscribers()`.
- The folder path was resolved by passing the item id to `geItemReadablePath()`, even though the helper expects a folder/tree id.
- Some translated email templates contain non-standard link markup, which can make AntiXSS escape the full email body and display raw `<br>` / `<a>` tags in mail clients.
- The top item action link for "Notify" always used the same bell icon, even when the current user was subscribed.
- The fresh install schema for the `notification` table did not define `increment_id` as `AUTO_INCREMENT`.

## Root Cause

The item subscription feature mixed two generations of email handling.

Most application-triggered emails now go through `prepareSendingEmail()`, which creates a `send_email` background task processed by the background worker. Item change subscriber notifications still wrote directly to the old `emails` backlog table, leaving delivery dependent on admin-side backlog processing.

The visual state was already calculated per current user in the item details response, but only the secondary misc icon used it. The main notify action remained static.

## Changes Made

### Automatic Notification Email Delivery

Updated `app/sources/main.functions.php` so `notifyChangesToSubscribers()` now:

- Selects subscribed users with valid email addresses.
- Excludes the user who performed the item update.
- Resolves the item folder id before building the item link.
- Builds the item URL with `page=items`, `group=<folder_id>`, and `id=<item_id>`.
- Replaces all placeholders used by the item update email body, including `#item_category#`.
- Queues each notification through `prepareSendingEmail()`.
- Triggers the background handler after queueing notification emails.

This avoids the legacy admin email backlog for item subscriber notifications.

### Email Body Normalization

Updated the notification email generation to:

- Decode HTML entities in the translated template before sending it to the email service.
- Escape dynamic values such as item label, user name, and changes.
- Normalize malformed or non-standard `<a>` markup to a clean item link.
- Keep the final body compatible with the standard TeamPass email template wrapper.

This prevents mail clients from displaying raw HTML tags for item notification emails.

### User-Specific Notify Icon State

Updated `app/pages/items.php` and `app/pages/items.js.php` so the main "Notify" action reflects the current user's subscription state:

- Subscribed: solid green bell.
- Not subscribed: regular neutral bell.
- The misc status badge still shows the existing subscribed / not subscribed state.
- The checkbox state and icon state both use the item details response for the current user.

The subscription status remains user-specific because the backend still reads `notification_status` using the current session user id.

### Notification Table Schema

Updated install and upgrade scripts to make notification subscription storage reliable:

- Fresh installs now create `notification.increment_id` with `AUTO_INCREMENT`.
- The 3.2.0 upgrade ensures the `notification` table exists.
- The 3.2.0 upgrade repairs `notification.increment_id` if it exists without `AUTO_INCREMENT`.

## Backward Compatibility

- Existing notification subscriptions remain stored in the same `notification` table.
- No data migration is required for existing subscription rows.
- Existing instances with a correct `notification` schema are left unchanged.
- Existing instances with a missing or broken `notification.increment_id` auto-increment are repaired during the 3.2.0 upgrade.
- The legacy admin `emails` backlog is not removed and remains available for the other paths that still use it.

## Security and Reliability Notes

- Notification emails are only sent to users explicitly subscribed to the updated item.
- The update author is excluded from subscriber notifications.
- Empty email addresses are ignored.
- Dynamic email content is escaped before being inserted into the HTML body.
- The generated item link is normalized server-side instead of trusting translated link markup.
- The notify icon state is based on the current session user's subscription status, not a global item flag.

## Manual Test Plan

1. Upgrade a `3.1.7.6` instance to this adjusted `3.2.0.1` branch.
2. Verify the `notification` table has `increment_id` with `AUTO_INCREMENT`.
3. Log in as User A and open an item.
4. Enable item change notification from the item details view.
5. Confirm the notify action changes to a green solid bell for User A.
6. Log in as User B and open the same item.
7. Confirm the notify action is not green for User B.
8. Modify the item as User B.
9. Confirm User A receives the notification automatically without admin action on the unsent email backlog.
10. Confirm the received email renders as HTML and does not display raw `<br>` or `<a>` tags.
11. Confirm the item link in the email opens the expected item details page.
12. Disable the notification as User A.
13. Modify the item again as User B and confirm User A no longer receives the notification.

## Verification Performed

- Confirmed the existing `3.1.7.6` behavior leaves item notification emails in the admin unsent email backlog.
- Confirmed the current `3.2.0.1` code still used the legacy backlog path in `notifyChangesToSubscribers()`.
- Confirmed the background email worker processes `send_email` tasks created through `prepareSendingEmail()`.
- Confirmed the item details response already computes `notification_status` for the current user.
- Confirmed the top notify action did not previously reflect that status.
- Confirmed `files_reference.txt` and `app/files_reference.txt` are not included.

## Files Changed

- `app/sources/main.functions.php`
- `app/pages/items.php`
- `app/pages/items.js.php`
- `public/install/install-steps/run.step5.php`
- `public/install/upgrade_run_3.2.0.php`

To @nilsteampassnet : - `public/install/upgrade_run_3.2.0.php` is herited from https://github.com/nilsteampassnet/TeamPass/pull/5231, be careful