### PR TITLE
Fix favorite highlighting on the initial item-list load

### DIFF
--- a/app/pages/items.js.php
+++ b/app/pages/items.js.php
@@ -367,8 +367,9 @@ $bip39Wordlist = loadBip39Wordlist($session->get('user-language') ?? 'english');
         }
     );
     // browserSession('init') skips keys when the store already exists (initialized by load.js.php),
-    // so force-inject HIBP settings via store.update to guarantee they are always present.
+    // so force-inject page settings before the first item list is rendered.
     store.update('teampassApplication', function(app) {
+        app.highlightFavorites = parseInt(<?php echo $SETTINGS['highlight_favorites']; ?>)
         app.hibpEnabled = parseInt(<?php echo isset($SETTINGS['hibp_enabled']) ? (int) $SETTINGS['hibp_enabled'] : 0; ?>)
         app.hibpIntervalDays = parseInt(<?php echo isset($SETTINGS['hibp_check_interval_days']) ? (int) $SETTINGS['hibp_check_interval_days'] : 7; ?>)
     })
@@ -5472,7 +5473,7 @@ $bip39Wordlist = loadBip39Wordlist($session->get('user-language') ?? 'english');
             value.anyone_can_modify = parseInt(value.anyone_can_modify);
             value.canMove = parseInt(value.canMove);
             value.expired = parseInt(value.expired);
-            value.is_favorite = parseInt(value.is_favorite);
+            value.is_favourited = parseInt(value.is_favourited ?? value.is_favorite ?? 0);
             value.is_result_of_search = parseInt(value.is_result_of_search);
             value.item_id = parseInt(value.item_id);
             value.is_corrupted = parseInt(value.is_corrupted || 0);

--- a/tests/Unit/FavoriteHighlightingRegressionTest.php
+++ b/tests/Unit/FavoriteHighlightingRegressionTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Sentinel tests for favorite highlighting on the initial item-list render.
+ */
+class FavoriteHighlightingRegressionTest extends TestCase
+{
+    private static function itemsJavaScriptSource(): string
+    {
+        $path = __DIR__ . '/../../app/pages/items.js.php';
+        $content = file_get_contents($path);
+        self::assertNotFalse($content, $path . ' must be readable');
+
+        return (string) $content;
+    }
+
+    public function testServerHighlightSettingIsForcedIntoExistingBrowserStore(): void
+    {
+        $source = self::itemsJavaScriptSource();
+        $settingUpdate = "app.highlightFavorites = parseInt(<?php echo \$SETTINGS['highlight_favorites']; ?>)";
+
+        $this->assertStringContainsString(
+            $settingUpdate,
+            $source
+        );
+
+        $settingPosition = strpos($source, $settingUpdate);
+        $treePosition = strpos($source, "$('#jstree').jstree");
+        $this->assertNotFalse($settingPosition);
+        $this->assertNotFalse($treePosition);
+        $this->assertLessThan(
+            $treePosition,
+            $settingPosition,
+            'The favorite highlight setting must be applied before the first item-list trigger.'
+        );
+    }
+
+    public function testFavoriteFlagAliasesAreNormalizedBeforeRendering(): void
+    {
+        $source = self::itemsJavaScriptSource();
+
+        $this->assertStringContainsString(
+            'value.is_favourited = parseInt(value.is_favourited ?? value.is_favorite ?? 0);',
+            $source
+        );
+        $this->assertStringContainsString(
+            "value.is_favourited === 1) ? ' bg-yellow' : ''",
+            $source
+        );
+    }
+}


### PR DESCRIPTION
## Summary

This pull request fixes favorite items not being highlighted immediately after a standard user signs in.

The backend already returns the correct favorite state, but the browser store keeps the default `highlightFavorites: 0` value during the first item-list render. Favorite highlighting starts working only after a search result opens an item through a `group`/`id` deep link, because that separate navigation path overwrites the stale store value.

The fix applies the server setting to the existing browser store before the folder tree and first item list are initialized. It also normalizes the two favorite-state property names currently returned by the normal list and search endpoints.

## User-visible problem

### Steps to reproduce

1. Enable **Highlight favorites** in TeamPass settings.
2. Mark one or more items as favorites for a standard user.
3. Sign out.
4. Sign in again as that user.
5. Open a folder containing a favorite item.

### Actual behavior

The favorite item is not highlighted and has no favorite marker in the row label.

If the user searches for a favorite and opens it from the search result, favorite highlighting then starts working in the item list.

### Expected behavior

Favorite items must be highlighted on the first item-list render immediately after sign-in, without requiring a search or deep-link navigation.

## Root cause

The issue is entirely in the browser-side initialization order:

1. `app/core/load.js.php` initializes `teampassApplication.highlightFavorites` to `0`.
2. `app/pages/items.js.php` later calls `browserSession('init', ...)` with the real `highlight_favorites` server setting.
3. `browserSession('init')` does not reliably replace properties when the store already exists.
4. The existing `store.update()` workaround only forces the HIBP page settings into that existing store.
5. The item renderer requires both `highlightFavorites === 1` and `is_favourited === 1`, so the valid favorite state returned by the backend is ignored during the first render.

