### PR TITLE
Enhance CSS for backups tables and indicators

### DIFF
--- a/public/assets/css/backups.css
+++ b/public/assets/css/backups.css
@@ -1,3 +1,44 @@
 /* Fun restore progress: a little cat that moves along the progress bar */
 .tp-restore-progress-track { position: relative; overflow: visible; }
 .tp-restore-progress-cat { position: absolute; top: -18px; left: 2%; transform: translateX(-50%); font-size: 18px; }
+
+#scheduled-backups-table,
+#externalized-backups-table {
+    min-width: 560px;
+}
+
+#scheduled-backups-table th:first-child,
+#scheduled-backups-table td:first-child,
+#externalized-backups-table th:first-child,
+#externalized-backups-table td:first-child {
+    min-width: 190px;
+}
+
+#scheduled-backups-table th:nth-child(2),
+#scheduled-backups-table td:nth-child(2),
+#externalized-backups-table th:nth-child(2),
+#externalized-backups-table td:nth-child(2) {
+    min-width: 90px;
+}
+
+#scheduled-backups-table th:nth-child(3),
+#scheduled-backups-table td:nth-child(3),
+#externalized-backups-table th:nth-child(3),
+#externalized-backups-table td:nth-child(3) {
+    min-width: 135px;
+}
+
+#scheduled-backups-table th:nth-child(4),
+#scheduled-backups-table td:nth-child(4),
+#externalized-backups-table th:nth-child(4),
+#externalized-backups-table td:nth-child(4) {
+    width: 86px;
+}
+
+.tp-backup-documents-indicator {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 1.25rem;
+    vertical-align: middle;
+}


### PR DESCRIPTION
## Summary

This change improves the visual alignment of the documents indicator in the backup lists.

The backup lists keep the same data and behavior, but the documents icon now has reserved space and no longer visually overlaps the backup size column on standard desktop layouts.

## Problem

On the scheduled and externalized backup tabs, backups containing documents display a paperclip indicator next to the backup date.

Because these lists are displayed inside a half-width administration card, the date column could become too narrow. The indicator then appeared too close to, or visually over, the backup size column.

The on-the-fly backup list uses a different layout and was not affected in the same way.

## Changes

- Added backup-list-specific CSS in `public/assets/css/backups.css`.
- Reserved a minimum width for the scheduled and externalized backup tables.
- Reserved stable widths for the Date, Size, TeamPass version, and Action columns in those two tables.
- Gave the documents indicator a stable inline width so it keeps a clean visual gap from the next column.
- Kept the existing tooltip and language strings unchanged.
- Kept the existing backup listing, restore selection, download, and delete behavior unchanged.

## Files Changed

- `public/assets/css/backups.css`

## Validation

- Reviewed the scheduled backup table markup and row rendering.
- Reviewed the externalized backup table markup and row rendering.
- Confirmed the documents indicator still uses the existing `bck_backup_contains_documents` language string.
- Confirmed no PHP, AJAX, backup metadata, restore, download, or delete logic was modified.

No automated test was run because this is a scoped CSS-only visual adjustment.
