### PR TITLE
Fix 5212 Renewal page expiration listing

### DIFF
--- a/app/pages/utilities.renewal.js.php
+++ b/app/pages/utilities.renewal.js.php
@@ -71,7 +71,7 @@ $checkUserAccess = new PerformChecks(
 );
 // Handle the case
 echo $checkUserAccess->caseHandler();
-if ($checkUserAccess->checkSession() === false || $checkUserAccess->userAccessPage('utilities.logs') === false) {
+if ($checkUserAccess->checkSession() === false || $checkUserAccess->userAccessPage('utilities.renewal') === false) {
     // Not allowed page
     $session->set('system-error_code', ERR_NOT_ALLOWED);
     include TEAMPASS_ROOT . '/public/error.php';
@@ -99,23 +99,21 @@ if ($checkUserAccess->checkSession() === false || $checkUserAccess->userAccessPa
         'sPaginationType': 'listbox',
         'searching': true,
         'order': [
-            [1, 'asc']
+            [0, 'asc']
         ],
         'info': true,
-        'processing': false,
+        'processing': true,
         'serverSide': true,
         'responsive': true,
         'stateSave': true,
-        'autoWidth': true,
+        'autoWidth': false,
         'ajax': {
             url: '<?php echo $SETTINGS['cpassman_url']; ?>/sources/expired.datatables.php',
-            data: function() {
-                if ($('#renewal-date').datepicker("getDate") === '' || $('#renewal-date').datepicker("getDate") === null) {
-                    return {};
-                } else {
-                    return {
-                        "dateCriteria": $('#renewal-date').datepicker("getDate").valueOf()
-                    }
+            data: function(data) {
+                var selectedDate = $('#renewal-date').datepicker("getDate");
+
+                if (selectedDate instanceof Date) {
+                    data.dateCriteria = selectedDate.valueOf();
                 }
             }
         },
@@ -127,24 +125,19 @@ if ($checkUserAccess->checkSession() === false || $checkUserAccess->userAccessPa
             toastr.info('<?php echo $lang->get('in_progress'); ?> ... <i class="fas fa-circle-notch fa-spin fa-2x"></i>');
         },
         'drawCallback': function() {
-            // Inform user
             toastr.remove();
-            toastr.info('<?php echo $lang->get('in_progress'); ?> ... <i class="fas fa-circle-notch fa-spin fa-2x"></i>');
+            $('.infotip').tooltip();
         },
         'columns': [{
-                'width': '60px',
-                className: 'dt-body-center'
-            },
-            {
                 'width': '40%',
-                className: 'dt-body-center'
+                className: 'dt-body-left'
             },
             {
                 'width': '20%',
                 className: 'dt-body-center'
             },
             {
-                className: 'datatable.path'
+                className: 'dt-body-left'
             }
         ]
     });

--- a/app/pages/utilities.renewal.php
+++ b/app/pages/utilities.renewal.php
@@ -90,7 +90,7 @@ header('Cache-Control: no-cache, no-store, must-revalidate');
     <div class="container-fluid">
         <div class="row mb-2">
             <div class="col-sm-12">
-                <h1 class="m-0 text-dark"><i class="fas fa-calendar mr-2"></i><?php echo $lang->get('renewal'); ?></h1>
+                <h1 class="m-0 text-dark"><i class="fas fa-calendar-check mr-2"></i><?php echo $lang->get('renewal'); ?></h1>
             </div><!-- /.col -->
         </div><!-- /.row -->
     </div><!-- /.container-fluid -->
@@ -103,31 +103,36 @@ header('Cache-Control: no-cache, no-store, must-revalidate');
     <div class="container-fluid">
         <div class="row">
             <div class="col-lg-12">
-                <div class="card">
+                <div class="card card-outline card-primary">
+                    <div class="card-header">
+                        <h3 class="card-title">
+                            <i class="fas fa-clock mr-2"></i><?php echo $lang->get('renewal'); ?>
+                        </h3>
+                    </div>
                     <div class="card-body">
-                        <div class="alert alert-primary row">
-                            <div class="col-1">
-                                <i class="fas fa-lightbulb text-warning fa-lg"></i>
-                            </div>
-                            <div class="col-11">
-                                <?php echo $lang->get('renewal_page_info'); ?>
+                        <div class="callout callout-info mb-3">
+                            <div class="d-flex align-items-start">
+                                <i class="fas fa-lightbulb text-info fa-lg mr-3 mt-1"></i>
+                                <div><?php echo $lang->get('renewal_page_info'); ?></div>
                             </div>
                         </div>
-                        <div class="row">
-                            <div class="d-inline p-2">
-                                <?php echo $lang->get('select_date_showing_items_expiration'); ?>
-                            </div>
-                            <div class="d-inline p-2">
-                                <div class="input-group date inline">
-                                    <input type="text" class="form-control" id="renewal-date">
+
+                        <div class="row align-items-end mb-3">
+                            <div class="col-md-6 col-lg-4">
+                                <label for="renewal-date"><?php echo $lang->get('select_date_showing_items_expiration'); ?></label>
+                                <div class="input-group date">
+                                    <div class="input-group-prepend">
+                                        <span class="input-group-text"><i class="fas fa-calendar-day"></i></span>
+                                    </div>
+                                    <input type="text" class="form-control" id="renewal-date" autocomplete="off">
                                 </div>
                             </div>
                         </div>
-                        <div>
-                            <table class="table table-striped table-responsive" id="table-renewal" style="width:100%;">
+
+                        <div class="table-responsive">
+                            <table class="table table-striped table-hover table-responsive-sm nowrap" id="table-renewal" style="width:100%;">
                                 <thead>
                                     <tr>
-                                        <th></th>
                                         <th><?php echo $lang->get('label'); ?></th>
                                         <th><?php echo $lang->get('expiration_date'); ?></th>
                                         <th><?php echo $lang->get('folder'); ?></th>

--- a/app/sources/expired.datatables.php
+++ b/app/sources/expired.datatables.php
@@ -71,7 +71,7 @@ $checkUserAccess = new PerformChecks(
 // Handle the case
 echo $checkUserAccess->caseHandler();
 if (
-    $checkUserAccess->userAccessPage('folders') === false ||
+    $checkUserAccess->userAccessPage('utilities.renewal') === false ||
     $checkUserAccess->checkSession() === false
 ) {
     // Not allowed page
@@ -93,17 +93,100 @@ set_time_limit(0);
 
 $tree = new NestedTree(prefixTable('nested_tree'), 'id', 'parent_id', 'title');
 //Columns name
-$aColumns = ['a.item_id', 'i.label', 'a.del_value', 'i.id_tree'];
-$aSortTypes = ['asc', 'desc'];
+$aColumns = ['i.label', 'expiration_date', 'n.title'];
+$aSortTypes = ['ASC', 'DESC'];
 //init SQL variables
-$sWhere = ' WHERE a.del_type = 2';
 $sOrder = $sLimit = '';
+
+$draw = (int) $request->query->filter('draw', FILTER_SANITIZE_NUMBER_INT);
+$emptyOutput = [
+    'draw' => $draw,
+    'recordsTotal' => 0,
+    'recordsFiltered' => 0,
+    'data' => [],
+    'sEcho' => $draw,
+    'iTotalRecords' => 0,
+    'iTotalDisplayRecords' => 0,
+    'aaData' => [],
+];
+
+if ((int) ($SETTINGS['activate_expiration'] ?? 0) !== 1) {
+    echo json_encode($emptyOutput);
+    exit;
+}
+
+$visibleFolders = $session->get('user-accessible_folders');
+if (is_array($visibleFolders) === false || empty($visibleFolders) === true) {
+    echo json_encode($emptyOutput);
+    exit;
+}
+
+$visibleFolders = array_values(
+    array_unique(
+        array_map(
+            'intval',
+            array_diff(
+                $visibleFolders,
+                is_array($session->get('user-forbiden_personal_folders')) === true ? $session->get('user-forbiden_personal_folders') : []
+            )
+        )
+    )
+);
+
+if (empty($visibleFolders) === true) {
+    echo json_encode($emptyOutput);
+    exit;
+}
+
 // Is a date sent?
 $dateCriteria = $request->query->get('dateCriteria');
 if ($dateCriteria !== null && !empty($dateCriteria)) {
-    $sWhere .= ' AND a.del_value < ' . round(filter_var($dateCriteria, FILTER_SANITIZE_NUMBER_INT) / 1000, 0);
+    $dateCriteria = (int) round((int) filter_var($dateCriteria, FILTER_SANITIZE_NUMBER_INT) / 1000, 0);
+    $targetExpirationTimestamp = $dateCriteria + TP_ONE_DAY_SECONDS - 1;
+} else {
+    $targetExpirationTimestamp = time();
 }
-//echo $sWhere;
+
+$lastRelevantDateSql = 'COALESCE(NULLIF(l.last_relevant_date, 0), NULLIF(CAST(i.created_at AS UNSIGNED), 0), 0)';
+$expirationDateSql = '(' . $lastRelevantDateSql . ' + (n.renewal_period * ' . TP_ONE_DAY_SECONDS . '))';
+$fromWhereSql = '
+    FROM ' . prefixTable('items') . ' AS i
+    INNER JOIN ' . prefixTable('nested_tree') . ' AS n ON (n.id = i.id_tree)
+    LEFT JOIN (
+        SELECT id_item, MAX(CAST(date AS UNSIGNED)) AS last_relevant_date
+        FROM ' . prefixTable('log_items') . '
+        WHERE action = %s
+        OR (action = %s AND raison LIKE %s)
+        GROUP BY id_item
+    ) AS l ON (l.id_item = i.id)
+    WHERE i.inactif = %i
+    AND i.deleted_at IS NULL
+    AND i.id_tree IN %ls
+    AND n.renewal_period > %i
+    AND ' . $lastRelevantDateSql . ' > %i
+    AND ' . $expirationDateSql . ' <= %i';
+$queryParams = [
+    'at_creation',
+    'at_modification',
+    'at_pw%',
+    0,
+    $visibleFolders,
+    0,
+    0,
+    (int) $targetExpirationTimestamp,
+];
+$baseFromWhereSql = $fromWhereSql;
+$baseQueryParams = $queryParams;
+
+// Filtering
+$search = $request->query->all('search');
+$searchValue = is_array($search) === true && isset($search['value']) === true ? trim((string) $search['value']) : '';
+if ($searchValue !== '') {
+    $fromWhereSql .= ' AND (i.label LIKE %ss OR n.title LIKE %ss)';
+    $queryParams[] = $searchValue;
+    $queryParams[] = $searchValue;
+}
+
 /* BUILD QUERY */
 //Paging
 $sLimit = '';
@@ -118,109 +201,50 @@ if ($request->query->has('order')) {
     $order = $request->query->all('order');
 
     // Vérifiez si la direction 'dir' est définie et est valide
-    if (isset($order[0]['dir']) && in_array($order[0]['dir'], $aSortTypes)) {
-        $sOrder = 'ORDER BY ';
+    if (isset($order[0]['dir']) && in_array(strtoupper((string) $order[0]['dir']), $aSortTypes, true)) {
         $columnIndex = filter_var($order[0]['column'], FILTER_SANITIZE_NUMBER_INT);
 
         if (array_key_exists($columnIndex, $aColumns)) {
-            $sOrder .= $aColumns[$columnIndex] . ' ' . $order[0]['dir'];
-        }
-
-        // Supprimez la virgule finale si elle existe
-        $sOrder = rtrim($sOrder, ', ');
-
-        if ($sOrder === 'ORDER BY') {
-            $sOrder = '';
+            $sOrder = ' ORDER BY ' . $aColumns[$columnIndex] . ' ' . strtoupper((string) $order[0]['dir']);
         }
     }
 }
 
-/*
-   * Filtering
-   * NOTE this does not match the built-in DataTables filtering which does it
-   * word by word on any field. It's possible to do here, but concerned about efficiency
-   * on very large tables, and MySQL's regex functionality is very limited
-*/
-// Vérifiez si 'letter' existe dans la requête GET
-if ($request->query->has('letter')) {
-    $letter = $request->query->filter('letter', FILTER_SANITIZE_FULL_SPECIAL_CHARS);
-
-    if ($letter !== '' && $letter !== 'None') {
-        $sWhere .= ' AND ';
-        $sWhere .= $aColumns[1] . " LIKE '" . $letter . "%' OR ";
-        $sWhere .= $aColumns[2] . " LIKE '" . $letter . "%' OR ";
-        $sWhere .= $aColumns[3] . " LIKE '" . $letter . "%' ";
-    }
-}
-
-// Si 'letter' n'est pas défini ou est vide, vérifiez 'search[value]'
-if (!isset($letter) || $letter === '') {
-    if ($request->query->has('search[value]')) {
-        $searchValue = $request->query->filter('search[value]', FILTER_SANITIZE_FULL_SPECIAL_CHARS);
-
-        if ($searchValue !== '') {
-            $sWhere = ' AND ';
-            $sWhere .= $aColumns[1] . " LIKE '" . $searchValue . "%' OR ";
-            $sWhere .= $aColumns[2] . " LIKE '" . $searchValue . "%' OR ";
-            $sWhere .= $aColumns[3] . " LIKE '" . $searchValue . "%' ";
-        }
-    }
-}
-
+$totalCountSql = 'SELECT COUNT(*) FROM (SELECT i.id ' . $baseFromWhereSql . ') AS renewal_items';
+$filteredCountSql = 'SELECT COUNT(*) FROM (SELECT i.id ' . $fromWhereSql . ') AS renewal_items';
+$iTotal = (int) DB::queryFirstField($totalCountSql, ...$baseQueryParams);
+$iFilteredTotal = (int) DB::queryFirstField($filteredCountSql, ...$queryParams);
 $rows = DB::query(
-    'SELECT a.item_id, i.label, a.del_value, i.id_tree
-    FROM ' . prefixTable('automatic_del') . ' AS a
-    INNER JOIN ' . prefixTable('items') . ' AS i ON (i.id = a.item_id)' .
-    $sWhere.
-    (string) $sOrder
+    'SELECT i.label, i.id_tree, ' . $expirationDateSql . ' AS expiration_date ' .
+    $fromWhereSql .
+    $sOrder .
+    $sLimit,
+    ...$queryParams
 );
-$iTotal = DB::count();
-$rows = DB::query(
-    'SELECT a.item_id, i.label, a.del_value, i.id_tree
-    FROM ' . prefixTable('automatic_del') . ' AS a
-    INNER JOIN ' . prefixTable('items') . ' AS i ON (i.id = a.item_id)' .
-        $sWhere .
-        $sLimit
-);
-$iFilteredTotal = DB::count();
-/*
-   * Output
-*/
-$sOutput = '{';
-$sOutput .= '"sEcho": '. (int) $request->query->filter('draw', FILTER_SANITIZE_NUMBER_INT) . ', ';
-$sOutput .= '"iTotalRecords": '.$iTotal.', ';
-$sOutput .= '"iTotalDisplayRecords": '.$iTotal.', ';
-$sOutput .= '"aaData": ';
-if ($iTotal > 0) {
-    $sOutput .= '[';
-} else {
-    $sOutput .= '';
-}
 
+$data = [];
 foreach ($rows as $record) {
-    // start the line
-    $sOutput .= '[';
-    // Column 1
-    $sOutput .= '"<i class=\"fas fa-external-link-alt pointer text-primary mr-2\" onclick=\"showItemCard($(this))\" data-item-id=\"' . $record['item_id'] . '\"  data-item-tree-id=\"' . $record['id_tree'] . '\"></i>", ';
-    // Column 2
-    $sOutput .= '"' . $record['label'] . '", ';
-    // Column 3
-    $sOutput .= '"' . date($SETTINGS['date_format'] . ' ' . $SETTINGS['time_format'], (int) $record['del_value']) . '", ';
-    // Column 4
     $path = [];
     $treeDesc = $tree->getPath($record['id_tree'], true);
     foreach ($treeDesc as $t) {
-        array_push($path, $t->title);
+        $path[] = htmlspecialchars((string) $t->title, ENT_QUOTES, 'UTF-8');
     }
-    $sOutput .= '"' . implode('<i class=\"fas fa-angle-right ml-1 mr-1\"></i>', $path) . '"],';
-}
 
-if (count($rows) > 0) {
-    $sOutput = substr_replace($sOutput, '', -1);
-    $sOutput .= '] }';
-} else {
-    $sOutput .= '[] }';
+    $data[] = [
+        htmlspecialchars((string) $record['label'], ENT_QUOTES, 'UTF-8'),
+        date($SETTINGS['date_format'] . ' ' . $SETTINGS['time_format'], (int) $record['expiration_date']),
+        implode('<i class="fas fa-angle-right ml-1 mr-1"></i>', $path),
+    ];
 }
 
 // finalize output
-echo (string) $sOutput;
+echo json_encode([
+    'draw' => $draw,
+    'recordsTotal' => $iTotal,
+    'recordsFiltered' => $iFilteredTotal,
+    'data' => $data,
+    'sEcho' => $draw,
+    'iTotalRecords' => $iTotal,
+    'iTotalDisplayRecords' => $iFilteredTotal,
+    'aaData' => $data,
+]);

--- a/app/sources/find.queries.php
+++ b/app/sources/find.queries.php
@@ -329,7 +329,7 @@ if (null === $request->query->get('type')) {
         // Expiration
         if ($SETTINGS['activate_expiration'] === '1') {
             if ($record['renewal_period'] > 0
-                && ($record['timestamp'] + ($record['renewal_period'] * TP_ONE_MONTH_SECONDS)) < time()
+                && ($record['timestamp'] + ($record['renewal_period'] * TP_ONE_DAY_SECONDS)) < time()
             ) {
                 $expired = 1;
             } else {
@@ -482,7 +482,7 @@ if (null === $request->query->get('type')) {
         $arr_data[$record['id']]['is_result_of_search'] = 1;
         if ((int) $SETTINGS['activate_expiration'] === 1) {
             if ($record['renewal_period'] > 0
-                && ($record['timestamp'] + ($record['renewal_period'] * TP_ONE_MONTH_SECONDS)) < time()
+                && ($record['timestamp'] + ($record['renewal_period'] * TP_ONE_DAY_SECONDS)) < time()
             ) {
                 $arr_data[$record['id']]['expired'] = 1;
                 $arr_data[$record['id']]['expirationFlag'] = 'red';

--- a/app/sources/items.queries.php
+++ b/app/sources/items.queries.php
@@ -4411,18 +4411,18 @@ switch ($inputData['type']) {
 
                 // Batch: get the most recent relevant date per item (creation or last pw change)
                 $logRows = DB::query(
-                    'SELECT id_item, MAX(date) AS date
+                    'SELECT id_item, MAX(CAST(date AS UNSIGNED)) AS date
                     FROM ' . prefixTable('log_items') . '
                     WHERE id_item IN %ls
                     AND (
                         action = %s
-                        OR (action = %s AND raison = %s)
+                        OR (action = %s AND raison LIKE %s)
                     )
                     GROUP BY id_item',
                     $allItemIds,
                     'at_creation',
                     'at_modification',
-                    'at_pw'
+                    'at_pw%'
                 );
                 foreach ($logRows as $logRow) {
                     $batchExpirationDates[$logRow['id_item']] = $logRow['date'];
@@ -4468,7 +4468,7 @@ switch ($inputData['type']) {
                     if (
                         (int) $SETTINGS['activate_expiration'] === 1
                         && intval($record['renewal_period']) > 0
-                        && (intval($record['date']) + (intval($record['renewal_period']) * TP_ONE_MONTH_SECONDS)) < time()
+                        && (intval($record['date']) + (intval($record['renewal_period']) * TP_ONE_DAY_SECONDS)) < time()
                     ) {
                         $expired_item = 1;
                     }

--- a/app/sources/main.functions.php
+++ b/app/sources/main.functions.php
@@ -693,13 +693,23 @@ function cacheTableRefresh(): void
     // reload date
         $rows = DB::query(
             'SELECT i.*,
-                IFNULL(l.id_user, 0) AS id_user,
-                IFNULL(l.date, 0) AS date
+                IFNULL(c.id_user, 0) AS id_user,
+                IFNULL(l.date, IFNULL(c.date, 0)) AS date
             FROM ' . prefixTable('items') . ' as i
-            LEFT JOIN ' . prefixTable('log_items') . ' as l
-                ON (l.id_item = i.id AND l.action = %s)
+            LEFT JOIN ' . prefixTable('log_items') . ' as c
+                ON (c.id_item = i.id AND c.action = %s)
+            LEFT JOIN (
+                SELECT id_item, MAX(CAST(date AS UNSIGNED)) AS date
+                FROM ' . prefixTable('log_items') . '
+                WHERE action = %s
+                OR (action = %s AND raison LIKE %s)
+                GROUP BY id_item
+            ) AS l ON (l.id_item = i.id)
             WHERE i.inactif = %i',
             'at_creation',
+            'at_creation',
+            'at_modification',
+            'at_pw%',
             0
         );
 
@@ -783,9 +793,22 @@ function cacheTableUpdate(?int $ident = null): void
     $tree = new NestedTree(prefixTable('nested_tree'), 'id', 'parent_id', 'title');
     // get new value from db
     $data = DB::queryFirstRow(
-        'SELECT label, description, id_tree, perso, restricted_to, login, url
-        FROM ' . prefixTable('items') . '
-        WHERE id=%i',
+        'SELECT i.label, i.description, i.id_tree, i.perso, i.restricted_to, i.login, i.url,
+            n.renewal_period,
+            IFNULL(l.date, NULLIF(CAST(i.created_at AS UNSIGNED), 0)) AS date
+        FROM ' . prefixTable('items') . ' AS i
+        INNER JOIN ' . prefixTable('nested_tree') . ' AS n ON (n.id = i.id_tree)
+        LEFT JOIN (
+            SELECT id_item, MAX(CAST(date AS UNSIGNED)) AS date
+            FROM ' . prefixTable('log_items') . '
+            WHERE action = %s
+            OR (action = %s AND raison LIKE %s)
+            GROUP BY id_item
+        ) AS l ON (l.id_item = i.id)
+        WHERE i.id=%i',
+        'at_creation',
+        'at_modification',
+        'at_pw%',
         $ident
     );
     // Get all TAGS
@@ -833,6 +856,8 @@ function cacheTableUpdate(?int $ident = null): void
             'login' => $data['login'] ?? '',
             'folder' => implode(' » ', $folder),
             'author' => $session->get('user-id'),
+            'renewal_period' => $data['renewal_period'] ?? '0',
+            'timestamp' => $data['date'] ?? '0',
         ],
         'id = %i',
         $ident
@@ -859,12 +884,21 @@ function cacheTableAdd(?int $ident = null): void
     // get new value from db
     $data = DB::queryFirstRow(
         'SELECT i.label, i.description, i.id_tree as id_tree, i.perso, i.restricted_to, i.id, i.login, i.url,
-            IFNULL(l.date, 0) AS date
+            n.renewal_period,
+            IFNULL(l.date, NULLIF(CAST(i.created_at AS UNSIGNED), 0)) AS date
         FROM ' . prefixTable('items') . ' as i
-        LEFT JOIN ' . prefixTable('log_items') . ' as l
-            ON (l.id_item = i.id AND l.action = %s)
+        INNER JOIN ' . prefixTable('nested_tree') . ' AS n ON (n.id = i.id_tree)
+        LEFT JOIN (
+            SELECT id_item, MAX(CAST(date AS UNSIGNED)) AS date
+            FROM ' . prefixTable('log_items') . '
+            WHERE action = %s
+            OR (action = %s AND raison LIKE %s)
+            GROUP BY id_item
+        ) AS l ON (l.id_item = i.id)
         WHERE i.id = %i',
         'at_creation',
+        'at_modification',
+        'at_pw%',
         $ident
     );
     // Get all TAGS
@@ -913,6 +947,7 @@ function cacheTableAdd(?int $ident = null): void
             'login' => $data['login'] ?? '',
             'folder' => implode(' » ', $folder),
             'author' => $globalsUserId,
+            'renewal_period' => $data['renewal_period'] ?? '0',
             'timestamp' => $data['date'],
         ]
     );


### PR DESCRIPTION
## Summary

This PR fixes the Renewal utility page so it lists items whose passwords are expired or will expire by the selected date.

It addresses the behavior reported in issue #5212, where the Renewal page stayed empty even when folders had a renewal delay configured.

It also cleans up the Renewal page table by removing the item-open link, which is not useful for administrators who cannot open item cards from this utility view.

## Root cause

The Renewal datatable was reading from `automatic_del` with `del_type = 2`.

That table belongs to the "delete after consultation" feature. It is populated when an item is configured for automatic deletion after a number of views or after a deletion date.

Password renewal, however, is configured on folders through `nested_tree.renewal_period`. The expiration date must be computed from:

- the item's creation date;
- or the most recent password-change log;
- plus the folder renewal period.

The page also had a secondary access check mismatch: `utilities.renewal.js.php` checked `utilities.logs` instead of `utilities.renewal`.

## Implementation details

The Renewal datatable now queries active items from visible folders and computes expiration directly from TeamPass renewal data:

- `items` for active item metadata;
- `nested_tree.renewal_period` for the folder delay;
- `log_items` for the latest relevant date, using `at_creation` or `at_modification` with `at_pw%`.

The selected date is treated as an inclusive target day. If no date is selected, the page lists items already expired at the current time.

The calculation now consistently treats `renewal_period` as days by using `TP_ONE_DAY_SECONDS`, matching the folder UI and documentation.

The Renewal datatable now preserves DataTables request parameters when adding the selected date filter, so server-side search, ordering, and pagination keep working.

Related expiration indicators were aligned in:

- the item list;
- search results;
- cache refresh/add/update helpers used by search.

The Renewal utility page layout was refreshed with the existing AdminLTE card, callout, input group, and responsive table patterns used elsewhere in TeamPass.

## User-facing behavior

After this change:

- folders with a renewal delay greater than `0` produce Renewal page results;
- changing the date picker shows items expiring up to that date;
- using the Renewal table search field filters the server-side results;
- Renewal rows show the item label, expiration date, and folder path without an unusable item-open link;
- the item list and search expiration flags use the same day-based renewal delay;
- users allowed to access `utilities.renewal` no longer need `utilities.logs` just to load the Renewal page JavaScript.

## Testing

Manual/static validation covered:

- verifying that `expired.datatables.php` no longer depends on `automatic_del`;
- verifying that renewal expiration uses `nested_tree.renewal_period` and `log_items`;
- verifying that legacy/current password-change log reasons are matched through `at_pw%`;
- verifying that no renewal calculation still uses `TP_ONE_MONTH_SECONDS`.
- verifying that `expired.datatables.php` no longer emits the item-open link column.

## Notes

This PR does not change the automatic deletion feature. Existing `automatic_del` usage remains limited to delete-after-consultation workflows.
