### PR TITLE
Add responsive search to the api users tab

### DIFF
--- a/app/pages/api.js.php
+++ b/app/pages/api.js.php
@@ -83,6 +83,29 @@ if ($checkUserAccess->checkSession() === false || $checkUserAccess->userAccessPa
 
     $('[data-mask]').inputmask();
 
+    function filterApiUsersTable() {
+        const criteria = ($('#api-users-search').val() || '').toString().trim().toLowerCase();
+        const $rows = $('#table-api-keys tbody tr');
+        let visibleRows = 0;
+
+        $rows.each(function() {
+            const userIdentity = $(this).find('td:first').text().toLowerCase();
+            const isVisible = criteria === '' || userIdentity.indexOf(criteria) !== -1;
+
+            $(this).toggleClass('hidden', isVisible === false);
+            if (isVisible === true) {
+                visibleRows++;
+            }
+        });
+
+        $('#api-search-no-results').toggleClass(
+            'hidden',
+            criteria === '' || visibleRows > 0 || $rows.length === 0
+        );
+    }
+
+    $(document).on('input keyup search', '#api-users-search', filterApiUsersTable);
+
     /**
      * TOGGLE API STATUS (ENABLED/DISABLED)
      */

--- a/app/pages/api.php
+++ b/app/pages/api.php
@@ -217,32 +217,46 @@ function getDomainFromSettingsUrl(string $url): string
 
                         <div class="tab-content">
                             <div class="tab-pane fade show active" id="users" role="tabpanel" aria-labelledby="keys-tab">
+                                <?php
+                                $rowsKeys = DB::query(
+                                    'SELECT a.*, u.name, u.lastname, u.login
+                                    FROM ' . prefixTable('api') . ' AS a
+                                    INNER JOIN ' . prefixTable('users') . ' AS u ON a.user_id = u.id
+                                    WHERE a.type = %s AND u.disabled = %i AND u.deleted_at IS NULL AND u.id NOT IN %li AND u.admin = %i
+                                    ORDER BY u.login ASC',
+                                    'user',
+                                    0,
+                                    [API_USER_ID, SSH_USER_ID, SSH_USER_ID, TP_USER_ID],
+                                    0
+                                );
+                                $apiKeysCount = count($rowsKeys);
+                                ?>
                                 <div class="row mb-4 mt-4">
-                                    <div class="col-6 text-muted">
+                                    <div class="col-12 col-lg-8 text-muted mb-2 mb-lg-0">
                                         <?php echo $lang->get('users_api_access_info'); ?>
                                     </div>
-                                    <div class="col-6">
+                                    <div class="col-12 col-lg-4 text-lg-right">
                                         <button type="button" class="btn btn-default pointer infotip" title="<?php echo $lang->get('build_missing_api_keys'); ?>" id="button-refresh-users-api">
                                             <i class="fas fa-sync-alt"></i>
                                         </button>
                                     </div>
                                 </div>
+
+                                <div class="row mb-3<?php echo $apiKeysCount > 0 ? '' : ' hidden'; ?>">
+                                    <div class="col-12 col-lg-6">
+                                        <div class="input-group input-group-sm">
+                                            <div class="input-group-prepend">
+                                                <div class="input-group-text">
+                                                    <i class="fas fa-search"></i>
+                                                </div>
+                                            </div>
+                                            <input type="search" class="form-control" placeholder="<?php echo $lang->get('find'); ?>" aria-label="<?php echo $lang->get('find'); ?>" id="api-users-search">
+                                        </div>
+                                    </div>
+                                </div>
                                 
                                 <div class="mt-4">
-                                    <?php
-                                    $rowsKeys = DB::query(
-                                        'SELECT a.*, u.name, u.lastname, u.login
-                                        FROM ' . prefixTable('api') . ' AS a
-                                        INNER JOIN ' . prefixTable('users') . ' AS u ON a.user_id = u.id
-                                        WHERE a.type = %s AND u.disabled = %i AND u.deleted_at IS NULL AND u.id NOT IN %li AND u.admin = %i
-                                        ORDER BY u.login ASC',
-                                        'user',
-                                        0,
-                                        [API_USER_ID, SSH_USER_ID, SSH_USER_ID, TP_USER_ID],
-                                        0
-                                    );
-                                    ?>
-                                    <table class="table table-hover table-striped<?php echo DB::count() > 0 ? '' : ' hidden'; ?> table-responsive" style="width:100%" id="table-api-keys">
+                                    <table class="table table-hover table-striped<?php echo $apiKeysCount > 0 ? '' : ' hidden'; ?> table-responsive" style="width:100%" id="table-api-keys">
                                         <thead>
                                             <tr>
                                                 <th><?php echo $lang->get('user'); ?></th>
@@ -269,7 +283,11 @@ function getDomainFromSettingsUrl(string $url): string
                                         </tbody>
                                     </table>
 
-                                    <div class="mt-2<?php echo DB::count() > 0 ? ' hidden' : ''; ?>" id="api-no-keys">
+                                    <div class="mt-2 hidden" id="api-search-no-results">
+                                        <i class="fas fa-info mr-2 text-warning"></i><?php echo $lang->get('no_item_to_display'); ?>
+                                    </div>
+
+                                    <div class="mt-2<?php echo $apiKeysCount > 0 ? ' hidden' : ''; ?>" id="api-no-keys">
                                         <i class="fas fa-info mr-2 text-warning"></i><?php echo $lang->get('no_data_defined'); ?>
                                     </div>
 


### PR DESCRIPTION
## Summary

This change adds a small client-side search experience to the API configuration page, inside the users tab. Administrators can now quickly filter the API users list without relying on the browser search shortcut.

## Implementation Details

- Added a responsive, left-aligned Bootstrap search input to the API users tab in `app/pages/api.php`.
- Reused the existing localized `find` label for the search placeholder and accessible label.
- Reused the existing localized `no_item_to_display` label for the empty filtered state.
- Moved the API users query before the users tab toolbar so the search input can be hidden when no API user rows exist.
- Kept the missing API keys recovery action visually separate from the search input to avoid suggesting that the recovery action submits the search.
- Added a local table filter in `app/pages/api.js.php` that matches the visible user identity column, including first name, last name, and login.
- Kept the existing "Build missing API keys for users" recovery button unchanged.

## Behavior

- When the search field is empty, all API user rows are displayed.
- When a search term is entered, only matching user rows remain visible.
- When no user matches the current search term, the table remains in place and a localized "No items to display" message is shown.
- No database query, API permission, token, or key-generation behavior was changed.

## Notes

The existing API users SQL exclusion list currently contains `SSH_USER_ID` twice and does not include `OTV_USER_ID`. That looks like a pre-existing typo in the system-account exclusion list, but it is intentionally left out of this PR to keep this change focused on the search improvement.

The "Build missing API keys for users" button was also left in place. It still acts as a backfill/recovery action for active non-admin users that have a public key but no matching `teampass_api` row.
