### PR TITLE
Request mfa only after primary authentication succeeds

### DIFF
--- a/app/core/login.js.php
+++ b/app/core/login.js.php
@@ -48,6 +48,17 @@ declare(strict_types=1);
         $('#forgot-local-password-link').prop('disabled', false);
     }
 
+    function resetMfaStep() {
+        mfaStepPending = false;
+        cachedMfaData = null;
+        $('#2fa_user_selection').val('');
+        $('#2fa_methods_selector').addClass('hidden');
+        $('.div-2fa-method').addClass('hidden');
+        $('.2fa_selector_select').prop('checked', false);
+        $('#ga_code').val('').removeClass('ui-state-error');
+        $('#yubico_key, #yubico_user_id, #yubico_user_key').val('').removeClass('ui-state-error');
+    }
+
     function showForgotLocalPasswordLink(login) {
         if (typeof login === 'undefined' || String(login).trim() === '') {
             hideForgotLocalPasswordLink();
@@ -80,7 +91,10 @@ declare(strict_types=1);
 
         // Set focus on login input
         $('#login').focus();
-        $('#login, #pw').on('input', hideForgotLocalPasswordLink);
+        $('#login, #pw').on('input', function() {
+            hideForgotLocalPasswordLink();
+            resetMfaStep();
+        });
 
         // Page has beed reloaded due to session key inconsistency
         if (store.get('teampassUser') !== null && typeof store.get('teampassUser') !== 'undefined' && store.get('teampassUser').page_reload === 1) {
@@ -729,84 +743,16 @@ declare(strict_types=1);
             return;
         }
 
-        // First step: check if this specific user needs MFA based on their roles
-        $.post(
-            'sources/identify.php', {
-                type: 'get2FAMethodsForUser',
-                login: $('#login').val()
-            },
-            function(response) {
-                response = JSON.parse(response);
-
-                if (response.error === true) {
-                    toastr.remove();
-                    toastr.error(
-                        response.message,
-                        '<?php echo $lang->get('caution'); ?>', {
-                            timeOut: 5000,
-                            progressBar: true,
-                            positionClass: "toast-bottom-right"
-                        }
-                    );
-                    return false;
-                }
-
-                if (debugJavascript === true) {
-                    console.log('Received key ' + response.key + ' and local key <?php echo strval($session->get('key')); ?>')
-                }
-                if (response.key !== '<?php echo strval($session->get('key')); ?>') {
-                    store.update(
-                        'teampassUser', {},
-                        function(teampassUser) {
-                            teampassUser.login = $("#login").val();
-                            teampassUser.mfaSelector = $("#select2fa-otp").is(":checked");
-                            teampassUser.mfaCode = $("#ga_code").val();
-                            teampassUser.page_reload = 1;
-                        }
-                    );
-                    document.location.reload(true);
-                    return false;
-                }
-
-                var data;
-                try {
-                    data = prepareExchangedData(response.ret, "decode", response.key);
-                } catch (e) {
-                    toastr.remove();
-                    toastr.error(
-                        '<?php echo $lang->get('server_answer_error'); ?>',
-                        '<?php echo $lang->get('caution'); ?>', {
-                            timeOut: 5000,
-                            progressBar: true,
-                            positionClass: "toast-bottom-right"
-                        }
-                    );
-                    return false;
-                }
-
-                if (debugJavascript === true) {
-                    console.info('Get 2FA Methods for user answer:');
-                    console.log(data);
-                }
-
-                if (data.mfa_required === false) {
-                    // No MFA needed for this user - proceed directly to authentication
-                    toastr.remove();
-                    toastr.info(
-                        '<?php echo $lang->get('in_progress'); ?><i class="fas fa-circle-notch fa-spin fa-2x ml-3"></i>',
-                        '', {
-                            positionClass: "toast-top-center"
-                        }
-                    );
-                    buildMfaDataAndIdentify(isDuo, redirect, psk, data);
-                } else {
-                    // MFA required - show the appropriate 2FA UI
-                    cachedMfaData = data;
-                    mfaStepPending = true;
-                    showMFAMethodForUser(data);
-                }
+        // First step: submit the primary credentials. The server now requests
+        // MFA only after the password/LDAP/OAuth2 factor has been validated.
+        toastr.remove();
+        toastr.info(
+            '<?php echo $lang->get('in_progress'); ?><i class="fas fa-circle-notch fa-spin fa-2x ml-3"></i>',
+            '', {
+                positionClass: "toast-top-center"
             }
         );
+        buildMfaDataAndIdentify(isDuo, redirect, psk, cachedMfaData);
     }
 
     /**
@@ -815,7 +761,7 @@ declare(strict_types=1);
      * @param {boolean} isDuo
      * @param {string} redirect
      * @param {string} psk
-     * @param {object|null} availableMfaMethods - response from get2FAMethodsForUser
+     * @param {object|null} availableMfaMethods - MFA methods returned after primary auth
      */
     function buildMfaDataAndIdentify(isDuo, redirect, psk, availableMfaMethods) {
         // Clear localstorage
@@ -974,13 +920,15 @@ declare(strict_types=1);
                     return false;
                 }
 
-                // Server detected that MFA is required but no 2FA code was provided.
-                // This can happen if get2FAMethodsForUser returned mfa_required:false incorrectly.
-                // Show the 2FA form as a fallback.
+                // Server detected that MFA is required after validating the primary factor.
                 if (data.value === '2fa_not_set' || data.error === '2fa_not_set') {
                     toastr.remove();
                     mfaStepPending = true;
-                    if (cachedMfaData !== null) {
+
+                    if (typeof data.mfa_methods !== 'undefined') {
+                        cachedMfaData = data.mfa_methods;
+                        showMFAMethodForUser(cachedMfaData);
+                    } else if (cachedMfaData !== null) {
                         showMFAMethodForUser(cachedMfaData);
                     } else {
                         $.post(
@@ -1016,6 +964,9 @@ declare(strict_types=1);
                             );
                             return false;
                         } else if (data.extra === 'oauth2_user_not_found') {
+                            if (data.primary_auth_failed === true) {
+                                resetMfaStep();
+                            }
                             toastr.remove();
                             toastr.error(
                                 data.message,
@@ -1039,6 +990,9 @@ declare(strict_types=1);
                             return false;
                         }
                     }  else if (data.error === true || data.error !== '') {
+                        if (data.primary_auth_failed === true) {
+                            resetMfaStep();
+                        }
                         toastr.remove();
                         toastr.error(
                             data.message,
@@ -1265,9 +1219,9 @@ declare(strict_types=1);
 
     /**
      * Shows the appropriate MFA method UI based on user-specific data
-     * returned by the get2FAMethodsForUser endpoint.
+     * returned after the primary authentication factor succeeds.
      *
-     * @param {object} data - decoded response from get2FAMethodsForUser
+     * @param {object} data - decoded MFA method response
      * @return void
      */
     function showMFAMethodForUser(data) {

--- a/app/core/login.js.php
+++ b/app/core/login.js.php
@@ -948,6 +948,21 @@ declare(strict_types=1);
                             }
                         );
                     }
+                    if (data.mfa_enrollment_started === true) {
+                        var mfaEnrollmentMessage = (
+                            typeof data.email_result !== 'undefined' &&
+                            data.email_result !== ''
+                        ) ? data.email_result : data.mfa_enrollment_message;
+                        toastr.success(
+                            mfaEnrollmentMessage,
+                            '<?php echo $lang->get('success'); ?>',
+                            {
+                                timeOut: 5000,
+                                progressBar: true,
+                                positionClass: "toast-bottom-right"
+                            }
+                        );
+                    }
                     return false;
                 }
 

--- a/app/sources/identify.php
+++ b/app/sources/identify.php
@@ -261,6 +261,101 @@ function getMfaMethodsForLogin(array $SETTINGS, string $login): array
 }
 
 /**
+ * Count enabled MFA methods returned to the login form.
+ *
+ * @param array<string, mixed> $mfaMethods
+ */
+function countEnabledMfaMethods(array $mfaMethods): int
+{
+    return (int) (($mfaMethods['agses'] ?? false) === true)
+        + (int) (($mfaMethods['google'] ?? false) === true)
+        + (int) (($mfaMethods['yubico'] ?? false) === true)
+        + (int) (($mfaMethods['duo'] ?? false) === true);
+}
+
+/**
+ * Determine if Google MFA has enough data to challenge the user.
+ *
+ * @param array<string, mixed> $userInfo
+ */
+function googleMfaSecretExists(array $userInfo): bool
+{
+    return trim((string) ($userInfo['ga'] ?? '')) !== '';
+}
+
+/**
+ * Start the first Google MFA enrollment after primary authentication succeeds.
+ *
+ * @param array<string, mixed> $SETTINGS
+ * @param array<string, mixed> $userInfo
+ */
+function initializeGoogleMfaEnrollment(
+    array $SETTINGS,
+    array $userInfo,
+    string $username,
+    Language $lang
+): array
+{
+    if (googleMfaSecretExists($userInfo) === true) {
+        return [
+            'error' => false,
+            'started' => false,
+        ];
+    }
+
+    if (empty($userInfo['email']) === true) {
+        return [
+            'error' => true,
+            'message' => $lang->get('no_email_set'),
+        ];
+    }
+
+    $tfa = new TwoFactorAuth($SETTINGS['ga_website_name']);
+    $gaSecretKey = $tfa->createSecret();
+    $gaTemporaryCode = GenerateCryptKey(12, false, true, true, false, true);
+
+    DB::update(
+        prefixTable('users'),
+        [
+            'ga' => $gaSecretKey,
+            'ga_temporary_code' => $gaTemporaryCode,
+        ],
+        'id = %i',
+        $userInfo['id']
+    );
+
+    logEvents(
+        $SETTINGS,
+        'user_connection',
+        'at_2fa_google_code_send_by_email',
+        (string) $userInfo['id'],
+        stripslashes($username),
+        stripslashes($username)
+    );
+
+    prepareSendingEmail(
+        $lang->get('email_ga_subject'),
+        str_replace(
+            '#2FACode#',
+            $gaTemporaryCode,
+            $lang->get('email_ga_text')
+        ),
+        $userInfo['email']
+    );
+
+    return [
+        'error' => false,
+        'started' => true,
+        'message' => $lang->get('mfa_code_send_by_email'),
+        'email_result' => str_replace(
+            '#email#',
+            '<b>' . obfuscateEmail($userInfo['email']) . '</b>',
+            addslashes($lang->get('admin_email_result_ok'))
+        ),
+    ];
+}
+
+/**
  * Complete authentication of user through Teampass
  *
  * @param string $sentData Credentials
@@ -548,6 +643,32 @@ function identifyUser(string $sentData, array $SETTINGS): bool
     // Check if MFA is required after the primary authentication factor is valid.
     if ($mfaMethods['mfa_required'] === true) {
         if (empty($dataReceived['user_2fa_selection']) === true) {
+            $mfaEnrollment = [
+                'error' => false,
+                'started' => false,
+            ];
+
+            if ($mfaMethods['google'] === true && countEnabledMfaMethods($mfaMethods) === 1) {
+                $mfaEnrollment = initializeGoogleMfaEnrollment(
+                    $SETTINGS,
+                    $userInfo,
+                    (string) $username,
+                    $lang
+                );
+
+                if ($mfaEnrollment['error'] === true) {
+                    echo prepareExchangedData(
+                        [
+                            'error' => true,
+                            'message' => $mfaEnrollment['message'],
+                            'mfa_setup_error' => true,
+                        ],
+                        'encode'
+                    );
+                    return false;
+                }
+            }
+
             $session->set('mfa_primary_login_validated', [
                 'login' => $username,
                 'created_at' => time(),
@@ -562,6 +683,9 @@ function identifyUser(string $sentData, array $SETTINGS): bool
                     'error' => '2fa_not_set',
                     'message' => $lang->get('select_valid_2fa_credentials'),
                     'mfa_methods' => $mfaMethods,
+                    'mfa_enrollment_started' => $mfaEnrollment['started'],
+                    'mfa_enrollment_message' => $mfaEnrollment['message'] ?? '',
+                    'email_result' => $mfaEnrollment['email_result'] ?? '',
                 ] + $mfaMethods,
                 'encode'
             );
@@ -578,7 +702,9 @@ function identifyUser(string $sentData, array $SETTINGS): bool
         );
         if ($userMfa['error'] === true) {
             // Add failed authentication log
-            addFailedAuthentication($username, getClientIpServer(), $SETTINGS);
+            if (($userMfa['mfaData']['mfa_setup_error'] ?? false) !== true) {
+                addFailedAuthentication($username, getClientIpServer(), $SETTINGS);
+            }
 
             echo prepareExchangedData(
                 [
@@ -587,6 +713,7 @@ function identifyUser(string $sentData, array $SETTINGS): bool
                     'mfaStatus' => $userMfa['mfaData']['mfaStatus'] ?? '',
                     'ga_bad_code' => $userMfa['mfaData']['ga_bad_code'] ?? false,
                     'mfa_error' => true,
+                    'mfa_setup_error' => $userMfa['mfaData']['mfa_setup_error'] ?? false,
                 ],
                 'encode'
             );
@@ -2205,9 +2332,23 @@ function googleMFACheck(string $username, array $userInfo, $dataReceived, array 
         $tfa = new TwoFactorAuth($SETTINGS['ga_website_name']);
         // Init
         $firstTime = [];
+        $gaSecret = trim((string) ($userInfo['ga'] ?? ''));
+        $gaTemporaryCode = trim((string) ($userInfo['ga_temporary_code'] ?? ''));
+
+        if ($gaSecret === '') {
+            return [
+                'error' => true,
+                'message' => $lang->get('i_need_to_generate_new_ga_code'),
+                'proceedIdentification' => false,
+                'ga_bad_code' => false,
+                'mfa_setup_error' => true,
+                'firstTime' => $firstTime,
+            ];
+        }
+
         // now check if it is the 1st time the user is using 2FA
-        if ($userInfo['ga_temporary_code'] !== 'none' && $userInfo['ga_temporary_code'] !== 'done') {
-            if ($userInfo['ga_temporary_code'] !== $dataReceived['GACode']) {
+        if ($gaTemporaryCode !== '' && $gaTemporaryCode !== 'none' && $gaTemporaryCode !== 'done') {
+            if (hash_equals($gaTemporaryCode, (string) $dataReceived['GACode']) === false) {
                 return [
                     'error' => true,
                     'message' => $lang->get('ga_bad_code'),
@@ -2223,7 +2364,7 @@ function googleMFACheck(string $username, array $userInfo, $dataReceived, array 
             // generate new QR
             $new_2fa_qr = $tfa->getQRCodeImageAsDataUri(
                 'Teampass - ' . $username,
-                $userInfo['ga']
+                $gaSecret
             );
             // clear temporary code from DB
             DB::update(
@@ -2244,7 +2385,7 @@ function googleMFACheck(string $username, array $userInfo, $dataReceived, array 
             ];
         } else {
             // verify the user GA code
-            if ($tfa->verifyCode($userInfo['ga'], $dataReceived['GACode'])) {
+            if ($tfa->verifyCode($gaSecret, $dataReceived['GACode'])) {
                 $proceedIdentification = true;
             } else {
                 return [
@@ -3428,7 +3569,9 @@ function identifyDoMFAChecks(
                 $SETTINGS
             );
             if ($ret['error'] !== false) {
-                logEvents($SETTINGS, 'failed_auth', 'wrong_mfa_code', '', stripslashes($username), stripslashes($username));
+                if (($ret['mfa_setup_error'] ?? false) !== true) {
+                    logEvents($SETTINGS, 'failed_auth', 'wrong_mfa_code', '', stripslashes($username), stripslashes($username));
+                }
                 return [
                     'error' => true,
                     'mfaData' => $ret,

--- a/app/sources/identify.php
+++ b/app/sources/identify.php
@@ -109,64 +109,22 @@ if ($post_type === 'identify_user') {
     return false;
 } elseif ($post_type === 'get2FAMethodsForUser') {
     //--------
-    // Get MFA methods required for a specific user based on their roles
+    // Get MFA methods required for a specific user after primary auth succeeded
     //--------
     //
 
     $login = empty($post_login) === false ? $post_login : '';
-
-    $needsMfa = false;
-    $anyMfaEnabled = isOneVarOfArrayEqualToValue(
-        [
-            (int) ($SETTINGS['google_authentication'] ?? 0),
-            (int) ($SETTINGS['yubico_authentication'] ?? 0),
-            (int) ($SETTINGS['duo'] ?? 0),
-            (int) ($SETTINGS['agses_authentication_enabled'] ?? 0),
-        ],
-        1
-    );
-
-    if ($anyMfaEnabled === true && empty($login) === false) {
-        $userInfo = DB::queryFirstRow(
-            'SELECT u.admin, u.mfa_enabled,
-                GROUP_CONCAT(DISTINCT CASE WHEN ur.source = "manual" THEN ur.role_id END SEPARATOR ";") AS fonction_id,
-                GROUP_CONCAT(DISTINCT CASE WHEN ur.source = "ad" THEN ur.role_id END SEPARATOR ";") AS roles_from_ad_groups
-            FROM ' . prefixTable('users') . ' AS u
-            LEFT JOIN ' . prefixTable('users_roles') . ' AS ur ON (u.id = ur.user_id)
-            WHERE u.login=%s AND u.disabled=0 AND u.deleted_at IS NULL
-            GROUP BY u.id',
-            $login
-        );
-
-        if ($userInfo !== null) {
-            // Merge manual roles and AD-sourced roles, same as identifyUserDetails()
-            $fonctionId = (string) ($userInfo['fonction_id'] ?? '');
-            if (empty($userInfo['roles_from_ad_groups']) === false) {
-                $fonctionId = empty($fonctionId) === true
-                    ? (string) $userInfo['roles_from_ad_groups']
-                    : $fonctionId . ';' . (string) $userInfo['roles_from_ad_groups'];
-            }
-
-            $mfaForRoles = is_null($SETTINGS['mfa_for_roles']) === true ? '' : (string) $SETTINGS['mfa_for_roles'];
-            $userNeedsMfaByRole = mfa_auth_requested_roles($fonctionId, $mfaForRoles);
-
-            $isAdmin = (int) $userInfo['admin'] === 1;
-            $adminMfaRequired = isKeyExistingAndEqual('admin_2fa_required', 1, $SETTINGS) === true;
-
-            $needsMfa = ($isAdmin === false && (int) $userInfo['mfa_enabled'] === 1 && $userNeedsMfaByRole === true)
-                || ($isAdmin === true && $adminMfaRequired === true);
-        }
-    }
+    $validatedPrimaryLogin = $session->get('mfa_primary_login_validated') ?? [];
+    $canReturnUserMfaMethods = is_array($validatedPrimaryLogin) === true
+        && empty($login) === false
+        && hash_equals((string) ($validatedPrimaryLogin['login'] ?? ''), $login) === true
+        && time() - (int) ($validatedPrimaryLogin['created_at'] ?? 0) <= 300;
 
     echo json_encode([
         'ret' => prepareExchangedData(
-            [
-                'mfa_required' => $needsMfa,
-                'agses'  => $needsMfa === true && isKeyExistingAndEqual('agses_authentication_enabled', 1, $SETTINGS) === true,
-                'google' => $needsMfa === true && isKeyExistingAndEqual('google_authentication', 1, $SETTINGS) === true,
-                'yubico' => $needsMfa === true && isKeyExistingAndEqual('yubico_authentication', 1, $SETTINGS) === true,
-                'duo'    => $needsMfa === true && isKeyExistingAndEqual('duo', 1, $SETTINGS) === true,
-            ],
+            $canReturnUserMfaMethods === true
+                ? getMfaMethodsForLogin($SETTINGS, $login)
+                : buildMfaMethodsResponse($SETTINGS, false),
             'encode'
         ),
         'key' => $session->get('key'),
@@ -201,6 +159,105 @@ if ($post_type === 'identify_user') {
         'encode'
     );
     return false;
+}
+
+/**
+ * Return the MFA methods that can be used for the current request.
+ *
+ * @param array<string, mixed> $SETTINGS
+ */
+function buildMfaMethodsResponse(array $SETTINGS, bool $needsMfa): array
+{
+    return [
+        'mfa_required' => $needsMfa,
+        'agses'  => $needsMfa === true && isKeyExistingAndEqual('agses_authentication_enabled', 1, $SETTINGS) === true,
+        'google' => $needsMfa === true && isKeyExistingAndEqual('google_authentication', 1, $SETTINGS) === true,
+        'yubico' => $needsMfa === true && isKeyExistingAndEqual('yubico_authentication', 1, $SETTINGS) === true,
+        'duo'    => $needsMfa === true && isKeyExistingAndEqual('duo', 1, $SETTINGS) === true,
+    ];
+}
+
+/**
+ * Determine if a user must complete MFA after primary authentication succeeds.
+ *
+ * @param array<string, mixed> $SETTINGS
+ * @param array<string, mixed> $userInfo
+ */
+function userNeedsMfa(array $SETTINGS, array $userInfo): bool
+{
+    if (
+        isOneVarOfArrayEqualToValue(
+            [
+                (int) ($SETTINGS['yubico_authentication'] ?? 0),
+                (int) ($SETTINGS['google_authentication'] ?? 0),
+                (int) ($SETTINGS['duo'] ?? 0),
+            ],
+            1
+        ) !== true
+    ) {
+        return false;
+    }
+
+    $isAdmin = (int) ($userInfo['admin'] ?? 0) === 1;
+    if ($isAdmin === true) {
+        return isKeyExistingAndEqual('admin_2fa_required', 1, $SETTINGS) === true;
+    }
+
+    if ((int) ($userInfo['mfa_enabled'] ?? 0) !== 1) {
+        return false;
+    }
+
+    if (array_key_exists('mfa_auth_requested_roles', $userInfo) === true) {
+        return filter_var($userInfo['mfa_auth_requested_roles'], FILTER_VALIDATE_BOOLEAN) === true;
+    }
+
+    $fonctionId = (string) ($userInfo['fonction_id'] ?? '');
+    if (empty($userInfo['roles_from_ad_groups']) === false) {
+        $fonctionId = empty($fonctionId) === true
+            ? (string) $userInfo['roles_from_ad_groups']
+            : $fonctionId . ';' . (string) $userInfo['roles_from_ad_groups'];
+    }
+
+    return mfa_auth_requested_roles(
+        $fonctionId,
+        is_null($SETTINGS['mfa_for_roles'] ?? null) === true ? '' : (string) $SETTINGS['mfa_for_roles']
+    );
+}
+
+/**
+ * Return MFA methods for an authenticated primary-login attempt.
+ *
+ * @param array<string, mixed> $SETTINGS
+ * @param array<string, mixed> $userInfo
+ */
+function getMfaMethodsForUserInfo(array $SETTINGS, array $userInfo): array
+{
+    return buildMfaMethodsResponse($SETTINGS, userNeedsMfa($SETTINGS, $userInfo));
+}
+
+/**
+ * Return MFA methods for a login after primary authentication was confirmed.
+ *
+ * @param array<string, mixed> $SETTINGS
+ */
+function getMfaMethodsForLogin(array $SETTINGS, string $login): array
+{
+    $userInfo = DB::queryFirstRow(
+        'SELECT u.admin, u.mfa_enabled,
+            GROUP_CONCAT(DISTINCT CASE WHEN ur.source = "manual" THEN ur.role_id END SEPARATOR ";") AS fonction_id,
+            GROUP_CONCAT(DISTINCT CASE WHEN ur.source = "ad" THEN ur.role_id END SEPARATOR ";") AS roles_from_ad_groups
+        FROM ' . prefixTable('users') . ' AS u
+        LEFT JOIN ' . prefixTable('users_roles') . ' AS ur ON (u.id = ur.user_id)
+        WHERE u.login=%s AND u.disabled=0 AND u.deleted_at IS NULL
+        GROUP BY u.id',
+        $login
+    );
+
+    if (is_array($userInfo) === false) {
+        return buildMfaMethodsResponse($SETTINGS, false);
+    }
+
+    return getMfaMethodsForUserInfo($SETTINGS, $userInfo);
 }
 
 /**
@@ -291,6 +348,10 @@ function identifyUser(string $sentData, array $SETTINGS): bool
         ]);
         return false;
     }
+
+    if (empty($dataReceived['user_2fa_selection']) === true) {
+        $session->remove('mfa_primary_login_validated');
+    }
     
     // prepare variables
     // IMPORTANT: Do NOT sanitize passwords - they should be treated as opaque binary data
@@ -345,6 +406,7 @@ function identifyUser(string $sentData, array $SETTINGS): bool
         (int) $sessionPwdAttempts
     );
     if ($userLdap['error'] === true) {
+        $session->remove('mfa_primary_login_validated');
         // Log LDAP/AD failed authentication into teampass_log_system
         logEvents(
             $SETTINGS,
@@ -414,6 +476,7 @@ function identifyUser(string $sentData, array $SETTINGS): bool
         (int) $userLdap['user_info']['has_been_created']
     );
     if ($userOauth2['error'] === true) {
+        $session->remove('mfa_primary_login_validated');
         $session->set('userOauth2Info', '');
 
         // Add failed authentication log
@@ -427,6 +490,7 @@ function identifyUser(string $sentData, array $SETTINGS): bool
                 'error' => true,
                 'message' => $lang->get($userOauth2['message']),
                 'extra' => 'oauth2_user_not_found',
+                'primary_auth_failed' => true,
             ],
             'encode'
         );
@@ -452,6 +516,7 @@ function identifyUser(string $sentData, array $SETTINGS): bool
     // Check user and password
     $authResult = checkCredentials($passwordClear, $userInfo);
     if ($userLdap['userPasswordVerified'] === false && $userOauth2['userPasswordVerified'] === false && $authResult['authenticated'] !== true) {
+        $session->remove('mfa_primary_login_validated');
         // Log failure (wrong password on existing account) into teampass_log_system
         logEvents($SETTINGS, 'failed_auth', 'password_is_not_correct', '', stripslashes($username), stripslashes($username));
         // Add failed authentication log
@@ -466,6 +531,7 @@ function identifyUser(string $sentData, array $SETTINGS): bool
                 'error' => true,
                 'message' => $lang->get('error_bad_credentials'),
                 'forgot_password_available' => $forgotLocalPasswordContext['available'],
+                'primary_auth_failed' => true,
             ],
             'encode'
         );
@@ -477,19 +543,31 @@ function identifyUser(string $sentData, array $SETTINGS): bool
         $userInfo['private_key'] = $authResult['private_key_reencrypted'];
     }
     
-    // Check if MFA is required
-    if ((
-        isOneVarOfArrayEqualToValue(
-            [
-                (int) $SETTINGS['yubico_authentication'],
-                (int) $SETTINGS['google_authentication'],
-                (int) $SETTINGS['duo']
-            ],
-            1
-        ) === true)
-        && (((int) $userInfo['admin'] !== 1 && (int) $userInfo['mfa_enabled'] === 1 && $userInfo['mfa_auth_requested_roles'] === true)
-        || ((int) $SETTINGS['admin_2fa_required'] === 1 && (int) $userInfo['admin'] === 1))
-    ) {
+    $mfaMethods = getMfaMethodsForUserInfo($SETTINGS, $userInfo);
+
+    // Check if MFA is required after the primary authentication factor is valid.
+    if ($mfaMethods['mfa_required'] === true) {
+        if (empty($dataReceived['user_2fa_selection']) === true) {
+            $session->set('mfa_primary_login_validated', [
+                'login' => $username,
+                'created_at' => time(),
+            ]);
+
+            echo prepareExchangedData(
+                [
+                    'value' => '2fa_not_set',
+                    'user_admin' => isset($sessionAdmin) ? (int) $sessionAdmin : 0,
+                    'initial_url' => isset($sessionUrl) === true ? $sessionUrl : '',
+                    'pwd_attempts' => (int) $sessionPwdAttempts,
+                    'error' => '2fa_not_set',
+                    'message' => $lang->get('select_valid_2fa_credentials'),
+                    'mfa_methods' => $mfaMethods,
+                ] + $mfaMethods,
+                'encode'
+            );
+            return false;
+        }
+
         // Check user against MFA method if selected
         $userMfa = identifyDoMFAChecks(
             $SETTINGS,
@@ -506,7 +584,9 @@ function identifyUser(string $sentData, array $SETTINGS): bool
                 [
                     'error' => true,
                     'message' => $userMfa['mfaData']['message'],
-                    'mfaStatus' => $userMfa['mfaData']['mfaStatus'],
+                    'mfaStatus' => $userMfa['mfaData']['mfaStatus'] ?? '',
+                    'ga_bad_code' => $userMfa['mfaData']['ga_bad_code'] ?? false,
+                    'mfa_error' => true,
                 ],
                 'encode'
             );
@@ -546,6 +626,7 @@ function identifyUser(string $sentData, array $SETTINGS): bool
             return false;
         }
     }
+    $session->remove('mfa_primary_login_validated');
 
     // Can connect if
     // 1- no LDAP mode + user enabled + pw ok
@@ -2792,31 +2873,6 @@ function identifyDoInitialChecks(
         is_null($SETTINGS['mfa_for_roles']) === true ? '' : (string) $SETTINGS['mfa_for_roles']
     );
 
-    // Check if 2FA code is requested
-    try {
-        $checks->is2faCodeRequired(
-            $SETTINGS['yubico_authentication'],
-            $SETTINGS['google_authentication'],
-            $SETTINGS['duo'],
-            $userInfo['admin'],
-            $SETTINGS['admin_2fa_required'],
-            $userInfo['mfa_auth_requested_roles'],
-            $user2faSelection,
-            $userInfo['mfa_enabled']
-        );
-    } catch (Exception $e) {
-        return [
-            'error' => true,
-            'array' => [
-                'value' => '2fa_not_set',
-                'user_admin' => (int) $sessionAdmin,
-                'initial_url' => $sessionUrl,
-                'pwd_attempts' => (int) $sessionPwdAttempts,
-                'error' => '2fa_not_set',
-                'message' => $lang->get('select_valid_2fa_credentials'),
-            ]
-        ];
-    }
     // If admin user then check if folder install exists
     // if yes then refuse connection
     try {
@@ -2921,6 +2977,7 @@ function identifyDoLDAPChecks(
                     'pwd_attempts' => (int) $sessionPwdAttempts,
                     'error' => true,
                     'message' => $errorMessage,
+                    'primary_auth_failed' => true,
                 ]
             ];
         }

--- a/tests/Stubs/auth_pure_functions.php
+++ b/tests/Stubs/auth_pure_functions.php
@@ -111,6 +111,29 @@ function identifyGetUserCredentials(
 }
 
 /**
+ * Count enabled MFA methods returned to the login form.
+ *
+ * @param array<string, mixed> $mfaMethods
+ */
+function countEnabledMfaMethods(array $mfaMethods): int
+{
+    return (int) (($mfaMethods['agses'] ?? false) === true)
+        + (int) (($mfaMethods['google'] ?? false) === true)
+        + (int) (($mfaMethods['yubico'] ?? false) === true)
+        + (int) (($mfaMethods['duo'] ?? false) === true);
+}
+
+/**
+ * Determine if Google MFA has enough data to challenge the user.
+ *
+ * @param array<string, mixed> $userInfo
+ */
+function googleMfaSecretExists(array $userInfo): bool
+{
+    return trim((string) ($userInfo['ga'] ?? '')) !== '';
+}
+
+/**
  * Return true when needle-based permission adjustments should be considered
  * for the given user.
  */

--- a/tests/Unit/LoginAuthenticationTest.php
+++ b/tests/Unit/LoginAuthenticationTest.php
@@ -471,6 +471,36 @@ class LoginAuthenticationTest extends TestCase
         $checks->is2faCodeRequired(0, 1, 0, 1, 1, true, '', true);
     }
 
+    public function testCountsEnabledMfaMethods(): void
+    {
+        $methods = [
+            'mfa_required' => true,
+            'agses' => false,
+            'google' => true,
+            'yubico' => true,
+            'duo' => false,
+        ];
+
+        $this->assertSame(2, countEnabledMfaMethods($methods));
+    }
+
+    public function testMissingMfaMethodKeysAreCountedAsDisabled(): void
+    {
+        $this->assertSame(1, countEnabledMfaMethods(['google' => true]));
+    }
+
+    public function testGoogleMfaSecretExistsWhenSecretIsPresent(): void
+    {
+        $this->assertTrue(googleMfaSecretExists(['ga' => 'ABCDEF123456']));
+    }
+
+    public function testGoogleMfaSecretDoesNotExistWhenSecretIsEmptyOrMissing(): void
+    {
+        $this->assertFalse(googleMfaSecretExists(['ga' => '']));
+        $this->assertFalse(googleMfaSecretExists(['ga' => '   ']));
+        $this->assertFalse(googleMfaSecretExists([]));
+    }
+
     // =========================================================================
     // 7. checkUserPasswordValidity — password expiry logic
     // =========================================================================


### PR DESCRIPTION
## Summary

This change updates the web login flow so MFA is requested only after the primary authentication factor has succeeded, and makes first-time Google Authenticator enrollment reliable for users whose roles require MFA.

Users with MFA enabled are no longer asked for a TOTP, Duo, or Yubico challenge when their password, LDAP bind, or OAuth2 authentication state is invalid.

## Problem

The login page previously called `get2FAMethodsForUser` with only the login name before submitting the real authentication request. That allowed the UI to show the MFA form before the password was validated.

As a result, users could enter a wrong password, be asked for MFA, and only then receive the final bad credentials error. This was confusing and also exposed user-specific MFA requirements before primary authentication.

In addition, accounts that inherit mandatory MFA from a role could reach the Google Authenticator step without an initialized Google secret or temporary enrollment code. In that state, the login flow could fail with a server error instead of starting the first-time MFA setup process.

## Changes

- Removed the pre-authentication MFA discovery step from `app/core/login.js.php`.
- Changed the login page to submit primary credentials first through `identify_user`.
- Moved the `2fa_not_set` response so it is returned only after LDAP, OAuth2, or local password authentication succeeds.
- Included the available MFA methods in the authenticated `2fa_not_set` response.
- Restricted `get2FAMethodsForUser` so it only returns user-specific MFA methods after a primary login factor was validated in the current session.
- Avoided recording the missing MFA selection as a failed authentication attempt.
- Reset the pending MFA UI when the primary credentials are changed or rejected.
- Automatically initializes first-time Google Authenticator enrollment after primary authentication succeeds when Google is the only available MFA method and the user has no Google secret yet.
- Sends the existing temporary Google MFA enrollment code email and surfaces the existing "email sent" feedback in the login UI.
- Hardened Google MFA validation so missing or inconsistent enrollment data returns a controlled setup error instead of causing a server error.
- Added focused unit coverage for the pure MFA helper logic used by this flow.

## Security Notes

This preserves the existing server-side MFA validation while improving the factor order:

1. Validate login and primary credentials.
2. If primary authentication fails, return bad credentials immediately.
3. If primary authentication succeeds and MFA is required, return the MFA challenge metadata.
4. Validate the MFA code or external MFA callback.

The user-specific MFA discovery endpoint no longer discloses MFA requirements before a valid primary factor has been presented.

The first-time Google Authenticator setup is only initialized after the primary factor is valid. It does not reset an existing Google secret, and repeated login attempts do not regenerate a new temporary code once enrollment data exists.

## Validation

- Reviewed the updated server flow to confirm `2fa_not_set` is emitted only after primary authentication succeeds.
- Verified the updated login JavaScript no longer calls `get2FAMethodsForUser` before submitting primary credentials.
- Reviewed the first-time Google MFA path to confirm a missing Google secret is initialized after password validation and before the MFA form is shown.
- Confirmed Google MFA validation now handles a missing secret with a controlled setup error.
- Added unit tests for MFA method counting and Google MFA secret detection in `tests/Unit/LoginAuthenticationTest.php`.