The search/deep-link path appears to refresh a cache because it calls `store.set()` with the real highlight setting. It is therefore a navigation-dependent store initialization bug, not a PHP session, database, or server-cache issue.

There is also a response-contract mismatch:

- the normal item-list endpoint returns `is_favourited`;
- the search endpoint returns `is_favorite`;
- the shared renderer previously converted `is_favorite` to an integer but rendered only `is_favourited`.

## Changes

### Force the server setting into the existing store

The existing `store.update('teampassApplication', ...)` block now also assigns:

```javascript
app.highlightFavorites = parseInt(serverSetting)
```

This runs before the folder tree initialization and before any item-list request can render rows. It preserves the existing store and changes only the page setting that was left at its default value.

### Normalize favorite response aliases

The shared item renderer now uses `is_favourited` as its canonical property and falls back to the search response alias:

```javascript
value.is_favourited = parseInt(
  value.is_favourited ?? value.is_favorite ?? 0
)
```

This preserves compatibility with both current response shapes without changing either backend contract in this focused pull request.

## Why this approach

The correction is intentionally local to `app/pages/items.js.php`.

Changing the global `browserSession()` merge behavior would affect every TeamPass page and every property stored through that helper. Such a change would have a much larger regression surface than this display bug requires.

Changing the PHP session or reloading favorites from the database would not address the root cause because:

- the user favorites are already loaded at sign-in;
- `items.queries.php` already returns the correct `is_favourited` value;
- only the browser highlight setting remains stale.

No cache invalidation is required.

## Security considerations

- No authentication or authorization behavior changes.
- No favorite ownership or access-control logic changes.
- No user-supplied values are inserted into a new HTML sink.
- The server setting is parsed as an integer before use.
- The favorite-state aliases are parsed as integers and default to `0`.

## Tests added

`tests/Unit/FavoriteHighlightingRegressionTest.php` is a source-level regression sentinel that verifies:

- the server `highlight_favorites` setting is forced into the existing `teampassApplication` store;
- this update appears before the folder-tree initialization and first list-render path;
- `is_favourited` and `is_favorite` are normalized to one canonical integer flag;
- the row renderer still uses that canonical flag for the yellow highlight.

## Manual validation checklist

### Initial sign-in

1. Enable the `highlight_favorites` setting.
2. Use a standard account with at least one favorite item.
3. Sign out and clear the TeamPass browser storage for the cleanest reproduction.
4. Sign in again.
5. Open a folder containing a favorite.
6. Confirm that the favorite row is immediately yellow and displays the star marker.
7. Confirm that no search is required.

### Persistent browser store

1. Sign in with existing TeamPass browser storage still present.
2. Open the Items page.
3. Confirm that the server setting overwrites a stale `highlightFavorites: 0` value before the first list render.

### Search compatibility

1. Search for a favorite item from the Items page.
2. Confirm that the search result is highlighted through the `is_favorite` fallback.
3. Close the search results and return to the current folder.
4. Confirm that regular list favorites remain highlighted through `is_favourited`.

### Live favorite changes

1. Add a non-favorite item to favorites.
2. Confirm that the row highlight and star appear without reloading.
3. Remove it from favorites.
4. Confirm that both disappear without reloading.

### Disabled setting

1. Disable `highlight_favorites` as an administrator.
2. Reload the Items page.
3. Confirm that favorite state and favorite actions still work, but rows are not highlighted.

### Roles

Repeat the initial-load check with:

- a standard user;
- an administrator;
- a read-only user, where favorites are available.

## Compatibility and deployment impact

- **PHP:** No runtime PHP logic changes.
- **JavaScript:** Uses the nullish coalescing operator already used in the target file.
- **Database:** No schema or data changes.
- **Installer/upgrade:** No changes required.
- **Configuration:** No new setting; the existing `highlight_favorites` value is used.
- **Session:** No PHP session changes.
- **API:** No public API contract changes.
- **Cache:** No invalidation or rebuild required.
- **Rollback:** Reverting `app/pages/items.js.php` restores the previous behavior.

## Files changed

- `app/pages/items.js.php`
  - Forces the favorite highlight setting into an already initialized browser store.
  - Normalizes the favorite-state aliases before rendering.
- `tests/Unit/FavoriteHighlightingRegressionTest.php`
  - Adds focused regression sentinels for initialization order and response alias handling.

## Risk assessment

The change is low risk and limited to item-list presentation.

The main behavior change is that the configured favorite highlighting option is honored earlier: on the first render rather than after a deep-link navigation. When the option is disabled, the forced value remains `0`, so existing non-highlight behavior is preserved.

## Reviewer focus

Reviewers should confirm that:

- the store update runs before tree and item-list initialization;
- the setting is sourced from the existing server configuration;
- both backend favorite property names normalize to `is_favourited`;
- live add/remove favorite behavior is unchanged;
- no global `browserSession()` behavior is altered.
