### PR TITLE
Polish renewal utility page layout

### DIFF
--- a/app/pages/utilities.renewal.js.php
+++ b/app/pages/utilities.renewal.js.php
@@ -96,8 +96,11 @@ if ($checkUserAccess->checkSession() === false || $checkUserAccess->userAccessPa
         'orderCellsTop': true,
         'fixedHeader': true,
         'paging': true,
-        'sPaginationType': 'listbox',
+        'pagingType': 'simple_numbers',
         'searching': true,
+        'dom': "<'row renewal-table-controls align-items-center'<'col-md-6'l><'col-md-6'f>>" +
+            "<'renewal-table-shell table-responsive'tr>" +
+            "<'row renewal-table-footer align-items-center'<'col-md-6'i><'col-md-6'p>>",
         'order': [
             [0, 'asc']
         ],
@@ -155,12 +158,9 @@ if ($checkUserAccess->checkSession() === false || $checkUserAccess->userAccessPa
         });
 
 
-    $('#renewal-date').addClear({
-        symbolClass: "far fa-times-circle text-danger",
-        onClear: function() {
-            $('#renewal-date').datepicker('clearDates');
-            oTable.ajax.reload();
-        }
+    $('#clear-renewal-date').on('click', function() {
+        $('#renewal-date').datepicker('clearDates').val('');
+        oTable.ajax.reload();
     });
 
 

--- a/app/pages/utilities.renewal.php
+++ b/app/pages/utilities.renewal.php
@@ -85,6 +85,211 @@ header('Cache-Control: no-cache, no-store, must-revalidate');
 
 ?>
 
+<style>
+    #renewal-page .renewal-card {
+        border-radius: .35rem;
+        overflow: hidden;
+    }
+
+    #renewal-page .renewal-toolbar {
+        align-items: center;
+        background-color: #ffffff;
+        border-bottom: 1px solid #e5e9ef;
+        display: flex;
+        gap: 1rem;
+        justify-content: space-between;
+        padding: 1rem;
+    }
+
+    #renewal-page .renewal-info {
+        align-items: center;
+        color: #3f4b57;
+        display: flex;
+        min-width: 0;
+    }
+
+    #renewal-page .renewal-info-icon {
+        align-items: center;
+        background-color: #e8f6f9;
+        border-radius: 50%;
+        color: #138496;
+        display: inline-flex;
+        flex: 0 0 32px;
+        height: 32px;
+        justify-content: center;
+        margin-right: .75rem;
+        width: 32px;
+    }
+
+    #renewal-page .renewal-date-filter {
+        flex: 0 0 360px;
+        max-width: 100%;
+    }
+
+    #renewal-page .renewal-date-label {
+        color: #3f4b57;
+        font-weight: 600;
+        margin-bottom: .35rem;
+    }
+
+    #renewal-page .renewal-date-filter .input-group-text,
+    #renewal-page .renewal-date-filter .btn,
+    #renewal-page .renewal-date-filter .form-control {
+        height: calc(1.8125rem + 2px);
+    }
+
+    #renewal-page .renewal-date-filter .btn {
+        align-items: center;
+        display: inline-flex;
+        justify-content: center;
+        min-width: 36px;
+    }
+
+    #renewal-page .renewal-table-section {
+        padding: 1rem;
+    }
+
+    #renewal-page .renewal-table-controls {
+        background-color: #f8fafc;
+        border: 1px solid #e5e9ef;
+        border-bottom: 0;
+        border-radius: .35rem .35rem 0 0;
+        margin: 0;
+        padding: .75rem 1rem;
+    }
+
+    #renewal-page .renewal-table-shell {
+        border: 1px solid #e5e9ef;
+        border-radius: 0;
+        overflow: hidden;
+    }
+
+    #renewal-page .renewal-table-footer {
+        background-color: #ffffff;
+        border: 1px solid #e5e9ef;
+        border-radius: 0 0 .35rem .35rem;
+        border-top: 0;
+        margin: 0;
+        padding: .75rem 1rem;
+    }
+
+    #renewal-page #table-renewal {
+        margin-bottom: 0 !important;
+    }
+
+    #renewal-page #table-renewal thead th {
+        background-color: #f3f5f7;
+        border-bottom: 1px solid #d9dee5;
+        border-top: 0;
+        color: #343a40;
+        font-weight: 600;
+        padding: .75rem;
+    }
+
+    #renewal-page #table-renewal tbody td {
+        padding: .85rem .75rem;
+        vertical-align: middle;
+    }
+
+    #renewal-page .dataTables_length label,
+    #renewal-page .dataTables_filter label {
+        align-items: center;
+        color: #3f4b57;
+        display: flex;
+        font-weight: 600;
+        margin-bottom: 0;
+    }
+
+    #renewal-page .dataTables_length select,
+    #renewal-page .dataTables_filter input {
+        border: 1px solid #ced4da;
+        border-radius: .2rem;
+        display: inline-block;
+        font-size: .875rem;
+        height: calc(1.8125rem + 2px);
+        padding: .25rem .5rem;
+        width: auto !important;
+    }
+
+    #renewal-page .dataTables_length select {
+        margin: 0 .5rem;
+        min-width: 72px;
+    }
+
+    #renewal-page .dataTables_filter {
+        text-align: right;
+    }
+
+    #renewal-page .dataTables_filter label {
+        justify-content: flex-end;
+    }
+
+    #renewal-page .dataTables_filter input {
+        margin-left: .5rem;
+        min-width: 220px;
+    }
+
+    #renewal-page .dataTables_info {
+        color: #6c757d;
+        padding-top: .25rem;
+    }
+
+    #renewal-page .dataTables_paginate {
+        text-align: right;
+    }
+
+    #renewal-page .dataTables_paginate .pagination {
+        justify-content: flex-end;
+        margin-bottom: 0;
+    }
+
+    #renewal-page .dataTables_empty {
+        background-color: #fbfcfd;
+        color: #6c757d;
+        padding: 1.5rem .75rem !important;
+    }
+
+    @media (max-width: 991.98px) {
+        #renewal-page .renewal-toolbar {
+            align-items: stretch;
+            flex-direction: column;
+        }
+
+        #renewal-page .renewal-date-filter {
+            flex-basis: auto;
+        }
+    }
+
+    @media (max-width: 767.98px) {
+        #renewal-page .dataTables_filter {
+            margin-top: .75rem;
+            text-align: left;
+        }
+
+        #renewal-page .dataTables_filter label {
+            align-items: flex-start;
+            flex-direction: column;
+            justify-content: flex-start;
+        }
+
+        #renewal-page .dataTables_filter input {
+            margin-left: 0;
+            margin-top: .35rem;
+            min-width: 0;
+            width: 100% !important;
+        }
+
+        #renewal-page .dataTables_paginate {
+            margin-top: .75rem;
+            text-align: left;
+        }
+
+        #renewal-page .dataTables_paginate .pagination {
+            justify-content: flex-start;
+        }
+    }
+</style>
+
 <!-- Content Header (Page header) -->
 <div class="content-header">
     <div class="container-fluid">
