### PR TITLE
Fix Docker on-premise migration blockers (issue #5238)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -121,23 +121,26 @@ RUN mkdir -p \
     storage/files \
     storage/upload \
     storage/config \
+    storage/backups \
     secrets \
     app/includes/libraries/csrfp/log \
     /var/lib/nginx/tmp \
     /var/log/supervisor \
     /run/nginx \
     && chown -R nginx:nginx \
+        storage \
         storage/sk \
         storage/files \
         storage/upload \
         storage/config \
+        storage/backups \
         secrets \
         app/includes/libraries/csrfp/log \
         /var/lib/nginx \
         /var/log \
         /run/nginx \
     && chmod 700 storage/sk secrets \
-    && chmod 750 storage/files storage/upload storage/config app/includes/libraries/csrfp/log
+    && chmod 750 storage storage/files storage/upload storage/config storage/backups app/includes/libraries/csrfp/log
 
 # Remove unnecessary files for production
 RUN rm -rf \

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -78,6 +78,7 @@ create_directories() {
     mkdir -p /var/www/html/storage/files
     mkdir -p /var/www/html/storage/upload
     mkdir -p /var/www/html/storage/config
+    mkdir -p /var/www/html/storage/backups
     mkdir -p /var/www/html/secrets
     mkdir -p /var/www/html/app/includes/libraries/csrfp/log
 
@@ -88,17 +89,23 @@ create_directories() {
 set_permissions() {
     echo -e "${BLUE}🔒 Setting file permissions...${NC}"
 
+    # The storage/ root itself must be writable by nginx so PHP can create
+    # runtime sub-directories, and the installer "writable" check passes (issue #5238).
+    chown nginx:nginx /var/www/html/storage
     chown -R nginx:nginx /var/www/html/storage/sk
     chown -R nginx:nginx /var/www/html/storage/files
     chown -R nginx:nginx /var/www/html/storage/upload
     chown -R nginx:nginx /var/www/html/storage/config
+    chown -R nginx:nginx /var/www/html/storage/backups
     chown -R nginx:nginx /var/www/html/secrets
     chown -R nginx:nginx /var/www/html/app/includes/libraries/csrfp/log
 
+    chmod 750 /var/www/html/storage
     chmod 700 /var/www/html/storage/sk
     chmod 750 /var/www/html/storage/files
     chmod 750 /var/www/html/storage/upload
     chmod 750 /var/www/html/storage/config
+    chmod 750 /var/www/html/storage/backups
     chmod 700 /var/www/html/secrets
     chmod 750 /var/www/html/app/includes/libraries/csrfp/log
 
@@ -128,8 +135,15 @@ link_persistent_file() {
         ln -s "$persist_file" "$app_file"
     fi
 
+    # Force ownership and mode so PHP-FPM (running as the nginx user) can read
+    # AND write the persistent file. A file copied in from an on-premise install
+    # may arrive owned by www-data or with restrictive bits, which otherwise
+    # fails the installer "writable" check (issue #5238).
     chown -h nginx:nginx "$app_file" 2>/dev/null || true
-    [ -f "$persist_file" ] && chown nginx:nginx "$persist_file" 2>/dev/null || true
+    if [ -f "$persist_file" ]; then
+        chown nginx:nginx "$persist_file"
+        chmod 0640 "$persist_file"
+    fi
 }
 
 # Ensure install-time state survives container recreation.
@@ -220,6 +234,29 @@ auto_install() {
     fi
 }
 
+# Read the TeamPass version recorded in the database.
+# Tries the current key (teampass_version) first, then the legacy key
+# (cpassman_version) used by TeamPass 3.1.5.x and earlier — so a database
+# migrated from an older on-premise install is detected correctly (issue #5238).
+# Echoes the version string, or nothing when it cannot be read.
+read_db_version() {
+    if [ -z "$DB_PASSWORD" ]; then
+        return 0
+    fi
+
+    _db_version=$(mysql -h "$DB_HOST" -P "$DB_PORT" -u "$DB_USER" -p"$DB_PASSWORD" \
+        "$DB_NAME" --skip-column-names --silent \
+        -e "SELECT valeur FROM ${DB_PREFIX}misc WHERE type='admin' AND intitule='teampass_version' LIMIT 1" 2>/dev/null || true)
+
+    if [ -z "$_db_version" ]; then
+        _db_version=$(mysql -h "$DB_HOST" -P "$DB_PORT" -u "$DB_USER" -p"$DB_PASSWORD" \
+            "$DB_NAME" --skip-column-names --silent \
+            -e "SELECT valeur FROM ${DB_PREFIX}misc WHERE type='admin' AND intitule='cpassman_version' LIMIT 1" 2>/dev/null || true)
+    fi
+
+    echo "$_db_version"
+}
+
 # Function to run pending database migrations when the container image is
 # newer than the version recorded in teampass_misc.  The upgrade scripts are
 # idempotent (CREATE TABLE IF NOT EXISTS / ALTER ... IF NOT EXISTS), so it is
@@ -230,10 +267,8 @@ auto_upgrade() {
         return 0
     fi
 
-    # Read the version stored in the database
-    DB_VERSION=$(mysql -h "$DB_HOST" -P "$DB_PORT" -u "$DB_USER" -p"$DB_PASSWORD" \
-        "$DB_NAME" --skip-column-names --silent \
-        -e "SELECT valeur FROM ${DB_PREFIX}misc WHERE type='admin' AND intitule='teampass_version' LIMIT 1" 2>/dev/null || true)
+    # Read the version stored in the database (current or legacy key)
+    DB_VERSION=$(read_db_version)
 
     if [ -z "$DB_VERSION" ]; then
         echo -e "${YELLOW}⚠️  Could not read DB version, skipping auto-upgrade${NC}"
@@ -326,16 +361,25 @@ main() {
     if is_installed; then
         echo -e "${GREEN}✅ TeamPass is already configured${NC}"
 
-        # Remove install directory if it exists (keep it during upgrades so
-        # upgrade.php is accessible, then remove once complete)
-        if [ -d "/var/www/html/public/install" ]; then
-            echo -e "${BLUE}🗑️  Removing install directory...${NC}"
-            rm -rf /var/www/html/public/install
-        fi
-
         # Auto-upgrade: apply pending database migrations when the image
         # version is newer than the version recorded in teampass_misc.
         auto_upgrade
+
+        # Remove the install directory only when the database is already at the
+        # image version. While an upgrade is pending (e.g. a database migrated
+        # from an older on-premise install), the install directory is kept so
+        # that /install/upgrade.php remains reachable to finish the upgrade
+        # through the web wizard (issue #5238). If the version cannot be read,
+        # the directory is removed (preserves the previous hardening default).
+        if [ -d "/var/www/html/public/install" ]; then
+            CURRENT_DB_VERSION=$(read_db_version)
+            if [ -n "$CURRENT_DB_VERSION" ] && [ "$CURRENT_DB_VERSION" != "${TP_VERSION:-${TEAMPASS_VERSION}}" ]; then
+                echo -e "${YELLOW}⏳ Upgrade pending (DB ${CURRENT_DB_VERSION} → ${TP_VERSION:-${TEAMPASS_VERSION}}); keeping install directory for /install/upgrade.php${NC}"
+            else
+                echo -e "${BLUE}🗑️  Removing install directory...${NC}"
+                rm -rf /var/www/html/public/install
+            fi
+        fi
     else
         echo -e "${YELLOW}⚙️  TeamPass is not configured yet${NC}"
 

--- a/docker/php/php.ini
+++ b/docker/php/php.ini
@@ -25,7 +25,11 @@ max_input_vars = 5000
 expose_php = Off
 allow_url_fopen = On
 allow_url_include = Off
-disable_functions = exec,passthru,shell_exec,system,popen,parse_ini_file,show_source
+; Note: exec is intentionally NOT disabled. TeamPass requires it for its cron
+; scheduler (GO\Scheduler), crontab setup during upgrade, and background-task
+; triggering. It is only ever called with escapeshellarg'd internal paths,
+; never with user input. The remaining shell functions stay disabled.
+disable_functions = passthru,shell_exec,system,popen,parse_ini_file,show_source
 
 ; Session
 session.save_handler = files

--- a/public/install/upgrade_ajax.php
+++ b/public/install/upgrade_ajax.php
@@ -935,7 +935,19 @@ if (isset($post_type)) {
             // get php location
             require_once 'tp.functions.php';
             $phpLocation = findPhpBinary();
-            if ($phpLocation['error'] === false) {
+            if (function_exists('exec') === false) {
+                // exec() is disabled (e.g. Docker hardening). The crontab manager
+                // relies on exec(), and in such environments the scheduler cron is
+                // already provided by the host (system crontab / supervisord), so
+                // skip the in-app crontab setup gracefully instead of crashing.
+                array_push(
+                    $returnStatus,
+                    array(
+                        'id' => 'step5_cronJob',
+                        'html' => '<i class="fa-solid fa-circle-check fa-lg text-success ml-2 mr-2"></i><span class="text-info font-italic">Skipped — cron managed by the host</span>',
+                    )
+                );
+            } elseif ($phpLocation['error'] === false) {
                 // Instantiate the adapter and repository
                 try {
                     $crontabAdapter = new CrontabAdapter();
@@ -972,8 +984,9 @@ if (isset($post_type)) {
                             )
                         );
                     }
-                } catch (Exception $e) {
-                    // do nothing
+                } catch (\Throwable $e) {
+                    // Swallow any failure (including a disabled-function Error)
+                    // so the crontab step can never abort the upgrade response.
                 }
             } else {
                 array_push(


### PR DESCRIPTION
- entrypoint: keep public/install until DB version matches image version so /install/upgrade.php stays reachable during a pending upgrade
- entrypoint: read DB version from legacy cpassman_version key as a fallback so migrated 3.1.5.x databases are detected
- entrypoint: force nginx:nginx 0640 on the persistent settings.php and make the storage/ root writable; create storage/backups
- Dockerfile: add storage/backups to the directory/permission baseline
- php.ini: stop disabling exec (required by the scheduler, crontab setup and background-task trigger); keep the other shell functions disabled
- upgrade_ajax.php: guard the crontab step with function_exists('exec') and catch \Throwable so it can never abort the upgrade response

Fixes #5238.