### PR TITLE
Keep item cache synchronized after api writes

### DIFF
--- a/app/api/Model/ItemModel.php
+++ b/app/api/Model/ItemModel.php
@@ -280,6 +280,8 @@ class ItemModel
             // Step 9: Handle post-insert tasks (logging, sharing, tagging, custom fields)
             $this->handlePostInsertTasks($newID, $itemInfos, $folderId, $passwordKey, $userId, $username, $tags, $fields, $data, $SETTINGS);
 
+            updateCacheTable('add_value', $newID, $userId);
+
             // Notify WebSocket subscribers so other users viewing this folder see the new item
             emitItemEvent('created', $newID, $folderId, $label, $username, $userId);
 
@@ -1350,6 +1352,8 @@ class ItemModel
             $label = isset($updateData['label']) ? $updateData['label'] : $currentItem['label'];
             logItems($SETTINGS, $itemId, $label, $userData['id'], 'at_modification', $userData['username']);
 
+            updateCacheTable('update_value', $itemId, (int) $userData['id']);
+
             // Success response
             return [
                 'error' => false,
@@ -1412,6 +1416,8 @@ class ItemModel
             );
 
             logItems($SETTINGS, $itemId, $currentItem['label'], $userData['id'], 'at_delete', $userData['username']);
+
+            updateCacheTable('delete_value', $itemId);
 
             // Success response
             return [

--- a/app/sources/main.functions.php
+++ b/app/sources/main.functions.php
@@ -656,20 +656,21 @@ function identUserGetPFList(
  *
  * @param string $action   What to do
  * @param int    $ident    Ident format
+ * @param int    $authorId User id to store as cache author. Useful outside web sessions.
  *
  * @return void
  */
-function updateCacheTable(string $action, ?int $ident = null): void
+function updateCacheTable(string $action, ?int $ident = null, ?int $authorId = null): void
 {
     if ($action === 'reload') {
         // Rebuild full cache table
         cacheTableRefresh();
     } elseif ($action === 'update_value' && is_null($ident) === false) {
         // UPDATE an item
-        cacheTableUpdate($ident);
+        cacheTableUpdate($ident, $authorId);
     } elseif ($action === 'add_value' && is_null($ident) === false) {
         // ADD an item
-        cacheTableAdd($ident);
+        cacheTableAdd($ident, $authorId);
     } elseif ($action === 'delete_value' && is_null($ident) === false) {
         // DELETE an item
         DB::delete(prefixTable('cache'), 'id = %i', $ident);
@@ -781,13 +782,27 @@ function cacheTableRefresh(): void
  * Cache table - update existing value.
  *
  * @param int    $ident    Ident format
+ * @param int    $authorId User id to store as cache author. Useful outside web sessions.
  * 
  * @return void
  */
-function cacheTableUpdate(?int $ident = null): void
+function cacheTableUpdate(?int $ident = null, ?int $authorId = null): void
 {
-    $session = SessionManager::getSession();
+    $cacheAuthorId = $authorId;
+    if ($cacheAuthorId === null) {
+        $session = SessionManager::getSession();
+        $cacheAuthorId = (int) $session->get('user-id');
+    }
+
     loadClasses('DB');
+
+    if ((int) DB::queryFirstField(
+        'SELECT COUNT(*) FROM ' . prefixTable('cache') . ' WHERE id = %i',
+        $ident
+    ) === 0) {
+        cacheTableAdd($ident, $authorId);
+        return;
+    }
 
     //Load Tree
     $tree = new NestedTree(prefixTable('nested_tree'), 'id', 'parent_id', 'title');
@@ -855,7 +870,7 @@ function cacheTableUpdate(?int $ident = null): void
             'restricted_to' => isset($data['restricted_to']) && ! empty($data['restricted_to']) ? $data['restricted_to'] : '0',
             'login' => $data['login'] ?? '',
             'folder' => implode(' » ', $folder),
-            'author' => $session->get('user-id'),
+            'author' => $cacheAuthorId,
             'renewal_period' => $data['renewal_period'] ?? '0',
             'timestamp' => $data['date'] ?? '0',
         ],
@@ -868,13 +883,17 @@ function cacheTableUpdate(?int $ident = null): void
  * Cache table - add new value.
  *
  * @param int    $ident    Ident format
+ * @param int    $authorId User id to store as cache author. Useful outside web sessions.
  * 
  * @return void
  */
-function cacheTableAdd(?int $ident = null): void
+function cacheTableAdd(?int $ident = null, ?int $authorId = null): void
 {
-    $session = SessionManager::getSession();
-    $globalsUserId = $session->get('user-id');
+    $cacheAuthorId = $authorId;
+    if ($cacheAuthorId === null) {
+        $session = SessionManager::getSession();
+        $cacheAuthorId = (int) $session->get('user-id');
+    }
 
     // Load class DB
     loadClasses('DB');
@@ -946,7 +965,7 @@ function cacheTableAdd(?int $ident = null): void
             'restricted_to' => isset($data['restricted_to']) && empty($data['restricted_to']) === false ? $data['restricted_to'] : '0',
             'login' => $data['login'] ?? '',
             'folder' => implode(' » ', $folder),
-            'author' => $globalsUserId,
+            'author' => $cacheAuthorId,
             'renewal_period' => $data['renewal_period'] ?? '0',
             'timestamp' => $data['date'],
         ]
@@ -9077,4 +9096,3 @@ function checkPasswordWithHIBP(string $password): array
 
     return ['pwned' => false, 'count' => 0];
 }
-

--- a/tests/Unit/Api/ApiItemCacheSyncTest.php
+++ b/tests/Unit/Api/ApiItemCacheSyncTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Static regression guards for API writes keeping the item cache synchronized.
+ */
+class ApiItemCacheSyncTest extends TestCase
+{
+    private function readSource(string $relativePath): string
+    {
+        $path = __DIR__ . '/../../..' . $relativePath;
+        self::assertFileExists($path, "Source file '$relativePath' not found");
+        $content = file_get_contents($path);
+        self::assertIsString($content);
+        return $content;
+    }
+
+    public function testApiItemWritesSynchronizeCacheTable(): void
+    {
+        $source = $this->readSource('/app/api/Model/ItemModel.php');
+
+        self::assertStringContainsString(
+            "updateCacheTable('add_value', \$newID, \$userId);",
+            $source,
+            'API item creation must add the item to the cache table.'
+        );
+
+        self::assertStringContainsString(
+            "updateCacheTable('update_value', \$itemId, (int) \$userData['id']);",
+            $source,
+            'API item updates must refresh the cache table.'
+        );
+
+        self::assertStringContainsString(
+            "updateCacheTable('delete_value', \$itemId);",
+            $source,
+            'API item deletion must remove the item from the cache table.'
+        );
+    }
+
+    public function testCacheUpdateCanRepairMissingCacheRows(): void
+    {
+        $source = $this->readSource('/app/sources/main.functions.php');
+
+        self::assertStringContainsString(
+            'function updateCacheTable(string $action, ?int $ident = null, ?int $authorId = null): void',
+            $source,
+            'Cache synchronization must accept an explicit author id for API contexts.'
+        );
+
+        self::assertStringContainsString(
+            'function cacheTableUpdate(?int $ident = null, ?int $authorId = null): void',
+            $source,
+            'Cache updates must accept an explicit author id.'
+        );
+
+        self::assertStringContainsString(
+            'cacheTableAdd($ident, $authorId);',
+            $source,
+            'Cache update must create a missing cache row instead of silently doing nothing.'
+        );
+    }
+}


### PR DESCRIPTION
## Summary

This change keeps the TeamPass item cache table synchronized when items are created, updated, or deleted through the API.

The web search page reads from the cache table, while API item reads search the main items table. Before this change, items written through the API could be visible through the extension/API but missing from the web search until the scheduled cache rebuild task ran.

## Problem

Items created or modified through the browser extension use the API item write paths. Those paths persisted the item, tags, logs, share keys, and background tasks, but they did not update `teampass_cache`.

As a result:

- API/extension search could find the item because it queries `items`.
- The web search page could miss the item because it queries `cache`.
- A later web move or edit could still fail to repair the row when the cache entry did not exist, because the cache update path only updated existing rows.
- Rebuilding the cache table from the admin task fixed the symptom, but only as a delayed maintenance workaround.

## Root Cause

`app/sources/find.queries.php` searches `cache` through the `c` alias.

The web item write flow already calls `updateCacheTable()` after item creation, update, copy, move, and deletion.

The API item write flow in `app/api/Model/ItemModel.php` did not call `updateCacheTable()`.

Additionally, `cacheTableUpdate()` only issued a `DB::update()` against `cache`; when a cache row was missing, the update silently affected no rows.

## Implementation Details

- Added an optional `$authorId` argument to `updateCacheTable()`, `cacheTableUpdate()`, and `cacheTableAdd()`.
- Kept the existing web-session fallback for current web UI calls.
- Used the explicit API user id when API writes synchronize the cache.
- Made `cacheTableUpdate()` repair a missing cache row by falling back to `cacheTableAdd()`.
- Called `updateCacheTable('add_value', ...)` after API item creation has completed post-insert work such as logging, tags, share keys, and custom fields.
- Called `updateCacheTable('update_value', ...)` after API item updates have completed tags/custom fields/share keys/logging.
- Called `updateCacheTable('delete_value', ...)` after API item deletion is persisted and logged.
- Added a static regression test to guard the API cache synchronization wiring and the missing-row repair behavior.

## Files Changed

- `app/api/Model/ItemModel.php`
- `app/sources/main.functions.php`
- `tests/Unit/Api/ApiItemCacheSyncTest.php`

## Behavior

- API-created items are immediately available to the web search page.
- API-renamed, API-moved, or API-retagged items refresh their cache metadata immediately.
- API-deleted items are removed from the web search cache immediately.
- If an API update touches an item whose cache row is missing from a previous write, the cache row is recreated instead of waiting for a full cache rebuild.
- Scheduled full cache rebuilds remain useful as a maintenance fallback, but they are no longer required for normal API write visibility.

## Testing

- Added `tests/Unit/Api/ApiItemCacheSyncTest.php`.
- The test verifies that API create/update/delete paths call `updateCacheTable()`.
- The test verifies that cache synchronization accepts an explicit author id for API contexts.
- The test verifies that cache updates can repair a missing cache row.

## Notes

- This change does not alter the web search query itself.
- This change does not change API read permissions or folder access filtering.
- `app/files_reference.txt` is intentionally not updated here; release packaging can refresh file hashes as part of the normal release build.
- This change has not been tested and validated yet - need to be done before merge