@@ -99,47 +304,43 @@ header('Cache-Control: no-cache, no-store, must-revalidate');
 
 
 <!-- Main content -->
-<div class="content">
+<div class="content" id="renewal-page">
     <div class="container-fluid">
         <div class="row">
             <div class="col-lg-12">
-                <div class="card card-outline card-primary">
-                    <div class="card-header">
-                        <h3 class="card-title">
-                            <i class="fas fa-clock mr-2"></i><?php echo $lang->get('renewal'); ?>
-                        </h3>
-                    </div>
-                    <div class="card-body">
-                        <div class="callout callout-info mb-3">
-                            <div class="d-flex align-items-start">
-                                <i class="fas fa-lightbulb text-info fa-lg mr-3 mt-1"></i>
-                                <div><?php echo $lang->get('renewal_page_info'); ?></div>
-                            </div>
+                <div class="card card-outline card-primary shadow-sm renewal-card">
+                    <div class="renewal-toolbar">
+                        <div class="renewal-info">
+                            <span class="renewal-info-icon">
+                                <i class="fas fa-lightbulb"></i>
+                            </span>
+                            <span><?php echo $lang->get('renewal_page_info'); ?></span>
                         </div>
-
-                        <div class="row align-items-end mb-3">
-                            <div class="col-md-6 col-lg-4">
-                                <label for="renewal-date"><?php echo $lang->get('select_date_showing_items_expiration'); ?></label>
-                                <div class="input-group date">
-                                    <div class="input-group-prepend">
-                                        <span class="input-group-text"><i class="fas fa-calendar-day"></i></span>
-                                    </div>
-                                    <input type="text" class="form-control" id="renewal-date" autocomplete="off">
+                        <div class="renewal-date-filter">
+                            <label class="renewal-date-label" for="renewal-date"><?php echo $lang->get('select_date_showing_items_expiration'); ?></label>
+                            <div class="input-group input-group-sm date">
+                                <div class="input-group-prepend">
+                                    <span class="input-group-text"><i class="fas fa-calendar-day"></i></span>
+                                </div>
+                                <input type="text" class="form-control" id="renewal-date" autocomplete="off">
+                                <div class="input-group-append">
+                                    <button type="button" class="btn btn-outline-secondary" id="clear-renewal-date" aria-label="Clear date">
+                                        <i class="fas fa-times"></i>
+                                    </button>
                                 </div>
                             </div>
                         </div>
