### PR TITLE
Fix item description rendering in search results

### DIFF
--- a/app/pages/search.js.php
+++ b/app/pages/search.js.php
@@ -232,6 +232,10 @@ $var['hidden_asterisk'] = '<i class="fas fa-asterisk mr-2"></i><i class="fas fa-
                 data = prepareExchangedData(data, 'decode', '<?php echo $session->get('key'); ?>');
                 console.info(data);
                 var return_html = '';
+                var descriptionHtml = DOMPurify.sanitize(
+                    htmlDecode(data.description || ''),
+                    {USE_PROFILES: {html: true}}
+                );
                 if (data.show_detail_option !== 0 || data.show_details === 0) {
                     //item expired
                     return_html = '<?php echo $lang->get('not_allowed_to_see_pw_is_expired'); ?>';
@@ -245,7 +249,7 @@ $var['hidden_asterisk'] = '<i class="fas fa-asterisk mr-2"></i><i class="fas fa-
                         '<h5 id="item-label">' + data.label + '</h5>' +
                         '</div>' +
                         '<div class="card-body">' +
-                        (data.description === '' ? '' : '<div class="form-group">' + data.description + '</div>') +
+                        (descriptionHtml === '' ? '' : '<div class="form-group">' + descriptionHtml + '</div>') +
                         '<div class="form-group">' +
                         '<?php echo $lang->get('pw'); ?>' +
                         '<button type="button" class="btn btn-secondary ml-2" id="btn-copy-pwd" data-id="' + data.id + '" data-label="' + data.label + '"><i class="fas fa-copy"></i></button>' +

--- a/app/sources/find.functions.php
+++ b/app/sources/find.functions.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Teampass - a collaborative passwords manager.
+ * ---
+ * This file is part of the TeamPass project.
+ *
+ * TeamPass is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * TeamPass is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Certain components of this file may be under different licenses. For
+ * details, see the `licenses` directory or individual file headers.
+ * ---
+ * @file      find.functions.php
+ * @author    Nils Laumaillé (nils@teampass.net)
+ * @copyright 2009-2026 Teampass.net
+ * @license   GPL-3.0
+ * @see       https://www.teampass.net
+ *
+ * Pure, DB-free helpers used by the item search handlers.
+ */
+
+/**
+ * Convert a stored item description into a bounded plain-text preview.
+ *
+ * Item descriptions may contain raw HTML (legacy records) or HTML entities
+ * produced by the current rich-text save path. Decode before removing tags so
+ * markup is never truncated or displayed literally in search results.
+ *
+ * @param string $description Stored item description
+ * @param int    $maxLength   Maximum preview length in Unicode characters
+ *
+ * @return string Normalized plain-text preview
+ */
+function findBuildDescriptionPreview(string $description, int $maxLength = 200): string
+{
+    if ($description === '' || $maxLength <= 0) {
+        return '';
+    }
+
+    $decodedDescription = html_entity_decode(
+        $description,
+        ENT_QUOTES | ENT_HTML5,
+        'UTF-8'
+    );
+
+    // Preserve visual boundaries between rich-text blocks before removing tags.
+    $decodedDescription = preg_replace(
+        '#<\s*(?:br|hr|/p|/div|/li|/ul|/ol|/blockquote|/h[1-6]|/tr|/td|/th|/table)\b[^>]*>#iu',
+        ' ',
+        $decodedDescription
+    ) ?? $decodedDescription;
+
+    $plainText = strip_tags($decodedDescription);
+    $plainText = str_replace("\xC2\xA0", ' ', $plainText);
+    $plainText = preg_replace('/\s+/u', ' ', $plainText) ?? $plainText;
+    $plainText = trim($plainText);
+
+    return mb_substr($plainText, 0, $maxLength);
+}

--- a/app/sources/find.queries.php
+++ b/app/sources/find.queries.php
@@ -38,6 +38,7 @@ use TeampassClasses\ConfigManager\ConfigManager;
 
 // Load functions
 require_once 'main.functions.php';
+require_once 'find.functions.php';
 
 // init
 loadClasses('DB');
@@ -381,12 +382,10 @@ if (null === $request->query->get('type')) {
         ) {
             $getItemInList = false;
         } else {
-            $txt = str_replace(['\n', '<br />', '\\'], [' ', ' ', '', ' '], strip_tags($record['description']));
-            if (strlen($txt) > 50) {
-                $sOutputItem .= '"' . base64_encode(substr(stripslashes(preg_replace('~/<[\/]{0,1}[^>]*>\//|[ \t]/~', '', $txt)), 0, 50)) . '", ';
-            } else {
-                $sOutputItem .= '"' . base64_encode(stripslashes(preg_replace('~/<[^>]*>|[ \t]/~', '', $txt))) . '", ';
-            }
+            $descriptionPreview = findBuildDescriptionPreview((string) $record['description'], 50);
+            $sOutputItem .= '"' . base64_encode(
+                htmlspecialchars($descriptionPreview, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8')
+            ) . '", ';
         }
 
         //col5 - TAGS
@@ -428,7 +427,7 @@ if (null === $request->query->get('type')) {
         $arr_data[$record['id']]['item_id'] = (int) $record['id'];
         $arr_data[$record['id']]['tree_id'] = (int) $record['id_tree'];
         $arr_data[$record['id']]['label'] = (string) $record['label'];
-        $arr_data[$record['id']]['desc'] = (string) strip_tags(explode('<br>', $record['description'])[0]);
+        $arr_data[$record['id']]['desc'] = findBuildDescriptionPreview((string) $record['description']);
         $arr_data[$record['id']]['folder'] = (string)$record['folder'];
         $arr_data[$record['id']]['login'] = (string) strtr($record['login'], '"', '&quot;');
         $arr_data[$record['id']]['item_key'] = (string) $record['item_key'];

--- a/tests/Unit/FindDescriptionPreviewTest.php
+++ b/tests/Unit/FindDescriptionPreviewTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../app/sources/find.functions.php';
+
+/**
+ * Unit tests for item-description previews returned by search handlers.
+ */
+class FindDescriptionPreviewTest extends TestCase
+{
+    public function testEncodedRichTextBecomesPlainText(): void
+    {
+        $description = '&lt;p&gt;&lt;b&gt;coucou&lt;/b&gt;&lt;/p&gt;'
+            . '&lt;p&gt;comment ça va ici ? c&#039;est l&#039;heure de rentrer&lt;/p&gt;'
+            . '&lt;p&gt;&lt;br&gt;&lt;/p&gt;';
+
+        $this->assertSame(
+            "coucou comment ça va ici ? c'est l'heure de rentrer",
+            findBuildDescriptionPreview($description)
+        );
+    }
+
+    public function testLegacyRawHtmlIsAlsoSupported(): void
+    {
+        $description = '<p>first <strong>important</strong> line</p><p>second line</p>';
+
+        $this->assertSame(
+            'first important line second line',
+            findBuildDescriptionPreview($description)
+        );
+    }
+
+    public function testPreviewIsTruncatedAfterHtmlNormalization(): void
+    {
+        $description = '&lt;p&gt;&lt;b&gt;coucou&lt;/b&gt;&lt;/p&gt;'
+            . '&lt;p&gt;comment ça va ici ? c&#039;est l&#039;heure de rentrer&lt;/p&gt;';
+        $preview = findBuildDescriptionPreview($description, 50);
+
+        $this->assertSame("coucou comment ça va ici ? c'est l'heure de rentre", $preview);
+        $this->assertSame(50, mb_strlen($preview));
+        $this->assertStringNotContainsString('&lt;', $preview);
+        $this->assertStringNotContainsString('<', $preview);
+        $this->assertStringNotContainsString('&', substr($preview, -1));
+    }
+
+    public function testUnicodeCharactersAreNotSplitByTheLimit(): void
+    {
+        $preview = findBuildDescriptionPreview('&lt;p&gt;ééé&lt;/p&gt;', 2);
+
+        $this->assertSame('éé', $preview);
+        $this->assertSame(2, mb_strlen($preview));
+    }
+
+    public function testMarkupAndDangerousAttributesAreNotReturned(): void
+    {
+        $description = '&lt;p onclick=&quot;alert(1)&quot;&gt;safe&lt;/p&gt;'
+            . '&lt;img src=x onerror=&quot;alert(1)&quot;&gt;';
+
+        $this->assertSame('safe', findBuildDescriptionPreview($description));
+    }
+
+    public function testEmptyDescriptionOrNonPositiveLimitReturnsEmptyPreview(): void
+    {
+        $this->assertSame('', findBuildDescriptionPreview(''));
+        $this->assertSame('', findBuildDescriptionPreview('<p>text</p>', 0));
+        $this->assertSame('', findBuildDescriptionPreview('<p>text</p>', -1));
+    }
+}


### PR DESCRIPTION
## Summary

This pull request fixes item descriptions being displayed as literal HTML markup in the search results page.

Current rich-text descriptions are stored HTML-encoded, for example:

```text
&lt;p&gt;&lt;b&gt;coucou&lt;/b&gt;&lt;/p&gt;&lt;p&gt;comment...&lt;/p&gt;
```

The main item page already handles this representation, but the legacy search handler removed tags and truncated the description before decoding the HTML entities. As a result, search results displayed fragments such as:

```text
<p><b>coucou</b></p><p&
```

The fix normalizes descriptions into safe plain-text previews before truncation and renders the expanded search detail as sanitized rich HTML.

## Reproduction

The issue was reproduced on TeamPass 3.2.0.8 with the following steps:

1. Create or edit an item.
2. Add a rich-text description containing paragraphs and bold text.
3. Save the item.
4. Confirm that the item detail page renders the formatting correctly.
5. Open **Search** and find the same item.
6. Observe that the Description column displays literal tags and a partial HTML entity.

Database inspection confirmed that the affected description was encoded once, not double-encoded:

```text
&lt;p&gt;&lt;b&gt;coucou&lt;/b&gt;&lt;/p&gt;...
```

The same save and search logic is present in the `preparing/3.2.1.0` branch.

## Root cause

The search result handler performed these operations in the wrong order:

1. `strip_tags()` was called on an HTML-encoded string.
2. Because encoded tags are text, `strip_tags()` did not remove them.
3. `strlen()` and `substr()` truncated the encoded byte representation at 50 bytes.
4. The truncation could split an entity such as `&lt;` in the middle.
5. The client decoded the base64 cell value and DataTables interpreted the remaining entities, exposing literal markup in the table.

The expanded result detail had a related problem: it inserted the encoded description into its HTML template without explicitly decoding it for rich-text rendering.

## Changes

### Backend preview normalization

A new DB-free helper, `findBuildDescriptionPreview()`, now:

1. Decodes one layer of HTML entities.
2. Preserves whitespace between rich-text block elements.
3. Removes all HTML tags.
4. Normalizes whitespace and non-breaking spaces.
5. Truncates the final text with `mb_substr()` so Unicode characters and HTML entities are never split.

The helper supports both current HTML-encoded descriptions and legacy raw-HTML descriptions.

The DataTables preview is escaped with `htmlspecialchars()` after normalization and before base64 transport. Base64 is retained for compatibility with the existing response format, but it is not treated as an HTML security boundary.

The same helper is used by both search-result response paths in `find.queries.php`, preventing the two implementations from diverging again.

### Expanded search detail

The search detail panel now:

1. Decodes the normalized transport value with the existing `htmlDecode()` helper.
2. Sanitizes the resulting rich HTML with DOMPurify's HTML profile.
3. Inserts only the sanitized HTML into the detail card.

This preserves expected rich-text formatting while maintaining defense in depth at the HTML sink.

## Security considerations

- The persisted description format is unchanged.
- No database migration is required.
- Plain-text previews are HTML-escaped before being passed to DataTables.
- Truncation happens after entity decoding and tag removal.
- Expanded rich HTML is sanitized with DOMPurify immediately before rendering.
- Encoded current records and raw legacy records are both supported.
- No password, encryption, authorization, or folder-access logic is changed.

This approach avoids the security risk of switching all stored descriptions to raw HTML without first auditing every rendering path.

## Tests added

`tests/Unit/FindDescriptionPreviewTest.php` covers:

- current HTML-encoded rich-text descriptions;
- legacy raw HTML descriptions;
- paragraph and block boundary preservation;
- truncation after normalization;
- multibyte character-safe limits;
- removal of markup and dangerous attributes;
- empty descriptions and non-positive limits.


## Manual validation checklist

1. Create an item with this description:
   - a bold first line;
   - a second paragraph containing accented characters;
   - an empty trailing paragraph.
2. Confirm that the main item detail page still renders the description correctly.
3. Search for the item from the Search page.
4. Confirm that the Description column contains plain text only.
5. Confirm that no partial entity such as `<p&` is visible.
6. Open the result with the eye icon.
7. Confirm that paragraphs and supported formatting render correctly in the expanded detail.
8. Repeat with a legacy item containing plain text or raw HTML.
9. Confirm that a long description is truncated at 50 visible Unicode characters in the table.


## Compatibility and deployment impact

- **PHP:** Compatible with PHP 8.2+.
- **Database:** No schema or data changes.
- **Installer/upgrade:** No changes required.
- **Configuration:** No changes required.
- **API:** No contract changes.
- **Public webroot:** No duplicated source change is required; `public/sources/find.queries.php` remains a proxy to the private application handler.
- **Rollback:** Reverting the changed files fully restores the previous behavior.

## Files changed

- `app/sources/find.functions.php`
  - Adds the pure description-preview normalization helper.
- `app/sources/find.queries.php`
  - Uses normalized, bounded and escaped search previews in both response paths.
- `app/pages/search.js.php`
  - Decodes and sanitizes rich descriptions before expanded-detail rendering.
- `tests/Unit/FindDescriptionPreviewTest.php`
  - Adds focused regression coverage.

## Risk assessment

The change is low risk and scoped to description presentation in search results. The main compatibility risk is whitespace changing slightly between adjacent rich-text blocks; this is intentional so separate paragraphs do not collapse into one word. No persisted data is rewritten.

## Reviewer focus

Reviewers should confirm that:

- entity decoding occurs before tag removal;
- the table output remains escaped after normalization;
- multibyte truncation is applied to visible text, not encoded bytes;
- DOMPurify remains the final boundary before rendering rich HTML;
- both encoded and legacy raw descriptions produce the same user-visible text.

## Closing keyword

Fixes #5282
