### PR TITLE
Fix API access to items stored in personal subfolders

### DIFF
--- a/app/api/Model/FolderAccessModel.php
+++ b/app/api/Model/FolderAccessModel.php
@@ -114,6 +114,7 @@ class FolderAccessModel
                 SELECT 1
                 FROM ' . prefixTable('nested_tree') . ' AS other_personal
                 WHERE other_personal.personal_folder = 1
+                AND other_personal.parent_id = 0
                 AND other_personal.title <> %s
                 AND nt.nleft >= other_personal.nleft
                 AND nt.nright <= other_personal.nright
@@ -156,6 +157,7 @@ class FolderAccessModel
                 SELECT 1
                 FROM ' . prefixTable('nested_tree') . ' AS other_personal
                 WHERE other_personal.personal_folder = 1
+                AND other_personal.parent_id = 0
                 AND other_personal.title <> %s
                 AND nt.nleft >= other_personal.nleft
                 AND nt.nright <= other_personal.nright
@@ -292,6 +294,7 @@ class FolderAccessModel
             FROM ' . prefixTable('nested_tree') . ' AS nt_access
             INNER JOIN ' . prefixTable('nested_tree') . ' AS other_personal
                 ON other_personal.personal_folder = 1
+                AND other_personal.parent_id = 0
                 AND nt_access.nleft >= other_personal.nleft
                 AND nt_access.nright <= other_personal.nright
             WHERE nt_access.id = ' . $itemFolderColumn . '

--- a/tests/Unit/FolderAccessModelTest.php
+++ b/tests/Unit/FolderAccessModelTest.php
@@ -1,5 +1,33 @@
 <?php
+
 declare(strict_types=1);
+
+/**
+ * Teampass - a collaborative passwords manager.
+ * ---
+ * This file is part of the TeamPass project.
+ * 
+ * TeamPass is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ * 
+ * TeamPass is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ * 
+ * Certain components of this file may be under different licenses. For
+ * details, see the `licenses` directory or individual file headers.
+ * ---
+ * @file      FolderAccessModelTest.php
+ * @author    Teampass Community
+ * @copyright 2009-2026 Teampass.net
+ * @license   GPL-3.0
+ * @see       https://www.teampass.net
+ */
 
 use PHPUnit\Framework\TestCase;
 
@@ -33,5 +61,22 @@ class FolderAccessModelTest extends TestCase
         $model = new FolderAccessModel();
 
         self::assertSame(' AND 1 = 0', $model->getItemFolderSqlConstraint('i.id_tree;DROP', 7));
+    }
+
+    public function testPersonalFolderSqlConstraintOnlyExcludesOtherUsersRoots(): void
+    {
+        $model = new FolderAccessModel();
+
+        $constraint = $model->getItemFolderSqlConstraint('i.id_tree', 7);
+
+        self::assertStringContainsString('other_personal.parent_id = 0', $constraint);
+    }
+
+    public function testPersonalFolderFiltersOnlyExcludeOtherUsersRoots(): void
+    {
+        $source = file_get_contents(__DIR__ . '/../../app/api/Model/FolderAccessModel.php');
+        self::assertIsString($source);
+
+        self::assertSame(3, substr_count($source, 'other_personal.parent_id = 0'));
     }
 }


### PR DESCRIPTION
## Summary

This PR fixes an API-side folder filtering issue that prevented API clients, including the browser extension, from listing items stored inside personal subfolders.

The user's personal root folder was still visible, but folders below it could be removed from the API-visible folder list. As a result, items stored in those personal subfolders were not returned by API item queries.

## Root cause

The API builds the authenticated user's folder list with the user's personal folder tree included. This part correctly adds the personal root and its descendants.

The issue happened later, when `FolderAccessModel` filtered folders and item access to prevent users from reading another user's personal folder tree.

The previous exclusion logic treated every `nested_tree` row with:

```sql
personal_folder = 1
```

as a personal folder root belonging to a user.

However, personal subfolders created below a user's personal root also have `personal_folder = 1`. Their `title` is the folder name, not the user's numeric ID. Because the exclusion logic compared `title <> current_user_id`, the current user's own personal subfolders could be mistaken for another user's personal root and excluded from:

- the API `folders_list`;
- the cached API folder tree;
- item SQL queries guarded by the personal-folder access constraint.

This made the browser extension see the personal root folder while failing to list the subfolders and the items stored below it.

## Implementation details

The personal-folder exclusion logic now only considers top-level personal roots as personal trees owned by other users.

This is done by adding:

```sql
other_personal.parent_id = 0
```

to the existing `other_personal.personal_folder = 1` checks.

The change is applied consistently in:

- `FolderAccessModel::filterFoldersForUser()`;
- `FolderAccessModel::isFolderInsideAllowedPersonalRoot()`;
- `FolderAccessModel::getItemFolderSqlConstraint()`.

With this condition in place:

- another user's top-level personal root is still excluded;
- every folder below that other user's personal root remains protected through the nested-tree boundary check;
- the current user's own personal subfolders are no longer misclassified as other users' personal roots;
- shared folder access logic remains unchanged.

## User-facing behavior

After this change, API clients can correctly browse the current user's personal folder tree:

- the personal root folder remains visible;
- subfolders below the personal root remain visible;
- items stored inside those personal subfolders are returned by API item queries;
- access to other users' personal folders remains blocked.

## Cache behavior

The API may cache the filtered folder tree for an authenticated user.

If a user authenticated before this fix, their cached `folders_list` may already have been stored without the affected personal subfolders. Re-authentication or cache invalidation may be required so the API rebuilds the folder tree with the corrected filter.

## Testing

Automated coverage was added for the personal-folder access filter:

- verify that the generated item-folder SQL constraint only excludes top-level personal roots;
- verify that all personal-folder exclusion filters include the `other_personal.parent_id = 0` guard.

Manual validation covered:

- browsing the personal root folder through an API client;
- browsing subfolders below the personal root;
- listing items stored inside personal subfolders;
- confirming that the fix restores the expected behavior for the browser extension.

## Notes

This PR does not change how personal folders are created. It only corrects how API access filters identify the root of another user's personal folder tree.
