### PR TITLE
Fix api session visibility and revocation in connected users administration

### DIFF
--- a/app/api/Model/AuthModel.php
+++ b/app/api/Model/AuthModel.php
@@ -260,18 +260,41 @@ class AuthModel
         // Store the ENCRYPTED private key and the AES session key server-side.
         // The session_aes_key never leaves the server (not embedded in JWT),
         // so a stolen JWT alone cannot decrypt the private key.
-        DB::update(
+        $apiSessionData = [
+            'encrypted_private_key' => $encryptedPrivateKey,
+            'session_key_salt' => $sessionKeySalt,
+            'session_key' => $keyTempo,
+            'session_aes_key' => base64_encode($sessionKey),
+            'timestamp' => time(),
+        ];
+
+        $apiSessionUpdated = DB::update(
             prefixTable('api'),
-            [
-                'encrypted_private_key' => $encryptedPrivateKey,
-                'session_key_salt' => $sessionKeySalt,
-                'session_key' => $keyTempo,
-                'session_aes_key' => base64_encode($sessionKey),
-                'timestamp' => time(),
-            ],
+            $apiSessionData,
             'user_id = %i',
             $userInfo['id']
         );
+
+        if ((int) $apiSessionUpdated === 0) {
+            DB::insert(
+                prefixTable('api'),
+                array_merge(
+                    [
+                        'type' => 'user',
+                        'label' => null,
+                        'value' => null,
+                        'user_id' => (int) $userInfo['id'],
+                        'allowed_folders' => (string) ($userInfo['api_allowed_folders'] ?? ''),
+                        'enabled' => (int) ($userInfo['api_enabled'] ?? 1),
+                        'allowed_to_create' => (int) ($userInfo['api_allowed_to_create'] ?? 0),
+                        'allowed_to_read' => (int) ($userInfo['api_allowed_to_read'] ?? 1),
+                        'allowed_to_update' => (int) ($userInfo['api_allowed_to_update'] ?? 0),
+                        'allowed_to_delete' => (int) ($userInfo['api_allowed_to_delete'] ?? 0),
+                    ],
+                    $apiSessionData
+                )
+            );
+        }
 
         // get user folders list and persist in cache_tree
         $ret = $this->buildUserFoldersList($userInfo);

--- a/app/api/inc/jwt_utils.php
+++ b/app/api/inc/jwt_utils.php
@@ -87,11 +87,11 @@ function is_jwt_valid($jwt) {
 		$decoded = (array) JWT::decode($jwt, new Key(getApiJwtSigningKey(), 'HS256'));
 
 		// Check if expiration is reached
-		if ($decoded['exp'] - time() < 0) {
+		if (!isset($decoded['exp']) || $decoded['exp'] - time() < 0) {
 			return false;
 		}
 
-		return true;
+        return is_api_session_valid($decoded);
 	} catch (InvalidArgumentException $e) {
 		// provided key/key-array is empty or malformed.
 		return false;
@@ -118,6 +118,33 @@ function is_jwt_valid($jwt) {
 		// provided key ID in key/key-array is empty or invalid.
 		return false;
 	}
+}
+
+function is_api_session_valid(array $decoded): bool
+{
+    $userId = (int) ($decoded['id'] ?? 0);
+    $keyTempo = (string) ($decoded['key_tempo'] ?? '');
+
+    if ($userId <= 0 || $keyTempo === '') {
+        return false;
+    }
+
+    $apiSession = DB::queryFirstRow(
+        'SELECT session_key, session_aes_key, encrypted_private_key
+         FROM ' . prefixTable('api') . '
+         WHERE user_id = %i',
+        $userId
+    );
+
+    if ($apiSession === null || empty($apiSession['session_key'])) {
+        return false;
+    }
+
+    if (!hash_equals((string) $apiSession['session_key'], $keyTempo)) {
+        return false;
+    }
+
+    return !empty($apiSession['session_aes_key']) && !empty($apiSession['encrypted_private_key']);
 }
 
 function base64url_encode($data) {

--- a/app/scripts/restore.php
+++ b/app/scripts/restore.php
@@ -258,6 +258,18 @@ if ($initiatorId > 0) {
             'id = %i',
             $initiatorId
         );
+        DB::update(
+            prefixTable('api'),
+            [
+                'encrypted_private_key' => null,
+                'session_key_salt' => null,
+                'session_key' => null,
+                'session_aes_key' => null,
+                'timestamp' => '',
+            ],
+            'user_id = %i',
+            $initiatorId
+        );
         $log('INFO', 'Disconnected restore initiator (user id=' . $initiatorId . ').');
     } catch (Throwable $e) {
         $log('WARN', 'Unable to disconnect restore initiator: ' . $e->getMessage());
@@ -293,47 +305,44 @@ try {
 }
 
 try {
-    $apiTokenDuration = 3600;
-    if (isset($SETTINGS['api_token_duration']) && is_numeric($SETTINGS['api_token_duration'])) {
-        $apiTokenDuration = (int) $SETTINGS['api_token_duration'];
-    }
-    if ($apiTokenDuration <= 0) {
-        $apiTokenDuration = 3600;
-    }
-    $apiConnectedAfter = $now - ($apiTokenDuration + 600);
+    $apiTokenDurationMinutes = min(max((int) ($SETTINGS['api_token_duration'] ?? 60), 1), 1440);
+    $apiConnectedAfter = (string) ($now - (($apiTokenDurationMinutes * 60) + 600));
 
     $apiUsers = DB::query(
         'SELECT u.id, u.login, u.name, u.lastname, api_conn.last_api_date AS last_api
          FROM ' . prefixTable('users') . ' u
          INNER JOIN (
-            SELECT qui, MAX(date) AS last_api_date
-            FROM ' . prefixTable('log_system') . '
-            WHERE type = %s AND label = %s AND date >= %i
-            GROUP BY qui
-         ) api_conn ON api_conn.qui = u.id',
-        'api',
-        'user_connection',
-        $apiConnectedAfter
+            SELECT user_id, MAX(timestamp) AS last_api_date
+            FROM ' . prefixTable('api') . '
+            WHERE session_key IS NOT NULL
+                AND session_key != %s
+                AND timestamp >= %s
+            GROUP BY user_id
+         ) api_conn ON api_conn.user_id = u.id
+         WHERE (%i = 0 OR u.id != %i)',
+        '',
+        $apiConnectedAfter,
+        $initiatorId,
+        $initiatorId
     );
 } catch (Throwable $e) {
     // Optional: ignore API checks if unavailable
     $log('WARN', 'Unable to check API activity: ' . $e->getMessage());
 }
 
-// Enforce disconnect policy for web sessions
-if (!empty($webUsers) && $forceDisconnect === false) {
-    $log('ERROR', 'Active web sessions detected. Re-run with --force-disconnect or disconnect users first.');
+// Enforce disconnect policy for web and API sessions
+if ((!empty($webUsers) || !empty($apiUsers)) && $forceDisconnect === false) {
+    $log('ERROR', 'Active sessions detected. Re-run with --force-disconnect or disconnect users first.');
     foreach ($webUsers as $u) {
         $log('ERROR', 'WEB user connected: ' . strval($u['login'] ?? '') . ' (' . strval($u['name'] ?? '') . ' ' . strval($u['lastname'] ?? '') . ')');
     }
     if (!empty($apiUsers)) {
-        $log('WARN', 'API activity detected as well (best-effort detection):');
         foreach ($apiUsers as $u) {
-            $log('WARN', 'API activity: ' . strval($u['login'] ?? '') . ' (' . strval($u['name'] ?? '') . ' ' . strval($u['lastname'] ?? '') . ')');
+            $log('ERROR', 'API user connected: ' . strval($u['login'] ?? '') . ' (' . strval($u['name'] ?? '') . ' ' . strval($u['lastname'] ?? '') . ')');
         }
     }
     // IMPORTANT: keep token pending so the operator can retry after disconnecting users.
-    $payload['last_error'] = 'active_web_sessions';
+    $payload['last_error'] = 'active_sessions';
     $payload['last_error_at'] = time();
     tpRestoreAuthorizationUpdatePayload($authId, $payload);
 
@@ -358,17 +367,38 @@ if (!empty($webUsers) && $forceDisconnect === true) {
     }
 }
 
+if (!empty($apiUsers) && $forceDisconnect === true) {
+    $log('INFO', 'Active API sessions detected: forcing disconnection.');
+    try {
+        $apiUserIds = array_values(array_unique(array_map(
+            static fn ($user): int => (int) ($user['id'] ?? 0),
+            $apiUsers
+        )));
+        $apiUserIds = array_values(array_filter($apiUserIds, static fn (int $userId): bool => $userId > 0));
+
+        if (!empty($apiUserIds)) {
+            DB::update(
+                prefixTable('api'),
+                [
+                    'encrypted_private_key' => null,
+                    'session_key_salt' => null,
+                    'session_key' => null,
+                    'session_aes_key' => null,
+                    'timestamp' => '',
+                ],
+                'user_id IN %li',
+                $apiUserIds
+            );
+        }
+    } catch (Throwable $e) {
+        $log('WARN', 'Failed to force-disconnect API users: ' . $e->getMessage());
+    }
+}
+
 // From this point, we consider the restore authorized to start.
 $payload['status'] = 'in_progress';
 $payload['started_at'] = time();
 tpRestoreAuthorizationUpdatePayload($authId, $payload);
-
-if (!empty($apiUsers)) {
-    $log('WARN', 'API activity detected (best-effort): those sessions may not be revocable. Proceeding.');
-    foreach ($apiUsers as $u) {
-        $log('WARN', 'API activity: ' . strval($u['login'] ?? '') . ' (' . strval($u['name'] ?? '') . ' ' . strval($u['lastname'] ?? '') . ')');
-    }
-}
 
 // Maintenance mode toggle (best-effort)
 // Keep maintenance enabled at the end of the restore (same behavior as the legacy web restore),

--- a/app/sources/backups.queries.php
+++ b/app/sources/backups.queries.php
@@ -2468,10 +2468,28 @@ function tpCheckRestoreCompatibility(array $SETTINGS, string $serverScope = '', 
                 $excludeUserId = (int) $session->get('user-id');
             }
 
+            $apiTokenDurationMinutes = min(max((int) ($SETTINGS['api_token_duration'] ?? 60), 1), 1440);
+            $apiConnectedAfter = (string) (time() - (($apiTokenDurationMinutes * 60) + 600));
+
             $connectedCount = (int) DB::queryFirstField(
-                'SELECT COUNT(*) FROM ' . prefixTable('users') . ' WHERE session_end >= %i AND id != %i',
+                'SELECT COUNT(*)
+                 FROM ' . prefixTable('users') . ' u
+                 WHERE u.id != %i
+                 AND (
+                    u.session_end >= %i
+                    OR EXISTS (
+                        SELECT 1
+                        FROM ' . prefixTable('api') . ' api_session
+                        WHERE api_session.user_id = u.id
+                            AND api_session.session_key IS NOT NULL
+                            AND api_session.session_key != %s
+                            AND api_session.timestamp >= %s
+                    )
+                 )',
+                $excludeUserId,
                 time(),
-                $excludeUserId
+                '',
+                $apiConnectedAfter
             );
 
             echo prepareExchangedData(['error' => false, 'connected_count' => $connectedCount], 'encode');

--- a/app/sources/logs.datatables.php
+++ b/app/sources/logs.datatables.php
@@ -893,13 +893,10 @@ if (isset($params['action']) && $params['action'] === 'connections') {
         $orderColumn = $aColumns[$params['order'][0]['column']];
     }    
 
-    // API activity is logged in log_system (type=api, label=user_connection) when a JWT is issued.
-    // A user is considered 'API connected' while their last API token is still valid.
-    $apiTokenDuration = (int) ($SETTINGS['api_token_duration'] ?? 3600); // Default 1 hour
-    if ($apiTokenDuration < 60) {
-        $apiTokenDuration = 3600; // Minimum 1 hour for safety
-    }
-    $apiConnectedAfter = time() - ($apiTokenDuration + 600);
+    // API JWT duration is configured in minutes. teampass_api.timestamp is refreshed
+    // when a JWT is issued, so it is cheaper to use than scanning log_system.
+    $apiTokenDurationMinutes = min(max((int) ($SETTINGS['api_token_duration'] ?? 60), 1), 1440);
+    $apiConnectedAfter = (string) (time() - (($apiTokenDurationMinutes * 60) + 600));
 
     // Filtering
     $sWhere = new WhereClause('AND');
@@ -912,20 +909,14 @@ if (isset($params['action']) && $params['action'] === 'connections') {
     $subclause2 = $sWhere->addClause('OR');
     $subclause2->add('u.session_end >= %i', time());
     $subclause2->add(
-        'EXISTS (SELECT 1 FROM '.prefixTable('log_system').' ls
-            WHERE ls.qui = u.id
-                AND ls.label = %s
-                AND ls.date >= %i
-                AND (
-                    (ls.type = %s)
-                    OR (ls.type = %s AND ls.field_1 LIKE %s)
-                )
+        'EXISTS (SELECT 1 FROM '.prefixTable('api').' api_session
+            WHERE api_session.user_id = u.id
+                AND api_session.session_key IS NOT NULL
+                AND api_session.session_key != %s
+                AND api_session.timestamp >= %s
         )',
-        'user_connection',
-        $apiConnectedAfter,
-        'api',
-        'user_connection',
-        '%tp_src=api%'
+        '',
+        $apiConnectedAfter
     );
 
     // Get the total number of records - use alias 'u'
@@ -941,21 +932,18 @@ if (isset($params['action']) && $params['action'] === 'connections') {
         api_conn.last_api_date AS api_last_connection
     FROM '.prefixTable('users').' u
     LEFT JOIN (
-        SELECT qui, MAX(date) as last_api_date
-        FROM '.prefixTable('log_system').'
-        WHERE label = %s
-            AND date >= %i
-            AND (
-                (type = %s)
-                OR (type = %s AND field_1 LIKE %s)
-            )
-        GROUP BY qui
-    ) api_conn ON api_conn.qui = u.id
+        SELECT user_id, MAX(timestamp) as last_api_date
+        FROM '.prefixTable('api').'
+        WHERE session_key IS NOT NULL
+            AND session_key != %s
+            AND timestamp >= %s
+        GROUP BY user_id
+    ) api_conn ON api_conn.user_id = u.id
     WHERE %l
     ORDER BY %l %l
     LIMIT %i, %i';
 
-    $params = ['user_connection', $apiConnectedAfter, 'api', 'user_connection', '%tp_src=api%', $sWhere, $orderColumn, $orderDirection, $sLimitStart, $sLimitLength];
+    $params = ['', $apiConnectedAfter, $sWhere, $orderColumn, $orderDirection, $sLimitStart, $sLimitLength];
 
     // Get the records
     $rows = DB::query($sql, ...$params);

--- a/app/sources/users.queries.php
+++ b/app/sources/users.queries.php
@@ -962,6 +962,7 @@ if (null !== $post_type) {
                     'id = %i',
                     $post_user_id
                 );
+                tpInvalidateUserApiSession($post_user_id);
             }
             break;
             
@@ -985,23 +986,48 @@ if (null !== $post_type) {
             }
 
             $now = time();
+            $apiTokenDurationMinutes = min(max((int) ($SETTINGS['api_token_duration'] ?? 60), 1), 1440);
+            $apiConnectedAfter = (string) ($now - (($apiTokenDurationMinutes * 60) + 600));
 
             try {
                 // Select IDs first to avoid multi-row update locking issues
                 if ($excludeUserId > 0) {
                     $rows = DB::query(
                         'SELECT id
-                         FROM ' . prefixTable('users') . '
-                         WHERE session_end >= %i AND id != %i',
+                         FROM ' . prefixTable('users') . ' u
+                         WHERE u.id != %i
+                         AND (
+                            u.session_end >= %i
+                            OR EXISTS (
+                                SELECT 1
+                                FROM ' . prefixTable('api') . ' api_session
+                                WHERE api_session.user_id = u.id
+                                    AND api_session.session_key IS NOT NULL
+                                    AND api_session.session_key != %s
+                                    AND api_session.timestamp >= %s
+                            )
+                         )',
+                        $excludeUserId,
                         $now,
-                        $excludeUserId
+                        '',
+                        $apiConnectedAfter
                     );
                 } else {
                     $rows = DB::query(
                         'SELECT id
-                         FROM ' . prefixTable('users') . '
-                         WHERE session_end >= %i',
-                        $now
+                         FROM ' . prefixTable('users') . ' u
+                         WHERE u.session_end >= %i
+                         OR EXISTS (
+                            SELECT 1
+                            FROM ' . prefixTable('api') . ' api_session
+                            WHERE api_session.user_id = u.id
+                                AND api_session.session_key IS NOT NULL
+                                AND api_session.session_key != %s
+                                AND api_session.timestamp >= %s
+                         )',
+                        $now,
+                        '',
+                        $apiConnectedAfter
                     );
                 }
 
@@ -1017,6 +1043,7 @@ if (null !== $post_type) {
                         'id = %i',
                         (int) $row['id']
                     );
+                    tpInvalidateUserApiSession((int) $row['id']);
                 }
 
                 echo prepareExchangedData(
@@ -4377,6 +4404,26 @@ function canAccessInactiveAndDeletedUsersPanels(): bool
     $session = SessionManager::getSession();
 
     return (int) $session->get('user-admin') === 1;
+}
+
+function tpInvalidateUserApiSession(int $userId): void
+{
+    if ($userId <= 0) {
+        return;
+    }
+
+    DB::update(
+        prefixTable('api'),
+        array(
+            'encrypted_private_key' => null,
+            'session_key_salt' => null,
+            'session_key' => null,
+            'session_aes_key' => null,
+            'timestamp' => '',
+        ),
+        'user_id = %i',
+        $userId
+    );
 }
 
 /**


### PR DESCRIPTION
## Summary

This PR improves how TeamPass detects, displays, and revokes active API sessions in the administration connected-users views.

The `utilities.database` tab "Currently connected users" now detects API users from the server-side API session state instead of rebuilding presence from `log_system` entries. The same API-session awareness is applied to the database restore strict-mode modal and to the CLI restore safety checks.

The change addresses two related issues:

- API users could disappear from the connected-users tab too early because `api_token_duration` was interpreted as seconds instead of minutes;
- connected-user detection was expensive because it scanned and aggregated `log_system`, including a non-index-friendly `LIKE '%tp_src=api%'` condition.

It also tightens API session revocation: disconnecting a user from the administration interface now invalidates the server-side API session state used by JWT validation.

## Root cause

The API JWT duration setting is configured and documented in minutes.

The JWT issuer uses:

```php
min(max((int) ($SETTINGS['api_token_duration'] ?? 60), 1), 1440) * 60
```

This means a value of `60` represents a token valid for 60 minutes.

The connected-users datatable and restore script used the same setting as if it was already expressed in seconds:

```php
time() - ($apiTokenDuration + 600)
```

With the default value of `60`, the administration page only considered the API user connected for about 11 minutes instead of 70 minutes including the existing 10-minute grace period.

The previous API presence detection also depended on `log_system` rows created when a JWT was issued. This had two drawbacks:

- active API users were detected from historical logs instead of the current server-side API session state;
- every connected-users refresh could query and aggregate a potentially large log table.

In addition, the administration disconnect actions cleared the web session fields in `teampass_users`, but did not clear the API session data stored in `teampass_api`. A JWT could therefore remain valid until expiration, especially for endpoints that only checked the JWT signature and expiration.

## Implementation details

### Connected-users datatable

The `users_logged_in` datatable now detects API sessions from `teampass_api`:

- `session_key IS NOT NULL`
- `session_key != ''`
- `timestamp >= current_time - api_token_duration_minutes - 10 minutes grace`

The API duration is now normalized consistently:

```php
$apiTokenDurationMinutes = min(max((int) ($SETTINGS['api_token_duration'] ?? 60), 1), 1440);
$apiConnectedAfter = time() - (($apiTokenDurationMinutes * 60) + 600);
```

The datatable still displays both connection types:

- active web session from `users.session_end`;
- active API session from `api.timestamp` and `api.session_key`.

When a web session has expired but the API session is still active, the "connected since" duration uses the API session timestamp.

### Restore strict-mode modal

The restore connected-users check now counts both web and API sessions.

This keeps the restore modal aligned with the connected-users tab and prevents the operator from continuing a restore while an API user is still considered active.

### CLI restore safety check

The CLI restore script now uses the same API-session source as the administration UI.

Without `--force-disconnect`, the script blocks when either web or API sessions are active and records:

```text
active_sessions
```

With `--force-disconnect`, the script now clears active API sessions in addition to web sessions.

The restore initiator is also disconnected from both web and API session state before the restore starts.

### User disconnect actions

The existing connected-users disconnect actions now invalidate API session state as well as web session state.

The new helper clears transient API session fields:

- `encrypted_private_key`
- `session_key_salt`
- `session_key`
- `session_aes_key`
- `timestamp`

The permanent API configuration remains untouched, including API permissions and API key configuration.

### JWT validation

JWT validation now checks the server-side API session state after verifying the JWT signature and expiration.

A JWT is only considered valid when:

- it contains a valid user id;
- it contains a non-empty `key_tempo`;
- `teampass_api.session_key` matches the JWT `key_tempo`;
- `session_aes_key` is present;
- `encrypted_private_key` is present.

This makes administration-side API session invalidation effective for all API endpoints that pass through the shared `verifyAuth()` path, not only endpoints that later decrypt the user's private key.

### API authentication fallback

When issuing a JWT, the API now updates the user's `teampass_api` row as before.

If no row exists for the user, a fallback insert creates the missing API session row with the user's current API permissions. This avoids issuing a JWT that immediately fails the new server-side session validation on older or inconsistent installations.

## User-facing behavior

After this change, administrators should see API users in "Currently connected users" for the same duration as the issued JWT remains valid, plus the existing 10-minute grace period.

For example, with `api_token_duration = 60`, an API user is considered connected for about 70 minutes after JWT issuance, instead of about 11 minutes.

The API indicator in the connected-users table continues to show which users are currently considered connected through API activity.

Disconnecting a user from the connected-users tab now also invalidates their API session. The user must authenticate again to obtain a valid API JWT.

## Restore behavior

The restore strict-mode modal and CLI restore now have consistent connected-user semantics.

When strict mode checks connected users:

- web sessions are counted from `users.session_end`;
- API sessions are counted from `teampass_api.session_key` and `teampass_api.timestamp`;
- the current administrator is still excluded where applicable.

When the operator chooses or runs force disconnect:

- web session fields are cleared;
- API session fields are cleared;
- active JWTs tied to those API sessions stop passing global JWT validation.

## Performance impact

The connected-users tab no longer needs to scan and aggregate `log_system` to detect API presence.

The previous logic used:

- `EXISTS` against `log_system`;
- a grouped `MAX(date)` subquery over `log_system`;
- a `field_1 LIKE '%tp_src=api%'` condition.

The new logic uses `teampass_api`, which already has:

- a `user_id` key;
- an `idx_api_timestamp` index.

This should reduce the cost of loading the connected-users tab on installations with large log tables.

## Security impact

The change improves API session revocation.

Before this PR, an administrator disconnect mostly affected the web session fields. API JWTs could remain accepted until expiration if the endpoint only validated the JWT signature and `exp` claim.

After this PR, API JWT validity also depends on server-side session material in `teampass_api`. Clearing that session state immediately invalidates the JWT.

The private key protection model remains unchanged: the API still stores the encrypted private key and session AES key server-side, and the JWT still only carries the `key_tempo` reference.

## Files changed

- `app/sources/logs.datatables.php`
  - Connected-users API detection now uses `teampass_api`.
  - `api_token_duration` is interpreted as minutes.

- `app/sources/backups.queries.php`
  - Restore connected-users modal count now includes active API sessions.

- `app/sources/users.queries.php`
  - User disconnect actions now clear API session state.
  - Disconnect-all now includes active API users, not only web users.

- `app/scripts/restore.php`
  - Restore CLI detects active API sessions from `teampass_api`.
  - Restore CLI blocks on API sessions unless `--force-disconnect` is used.
  - Force disconnect now clears API session state.

- `app/api/inc/jwt_utils.php`
  - JWT validation now checks the server-side API session state.

- `app/api/Model/AuthModel.php`
  - JWT issuance updates server-side API session state.
  - Missing API rows are inserted as a fallback for older or inconsistent user records.

## Testing

Recommended validation:

- set `api_token_duration` to 60 minutes;
- authenticate through the API or browser extension;
- open `utilities.database` and the "Currently connected users" tab;
- confirm the API user remains visible beyond the previous short window;
- confirm the API indicator is displayed for the user;
- disconnect the API user from the connected-users tab;
- confirm the row disappears after refresh;
- retry an API call with the old JWT and confirm it is rejected;
- re-authenticate through the API and confirm a new JWT works;
- open the restore strict-mode modal while an API session is active;
- confirm the modal blocks continuation;
- use "disconnect all" from the modal and confirm API sessions are cleared;
- run the restore CLI without `--force-disconnect` while API users are active and confirm it exits with active-session errors;
- run the restore CLI with `--force-disconnect` and confirm it clears web and API sessions before continuing.

Technical checks attempted locally:

- PHP syntax linting was attempted with `php -l`, but PHP CLI was not available in the local Windows PATH or common local PHP installation paths.

## Notes

This PR does not implement per-request API heartbeat tracking.

API presence is still based on the last successful JWT issuance and its configured validity window. This matches the current API authentication model and avoids adding a database write on every API request.

A future enhancement could add throttled `last_api_seen_at` updates during authenticated API requests if real-time API activity, rather than valid JWT session presence, becomes necessary.
