### PR TITLE
tests: Add basic security check for API folder endpoint

### DIFF
--- a/tests/FolderCreationTest.php
+++ b/tests/FolderCreationTest.php
@@ -1,0 +1,17 @@
+'add_folder',
+            'title' => 'Test DevOps Folder'
+        ]);
+
+        $ch = curl_init($this->apiUrl);
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+        curl_setopt($ch, CURLOPT_POST, true);
+        curl_setopt($ch, CURLOPT_POSTFIELDS, $payload);
+        curl_setopt($ch, CURLOPT_HTTPHEADER, ['Content-Type: application/json']);
+
+        $response = curl_exec($ch);
+        $httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+        curl_close($ch);
+
+        $this->assertNotEquals(200, $httpCode, "The API allowed access without a valid API key token.");
+    }
+}


### PR DESCRIPTION
Hi,
I have added a basic integration test case inside the `tests/` directory to verify that the API properly drops or handles incoming requests trying to create folders when a valid API token is missing. 

This helps expand the test framework layout as the project stabilizes code for newer PHP environments.