-
-                        <div class="table-responsive">
-                            <table class="table table-striped table-hover table-responsive-sm nowrap" id="table-renewal" style="width:100%;">
-                                <thead>
-                                    <tr>
-                                        <th><?php echo $lang->get('label'); ?></th>
-                                        <th><?php echo $lang->get('expiration_date'); ?></th>
-                                        <th><?php echo $lang->get('folder'); ?></th>
-                                    </tr>
-                                </thead>
-                            </table>
-                        </div>
+                    </div>
+                    <div class="renewal-table-section">
+                        <table class="table table-striped table-hover nowrap" id="table-renewal" style="width:100%;">
+                            <thead>
+                                <tr>
+                                    <th><?php echo $lang->get('label'); ?></th>
+                                    <th><?php echo $lang->get('expiration_date'); ?></th>
+                                    <th><?php echo $lang->get('folder'); ?></th>
+                                </tr>
+                            </thead>
+                        </table>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
## Summary

This change improves the visual layout of the Renewal utility page without changing the renewal expiration logic.

The page keeps the existing behavior introduced for issue #5212, but presents the information, date filter, table controls, and results in a cleaner AdminLTE-style layout.

## Problem

The Renewal page was functional but visually uneven:

- the page title and card title repeated the same label;
- the help message, date filter, and DataTables controls were loosely arranged;
- the DataTables listbox pagination rendered poorly in this view;
- the table controls did not feel aligned with the rest of the TeamPass administration UI.

This made the page look unfinished even though the underlying expiration listing was working.

## Changes

- Simplified the Renewal card by removing the duplicate inner title.
- Grouped the informational message and expiration date filter in a compact top toolbar.
- Scoped Renewal-specific styling to `#renewal-page`.
- Reworked the DataTables `dom` layout so length, search, table, info, and pagination are placed as one consistent table block.
- Replaced the listbox pagination style with the standard simple-number pagination.
- Constrained the generated DataTables controls so the page no longer shows oversized select/search fields.
- Replaced the external date clear icon with an integrated input-group button aligned with the date field.
- Kept the existing server-side search, date filter, and renewal listing logic unchanged.

## Validation

- Confirmed the Renewal table still has the same three columns: item label, expiration date, and folder path.
- Confirmed the DataTables AJAX callback still preserves server-side request parameters and only adds `dateCriteria` when a date is selected.
- Confirmed no expiration query or cache logic was modified.
