### PR TITLE
Fix corrupted item warning and danger highlighting

### DIFF
--- a/app/pages/items.js.php
+++ b/app/pages/items.js.php
@@ -5571,8 +5571,12 @@ $bip39Wordlist = loadBip39Wordlist($session->get('user-language') ?? 'english');
                 }
 
                 if (showCorruptedItemsInList === true && value.is_corrupted === 1) {
-                    corruption_row_class = ' tp-item-corrupted-danger';
-                    corruption_marker = '<i class="fa-solid fa-triangle-exclamation mr-1 infotip tp-item-corrupted-marker text-danger" title="<?php echo $lang->get('items_corrupted_marker_unreadable'); ?>"></i>';
+                    // Only accept the two severities supported by the stylesheet.
+                    // Unknown or missing values stay red to preserve the safest legacy behaviour.
+                    const corruptionSeverity = value.corruption_severity === 'warning' ? 'warning' : 'danger';
+                    const corruptionLabel = value.corruption_reason_label || <?php echo json_encode($lang->get('items_corrupted_marker_unreadable'), JSON_UNESCAPED_UNICODE); ?>;
+                    corruption_row_class = ' tp-item-corrupted-' + corruptionSeverity;
+                    corruption_marker = '<i class="fa-solid fa-triangle-exclamation mr-1 infotip tp-item-corrupted-marker text-' + corruptionSeverity + '" title="' + htmlEncode(corruptionLabel) + '"></i>';
                 }
 
                 $('#teampass_items_list').append(

--- a/tests/Unit/CorruptedItemSeverityRegressionTest.php
+++ b/tests/Unit/CorruptedItemSeverityRegressionTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Sentinel tests for warning/danger rendering of corrupted items.
+ */
+class CorruptedItemSeverityRegressionTest extends TestCase
+{
+    private static function source(string $relativePath): string
+    {
+        $path = __DIR__ . '/../../' . $relativePath;
+        $content = file_get_contents($path);
+        self::assertNotFalse($content, $path . ' must be readable');
+
+        return (string) $content;
+    }
+
+    public function testBackendReturnsCorruptionSeverityAndReasonLabel(): void
+    {
+        $source = self::source('app/sources/items.queries.php');
+
+        $this->assertStringContainsString(
+            "['corruption_severity'] = \$corruptedState['severity'] ?? '';",
+            $source
+        );
+        $this->assertStringContainsString(
+            "['corruption_reason_label'] = \$corruptedState !== null",
+            $source
+        );
+    }
+
+    public function testRendererWhitelistsWarningAndFallsBackToDanger(): void
+    {
+        $source = self::source('app/pages/items.js.php');
+
+        $this->assertStringContainsString(
+            "const corruptionSeverity = value.corruption_severity === 'warning' ? 'warning' : 'danger';",
+            $source
+        );
+        $this->assertStringContainsString(
+            "corruption_row_class = ' tp-item-corrupted-' + corruptionSeverity;",
+            $source
+        );
+        $this->assertStringContainsString(
+            "tp-item-corrupted-marker text-' + corruptionSeverity",
+            $source
+        );
+        $this->assertStringNotContainsString(
+            "corruption_row_class = ' tp-item-corrupted-danger';",
+            $source
+        );
+    }
+
+    public function testStylesExistForBothSupportedSeverities(): void
+    {
+        $source = self::source('public/assets/css/teampass.css');
+
+        $this->assertStringContainsString('tr.tp-item-corrupted-warning', $source);
+        $this->assertStringContainsString('tr.tp-item-corrupted-danger', $source);
+    }
+}


### PR DESCRIPTION
## Summary

This pull request fixes corrupted items always being displayed with the `danger` style in the item list, regardless of the severity returned by the backend.

The item-list response already exposes `corruption_severity`, and the stylesheet already provides separate styles for `warning` and `danger`. However, `app/pages/items.js.php` previously ignored the response value and always assigned the red `tp-item-corrupted-danger` and `text-danger` classes.

The renderer now uses the persisted corruption severity so users can distinguish suspected inconsistencies from unreadable password data at a glance.

## Target branch

This change is adapted for:

```text
preparing/3.2.1.0
```

## User-visible problem

When **Highlight corrupted items in items list** is enabled, every active corrupted item is currently rendered in red, including records classified by the backend as warnings.

This makes the existing severity model ineffective in the item list:

| Backend severity | Expected rendering | Previous rendering |
| --- | --- | --- |
| `warning` | Orange warning highlight | Red danger highlight |
| `danger` | Red danger highlight | Red danger highlight |

The marker tooltip also always uses the generic unreadable-password message, even though the backend already returns a localized reason label.

## Root cause

The backend already returns the following fields for an active corruption record:

```text
is_corrupted
corruption_reason
corruption_severity
corruption_reason_label
```

The renderer checked `is_corrupted`, but then hardcoded both presentation classes:

```javascript
corruption_row_class = ' tp-item-corrupted-danger';
corruption_marker = '... text-danger ...';
```

As a result, the value of `corruption_severity` never affected the item-list presentation.

## Changes

### Severity-aware row and marker classes

The item renderer now maps the server-provided severity to the existing CSS classes:

- `warning` uses `tp-item-corrupted-warning` and `text-warning`;
- `danger` uses `tp-item-corrupted-danger` and `text-danger`.

Only `warning` is explicitly accepted as the lower severity. Any missing, unknown, or unexpected value falls back to `danger` so a potentially unreadable item is never visually downgraded.

### Localized corruption reason tooltip

The warning marker now uses `corruption_reason_label`, which is already localized by the backend.

If the response does not contain a reason label, the existing `items_corrupted_marker_unreadable` translation remains the fallback. The selected label is HTML-encoded before being inserted into the tooltip attribute.

## Severity mapping

The existing backend mapping remains unchanged:

| Corruption reason | Severity | Rendering |
| --- | --- | --- |
| `empty_key` | `warning` | Orange |
| `len_mismatch` | `warning` | Orange |
| `decrypt_failed` | `danger` | Red |
| `binary_bytes` | `danger` | Red |
| `exception` | `danger` | Red |

## Why this approach

The change is intentionally limited to the item-list renderer because all required backend data and CSS rules already exist.

It does not:

- change corruption detection or scan behavior;
- change the `items_corruption` table;
- alter the existing severity mapping;
- modify authentication, authorization, encryption, or item access;
- add a new setting or require a migration.

## Security considerations

- The renderer accepts only the supported lower severity, `warning`.
- Every other value falls back to `danger`.
- The localized reason label is HTML-encoded before insertion into the tooltip.
- No user-supplied value is introduced into a new unescaped HTML sink.
- No password or encryption material is read or modified by this change.

## Manual validation checklist

### Prerequisites

1. Enable **Highlight corrupted items in items list**.
2. Run the corrupted-items scan from **System Health** so active records exist in `items_corruption`.
3. Sign in with a non-administrator account that can access the affected items.

### Warning severity

1. Open a folder containing an active `empty_key` or `len_mismatch` record.
2. Confirm that the row is highlighted in orange.
3. Confirm that the triangle marker uses the warning color.
4. Hover over the marker and confirm that the localized corruption reason is displayed.

### Danger severity

1. Open a folder containing an active `decrypt_failed`, `binary_bytes`, or `exception` record.
2. Confirm that the row remains highlighted in red.
3. Confirm that the triangle marker uses the danger color.
4. Hover over the marker and confirm that the localized corruption reason is displayed.

### Defensive fallback

1. Test a corrupted-item response with an empty or unknown `corruption_severity` value.
2. Confirm that the item is rendered in red rather than being downgraded or left unmarked.

### Disabled setting and unaffected items

1. Disable **Highlight corrupted items in items list** and confirm that no corruption highlight or marker is shown.
2. Re-enable the option and confirm that non-corrupted items keep their normal presentation.
3. Confirm that favorite highlighting, item actions, and folder navigation remain unchanged.

## Compatibility and deployment impact

- **Target:** `preparing/3.2.1.0`
- **PHP:** No runtime PHP logic change.
- **JavaScript:** Uses syntax already supported by the target branch.
- **CSS:** Reuses existing warning and danger classes; no stylesheet change is required.
- **Database:** No schema or data change.
- **Configuration:** No new setting.
- **Installer/upgrade:** No change required.
- **Cache:** No data-cache invalidation is required.
- **Rollback:** Reverting `app/pages/items.js.php` restores the previous all-red behavior.

## Files changed

- `app/pages/items.js.php`
  - Applies the backend corruption severity to the row and marker classes.
  - Uses the localized corruption reason as the marker tooltip.
  - Falls back safely to the danger presentation for unsupported values.

## Risk assessment

The change is low risk and limited to corrupted-item presentation in the standard item list.

The main visible difference is that warning-level records are now orange instead of red. Danger-level records retain the existing red presentation, and unknown severities also remain red through the defensive fallback.

## Reviewer focus

Reviewers should confirm that:

- `warning` selects the existing warning row and marker classes;
- `danger` retains the existing danger presentation;
- unsupported severity values cannot create arbitrary CSS classes;
- the tooltip label is encoded before insertion;
- the feature remains gated by `showCorruptedItemsInList` and `is_corrupted`;
- no corruption detection or persistence logic is changed.
