### PR TITLE
Restore admin update notification styling

### DIFF
--- a/app/core/load.js.php
+++ b/app/core/load.js.php
@@ -112,16 +112,22 @@ if (
     );
 
     /**
-     * Apply version badge data to the DOM element.
-     * Hides the badge when no update is available or data is invalid.
+     * Apply latest release notification data to the sidebar badge and admin dashboard alert.
+     * Hides both notification surfaces when no update is available or data is invalid.
      *
      * @param {jQuery} $badge
      * @param {object} data  - decoded server response
      * @returns {void}
      */
-    function applyVersionBadge($badge, data) {
+    function applyVersionNotifications($badge, data) {
+        const $adminAlert = $('#tp-admin-version-alert');
+        const $adminAlertText = $adminAlert.find('.tp-admin-version-alert-text');
+        const $adminAlertLink = $('#tp-admin-version-link');
+
         if (
-            data.error === true
+            data === null
+            || typeof data !== 'object'
+            || data.error === true
             || data.has_update !== true
             || typeof data.latest_version !== 'string'
             || data.latest_version.length === 0
@@ -129,6 +135,7 @@ if (
             || data.release_url.length === 0
         ) {
             $badge.addClass('d-none').tooltip('dispose');
+            $adminAlert.addClass('d-none');
             return;
         }
 
@@ -136,13 +143,26 @@ if (
         tooltipText = tooltipText.replace('%s', data.latest_version);
 
         $badge
-            .text(<?php echo json_encode($lang->get('admin_update_badge')); ?>)
+            .empty()
+            .append($('<i>', {'class': 'fas fa-circle-up', 'aria-hidden': 'true'}))
+            .append($('<span>').text(<?php echo json_encode($lang->get('admin_update_badge')); ?>))
             .attr('href', data.release_url)
             .attr('title', tooltipText)
             .attr('aria-label', tooltipText)
             .removeClass('d-none')
             .tooltip('dispose')
             .tooltip({container: 'body'});
+
+        if ($adminAlert.length > 0) {
+            let alertText = <?php echo json_encode($lang->get('admin_new_version_alert')); ?>;
+            alertText = alertText.replace('%s', data.latest_version);
+
+            $adminAlertText.text(alertText);
+            $adminAlertLink
+                .text(<?php echo json_encode($lang->get('admin_view_release')); ?>)
+                .attr('href', data.release_url);
+            $adminAlert.removeClass('d-none');
+        }
     }
 
     /**
@@ -172,7 +192,7 @@ if (
                     && typeof cached === 'object'
                     && (Date.now() - cached.ts) < CACHE_TTL
                 ) {
-                    applyVersionBadge($badge, cached.data);
+                    applyVersionNotifications($badge, cached.data);
                     return;
                 }
             }
@@ -201,7 +221,7 @@ if (
                     // Quota exceeded or unavailable — ignore
                 }
 
-                applyVersionBadge($badge, data);
+                applyVersionNotifications($badge, data);
             }
         );
     }

--- a/app/includes/language/english.php
+++ b/app/includes/language/english.php
@@ -2339,6 +2339,8 @@ return array(
     'email_body_on_user_lock' => 'Hello,<br><br>This is a generated email from TeamPass.<br><br>User account <b>#tp_user#</b> has been locked by the anti brute force protection on #tp_date# at #tp_time#.<br><br>Details:<ul><li>Name: #tp_name#</li><li>Email: #tp_email#</li><li>Source IP: #tp_ip#</li><li>Automatic unlock at: #tp_unlock_at#</li></ul><br>Regards.',
     'admin_update_badge' => 'Update',
     'admin_new_version_available' => 'version %s available',
+    'admin_new_version_alert' => 'New TeamPass version available: %s',
+    'admin_view_release' => 'View release',
     'passphrase_generate' => 'Generate a passphrase',
     'passphrase_options' => 'Passphrase options',
     'passphrase_words' => 'Words',

--- a/app/includes/language/french.php
+++ b/app/includes/language/french.php
@@ -2092,6 +2092,8 @@ return array(
     'not_secure' => 'Non sécurisé',
     'admin_update_badge' => 'Mise à jour',
     'admin_new_version_available' => 'version %s disponible',
+    'admin_new_version_alert' => 'Nouvelle version TeamPass disponible : %s',
+    'admin_view_release' => 'Voir la release',
     'passphrase_generate' => 'Générer une phrase de passe',
     'passphrase_options' => 'Options de la phrase de passe',
     'passphrase_words' => 'Mots',

--- a/app/pages/admin.php
+++ b/app/pages/admin.php
@@ -127,6 +127,11 @@ $extensionHasLicence = $extensionLicenceKey !== '';
                             <?php echo $lang->get('admin_view_changelog_github'); ?>
                         </a>
                     </span>
+                    <div id="tp-admin-version-alert" class="tp-admin-version-alert d-none" role="status" aria-live="polite">
+                        <i class="fas fa-circle-up mr-2" aria-hidden="true"></i>
+                        <span class="tp-admin-version-alert-text"></span>
+                        <a id="tp-admin-version-link" href="#" target="_blank" rel="noopener noreferrer" class="tp-admin-version-alert-link ml-2"></a>
+                    </div>
                 </div>
             </div>
             <div class="col-5">

--- a/public/assets/css/teampass.css
+++ b/public/assets/css/teampass.css
@@ -267,6 +267,124 @@
     bottom: 0px;
 }
 
+.tp-brand-link {
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+    min-height: 57px;
+    overflow: hidden;
+}
+
+.tp-brand-home-link {
+    display: flex;
+    align-items: center;
+    min-width: 0;
+    flex: 1 1 auto;
+    overflow: hidden;
+    color: inherit;
+    text-decoration: none !important;
+}
+
+.tp-brand-home-link:hover,
+.tp-brand-home-link:focus {
+    color: inherit;
+    text-decoration: none !important;
+}
+
+.tp-brand-home-link .brand-image {
+    float: none;
+    position: static;
+    margin: 0 0.5rem 0 0.2rem;
+    flex: 0 0 auto;
+}
+
+.tp-brand-home-link .brand-text {
+    display: block;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.tp-sidebar-version-badge {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.25rem;
+    min-height: 22px;
+    max-width: 92px;
+    padding: 2px 7px;
+    margin-right: 8px;
+    border-radius: 999px;
+    flex: 0 0 auto;
+    overflow: hidden;
+    font-size: 0.72rem;
+    font-weight: 700;
+    line-height: 1;
+    white-space: nowrap;
+    color: #212529 !important;
+    background: #ffc107;
+    box-shadow: inset 0 0 0 1px rgba(33, 37, 41, 0.08);
+    text-decoration: none !important;
+}
+
+.tp-sidebar-version-badge span {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.tp-sidebar-version-badge:hover,
+.tp-sidebar-version-badge:focus {
+    color: #212529 !important;
+    background: #e0a800;
+    text-decoration: none !important;
+}
+
+.sidebar-collapse .tp-sidebar-version-badge,
+.sidebar-closed .tp-sidebar-version-badge {
+    display: none !important;
+}
+
+.tp-admin-version-alert {
+    display: inline-flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 0.25rem;
+    vertical-align: middle;
+    max-width: 100%;
+    margin: 0 0 0 0.7rem;
+    padding: 0.22rem 0.5rem;
+    border: 1px solid rgba(255, 255, 255, 0.35);
+    border-radius: 0.2rem;
+    background: rgba(255, 255, 255, 0.12);
+    color: rgba(255, 255, 255, 0.95);
+    font-size: 0.86rem;
+    line-height: 1.25;
+}
+
+.tp-admin-version-alert i {
+    margin-right: 0 !important;
+    opacity: 0.85;
+    font-size: 0.8rem;
+}
+
+.tp-admin-version-alert-link {
+    margin-left: 0.2rem !important;
+    color: #fff !important;
+    font-weight: 600;
+    text-decoration: underline;
+    text-decoration-thickness: 1px;
+    text-underline-offset: 2px;
+    white-space: nowrap;
+}
+
+.tp-admin-version-alert-link:hover,
+.tp-admin-version-alert-link:focus {
+    color: #fff !important;
+    text-decoration: underline;
+}
+
 #sidebar-footer {
     display: flex;
     align-items: center;
@@ -398,6 +516,10 @@
 }
 
 @media (max-width: 767.98px) {
+    .tp-sidebar-version-badge {
+        display: none !important;
+    }
+
     .tp-online-users-drawer {
         width: min(340px, calc(100vw - 1rem));
     }


### PR DESCRIPTION
## Summary

This PR restores and refines the visual notification shown to administrators when a newer TeamPass release is available.

The backend release check and sidebar badge hook were already present in the current codebase, but the dedicated styling from the original implementation had been lost. As a result, the update notice appeared as plain text next to the TeamPass brand in the admin sidebar. This change restores the intended compact sidebar badge and adds a subtle dashboard reminder inside the existing administration information panel.

Related historical work: https://github.com/nilsteampassnet/TeamPass/pull/5146

## Context

The current version still exposes the admin-only latest release check through `get_teampass_latest_release`, and the sidebar markup already contains the `tp-sidebar-version-badge` element. However, without the matching CSS and with limited DOM handling, the UI no longer looked integrated with the current AdminLTE-based layout.

The existing sidebar badge placeholder in `public/index.php` is reused as-is and is not changed by this PR.

This PR focuses on restoring the visual quality of that feature while keeping the existing behavior and release-checking flow intact.

## Changes

- Restored the TeamPass sidebar brand layout so the logo, product name, and update badge align correctly.
- Reintroduced a compact admin-only update badge in the sidebar.
- Added an icon and accessible label to the sidebar badge from JavaScript when an update is available.
- Added a discreet update reminder inside the admin dashboard information block, next to the GitHub changelog link.
- Styled the dashboard reminder to match the existing turquoise dashboard panel instead of using a strong warning-style alert.
- Added defensive handling for invalid or empty cached/AJAX release responses.
- Added English and French translation strings for the dashboard reminder.

## User Experience

When no update is available, nothing is displayed and the interface remains unchanged.

When an update is available:

- Administrators see a compact "Update" badge in the sidebar brand area.
- The badge links directly to the GitHub release page.
- The badge is hidden when the sidebar is collapsed or on small screens to avoid layout issues.
- The administration dashboard shows a subtle inline reminder in the existing information panel.
- The dashboard reminder uses a translucent style that blends with the current dashboard design.

## Files Changed

- `app/core/load.js.php`
  - Applies latest-release data to both the sidebar badge and dashboard reminder.
  - Safely hides both notification surfaces when data is missing, invalid, or when no update is available.
  - Builds badge content with an icon, label, tooltip, and accessible label.

- `app/pages/admin.php`
  - Adds the hidden dashboard reminder container inside the existing admin information block.

- `public/assets/css/teampass.css`
  - Restores sidebar brand and update badge styling.
  - Adds responsive rules for the sidebar badge.
  - Adds the subtle dashboard reminder styling.

- `app/includes/language/english.php`
  - Adds dashboard reminder labels.

- `app/includes/language/french.php`
  - Adds dashboard reminder labels.

## Validation

- Checked that all JavaScript selectors for the sidebar badge and dashboard reminder are present.
- Checked that the previous badge application function is no longer referenced.
- Checked that the selected FontAwesome icon is available in the bundled FontAwesome assets.
- Confirmed the language system falls back to English for languages that do not yet define the new keys.

## Risk and Compatibility

Risk is low. The release-checking backend behavior is unchanged, and the feature remains admin-only through the existing markup and AJAX endpoint access checks.

The UI changes are scoped to:

- The sidebar brand area.
- The admin dashboard information panel.
- The latest release notification rendering logic.

Non-admin users should not see any change.

## Possible Follow-up

A future improvement could add an administration setting to disable external GitHub release checks for instances deployed in restricted or offline environments.
