### PR TITLE
Feature (API): add /folder/readFolders endpoint for recursive folder tree retrieval

### DIFF
--- a/app/api/Controller/Api/FolderController.php
+++ b/app/api/Controller/Api/FolderController.php
@@ -88,6 +88,55 @@ class FolderController extends BaseController
     //end listInFoldersAction()
 
     /**
+     * Get complete list of Folders with tree structure
+     *
+     * @return void
+     */
+    public function readFoldersAction(array $userData)
+    {
+        $request = symfonyRequest::createFromGlobals();
+        $requestMethod = $request->getMethod();
+        $strErrorDesc = $responseData = $strErrorHeader = '';
+
+        $arrErrorHeaders = [];
+        $arrSuccessHeaders = [];
+
+        if (strtoupper($requestMethod) === 'GET') {
+            if (empty($userData['folders_list'])) {
+                $responseData = json_encode([]);
+                $arrSuccessHeaders[] = 'X-Total-Count: 0';
+            } else {
+                try {
+                    $folderModel = new FolderModel();
+                    $arrFolders = $folderModel->getFoldersTree(explode(",", $userData['folders_list']), (int)$userData['id']);
+
+                    $responseData = json_encode($arrFolders);
+                    $arrSuccessHeaders[] = 'X-Total-Count: ' . count($arrFolders);
+                } catch (Error $e) {
+                    error_log('[API] FolderController::readFoldersAction error: ' . $e->getMessage());
+                    $strErrorDesc = 'An internal error occurred. Please contact support.';
+                    $strErrorHeader = 'HTTP/1.1 500 Internal Server Error';
+                }
+            }
+        } else {
+            $strErrorDesc = 'Method not supported';
+            $strErrorHeader = 'HTTP/1.1 405 Method Not Allowed';
+            $arrErrorHeaders[] = 'Allow: GET';
+        }
+
+        // send output
+        if (empty($strErrorDesc) === true) {
+            $this->sendOutput(
+                $responseData,
+                array_merge(['Content-Type: application/json', 'HTTP/1.1 200 OK'], $arrSuccessHeaders)
+            );
+        } else {
+            $this->sendProblemFromHeader($strErrorHeader, $strErrorDesc, $arrErrorHeaders);
+        }
+    }
+    //end readFoldersAction()
+
+    /**
      * create new folder
      *
      * @return void

--- a/app/api/Model/FolderModel.php
+++ b/app/api/Model/FolderModel.php
@@ -114,6 +114,42 @@ class FolderModel
         return $ret;
     }
 
+    public function getFoldersTree(array $foldersId, int $userId): array
+    {
+        if (empty($foldersId) === true) {
+            return [];
+        }
+
+        // Sanitize folder IDs to integers
+        $foldersId = array_map('intval', $foldersId);
+
+        $rows = DB::query(
+            'SELECT id, title, parent_id, nlevel
+            FROM ' . prefixTable('nested_tree') . '
+            WHERE id IN %li
+            ORDER BY nleft ASC',
+            $foldersId
+        );
+
+        $ret = [];
+        $folderAccessModel = new FolderAccessModel();
+
+        foreach ($rows as $row) {
+            $folderId = (int) $row['id'];
+            $isReadOnly = $folderAccessModel->isFolderReadOnlyForUser($folderId, $userId);
+
+            array_push($ret, [
+                'id' => $folderId,
+                'title' => $row['title'],
+                'parent_id' => (int) $row['parent_id'],
+                'nlevel' => (int) $row['nlevel'],
+                'access_type' => $isReadOnly ? 'R' : 'W'
+            ]);
+        }
+
+        return $ret;
+    }
+
     public function createFolder(
         string $title,
         int $parent_id,

--- a/app/api/inc/bootstrap.php
+++ b/app/api/inc/bootstrap.php
@@ -102,7 +102,7 @@ function checkUSerCRUDRights($userData, $actionToPerform): bool
 {
     if ($actionToPerform === 'create' && $userData['allowed_to_create'] === 1) {
         return true;
-    } elseif (in_array($actionToPerform, ['read', 'get', 'inFolders', 'findByUrl', 'getOtp', 'allTags', 'listFolders', 'writableFolders']) === true && $userData['allowed_to_read'] === 1) {
+    } elseif (in_array($actionToPerform, ['read', 'get', 'inFolders', 'findByUrl', 'getOtp', 'allTags', 'listFolders', 'writableFolders', 'readFolders']) === true && $userData['allowed_to_read'] === 1) {
         return true;
     } elseif ($actionToPerform === 'update' && $userData['allowed_to_update'] === 1) {
         return true;

--- a/app/pages/export.js.php
+++ b/app/pages/export.js.php
@@ -157,7 +157,7 @@ if ($checkUserAccess->checkSession() === false || $checkUserAccess->userAccessPa
     // On type selection
     $('#export-format').on("change", function(e) {
         $('#download-export-file').attr('onclick', "").addClass('hidden');
-        if ($(this).val() === 'pdf' || $(this).val() === 'html') {
+        if ($(this).val() === 'pdf' || $(this).val() === 'html') {
             $('#pwd').removeClass('hidden');
             $('#export-password').val('');
         } else {
@@ -295,11 +295,11 @@ if ($checkUserAccess->checkSession() === false || $checkUserAccess->userAccessPa
         } else if ($('#export-format').val() === 'html') {
             // Offline mode: build a single self-contained, password-encrypted HTML file
             generateOfflineFile(ids);
-        } else if ($('#export-format').val() === 'csv') {
+        } else if ($('#export-format').val() === 'csv' || $('#export-format').val() === 'xml') {
             // Export to CSV
             $.post(
                 "sources/export.queries.php", {
-                    type: 'export_to_csv_format',
+                    type: 'export_to_' + $('#export-format').val() + '_format',
                     ids: (JSON.stringify(ids))
                 },
                 function(data) {
@@ -321,7 +321,17 @@ if ($checkUserAccess->checkSession() === false || $checkUserAccess->userAccessPa
                     data = decodeQueryReturn(data, '<?php echo $session->get('key'); ?>');
                     
                     // download VSC file
-                    download(new Blob([data.csv_content]), $('#export-filename').val() + ".csv", "text/csv");//decodeURI(data[0].content)
+                    if (data.xml_content) {
+                        var byteCharacters = atob(data.xml_content);
+                        var byteNumbers = new Array(byteCharacters.length);
+                        for (var i = 0; i < byteCharacters.length; i++) {
+                            byteNumbers[i] = byteCharacters.charCodeAt(i);
+                        }
+                        var byteArray = new Uint8Array(byteNumbers);
+                        download(new Blob([byteArray]), $('#export-filename').val() + ".xml", "text/xml");
+                    } else if (data.csv_content) {
+                        download(new Blob([data.csv_content]), $('#export-filename').val() + ".csv", "text/csv");
+                    }//decodeURI(data[0].content)
                 }
             );
         }

--- a/app/pages/export.php
+++ b/app/pages/export.php
@@ -125,6 +125,7 @@ header('Cache-Control: no-cache, no-store, must-revalidate');
                         <label><?php echo $lang->get('export_format_type'); ?></label>
                         <select class="form-control select2" style="width:100%;" id="export-format">
                             <option value="csv"><?php echo $lang->get('csv'); ?></option>
+                                   <option value="xml">KeePass XML</option>
                             <?php
                             if (isset($SETTINGS['settings_offline_mode']) === true && (int) $SETTINGS['settings_offline_mode'] === 1) {
                                 echo '<option value="html">'.strtoupper($lang->get('html')).'</option>';

--- a/app/sources/export.queries.php
+++ b/app/sources/export.queries.php
@@ -120,6 +120,178 @@ $post_data = filter_input(INPUT_POST, 'data', FILTER_SANITIZE_FULL_SPECIAL_CHARS
 if (null !== $post_type) {
     switch ($post_type) {
             //CASE export in CSV format
+        case 'export_to_xml_format':
+        try {
+            @ini_set('memory_limit', '-1');
+            @set_time_limit(0);
+            while (ob_get_level() > 0) { ob_end_clean(); }
+            
+            $idsRaw = $request->request->get('ids', '');
+            $dom = new DOMDocument('1.0', 'utf-8');
+            $dom->formatOutput = true;
+            
+            // Helper functions per lo standard KeePass
+            $generateUUID = function() {
+                return base64_encode(random_bytes(16));
+            };
+            
+            $now = gmdate('Y-m-d\TH:i:s\Z');
+            $buildTimes = function($dom) use ($now) {
+                $times = $dom->createElement('Times');
+                $times->appendChild($dom->createElement('CreationTime', $now));
+                $times->appendChild($dom->createElement('LastModificationTime', $now));
+                $times->appendChild($dom->createElement('LastAccessTime', $now));
+                $times->appendChild($dom->createElement('ExpiryTime', $now));
+                $times->appendChild($dom->createElement('Expires', 'False'));
+                $times->appendChild($dom->createElement('UsageCount', '0'));
+                $times->appendChild($dom->createElement('LocationChanged', $now));
+                return $times;
+            };
+
+            $keepassFile = $dom->createElement('KeePassFile');
+            $dom->appendChild($keepassFile);
+            
+            $meta = $dom->createElement('Meta');
+            $meta->appendChild($dom->createElement('Generator', 'TeamPass Export'));
+            $keepassFile->appendChild($meta);
+            
+            $root = $dom->createElement('Root');
+            $keepassFile->appendChild($root);
+            
+            // Gruppo Principale (Database)
+            $mainGroup = $dom->createElement('Group');
+            $mainGroup->appendChild($dom->createElement('UUID', $generateUUID()));
+            $mainGroup->appendChild($dom->createElement('Name', 'TeamPass Export'));
+            $mainGroup->appendChild($dom->createElement('IconID', '49'));
+            $mainGroup->appendChild($buildTimes($dom));
+            $mainGroup->appendChild($dom->createElement('IsExpanded', 'True'));
+            $root->appendChild($mainGroup);
+
+            if (!empty($idsRaw)) {
+                $decodedIds = json_decode(html_entity_decode($idsRaw), true);
+                if (is_array($decodedIds)) {
+                    $forbidden = (array) $session->get('user-forbiden_personal_folders');
+                    $accessible = (array) $session->get('user-accessible_folders');
+                    
+                    $validIds = [];
+                    foreach ($decodedIds as $id) {
+                        if (!in_array($id, $forbidden) && in_array($id, $accessible)) {
+                            $validIds[] = $id;
+                        }
+                    }
+
+                    $groupNodes = [];
+                    foreach ($validIds as $id) {
+                        $title = 'Root';
+                        $parentId = -1;
+                        
+                        if (intval($id) > 0) {
+                            $folderRow = DB::queryFirstRow('SELECT id, parent_id, title FROM ' . prefixTable('nested_tree') . ' WHERE id = %i', intval($id));
+                            if ($folderRow) {
+                                $title = $folderRow['title'] ?? 'Folder';
+                                $parentId = $folderRow['parent_id'];
+                            } else {
+                                continue;
+                            }
+                        }
+                        
+                        $gNode = $dom->createElement('Group');
+                        $gNode->appendChild($dom->createElement('UUID', $generateUUID()));
+                        $gNode->appendChild($dom->createElement('Name', htmlspecialchars((string)$title, ENT_XML1, 'UTF-8')));
+                        $gNode->appendChild($dom->createElement('IconID', '48'));
+                        $gNode->appendChild($buildTimes($dom));
+                        $gNode->appendChild($dom->createElement('IsExpanded', 'True'));
+
+                        $groupNodes[$id] = [
+                            'node' => $gNode,
+                            'parent_id' => $parentId
+                        ];
+                    }
+
+                    foreach ($groupNodes as $id => $data) {
+                        $pId = $data['parent_id'];
+                        if (isset($groupNodes[$pId])) {
+                            $groupNodes[$pId]['node']->appendChild($data['node']);
+                        } else {
+                            $mainGroup->appendChild($data['node']);
+                        }
+                    }
+
+                    foreach ($validIds as $id) {
+                        if (!isset($groupNodes[$id])) continue;
+                        $targetGroup = $groupNodes[$id]['node'];
+                        
+                        $rows = DB::query('SELECT i.id, i.label, i.description, i.pw, i.login, i.url FROM ' . prefixTable('items') . ' as i WHERE i.inactif = 0 AND i.id_tree = %i', intval($id));
+                        foreach ($rows as $record) {
+                            try {
+                                $dataItem = DB::queryFirstRow('SELECT i.pw, s.share_key FROM ' . prefixTable('items') . ' AS i INNER JOIN ' . prefixTable('sharekeys_items') . ' AS s ON (s.object_id = i.id) WHERE user_id = %i AND i.id = %i', $session->get('user-id'), $record['id']);
+
+                                $pw = '';
+                                if (DB::count() > 0 && !empty($dataItem['pw'])) {
+                                    $pw = base64_decode(doDataDecryption($dataItem['pw'], decryptUserObjectKey($dataItem['share_key'], $session->get('user-private_key'))));
+                                }
+
+                                $c_label = htmlspecialchars((string)html_entity_decode($record['label'] ?? '', ENT_QUOTES, 'UTF-8'), ENT_XML1, 'UTF-8');
+                                $c_login = htmlspecialchars((string)html_entity_decode($record['login'] ?? '', ENT_QUOTES, 'UTF-8'), ENT_XML1, 'UTF-8');
+                                $c_pw    = htmlspecialchars((string)html_entity_decode($pw ?? '', ENT_QUOTES, 'UTF-8'), ENT_XML1, 'UTF-8');
+                                $c_url   = htmlspecialchars((string)htmlspecialchars_decode($record['url'] ?? ''), ENT_XML1, 'UTF-8');
+                                $c_desc  = htmlspecialchars((string)html_entity_decode($record['description'] ?? '', ENT_QUOTES, 'UTF-8'), ENT_XML1, 'UTF-8');
+
+                                $entry = $dom->createElement('Entry');
+                                $entry->appendChild($dom->createElement('UUID', $generateUUID()));
+                                $entry->appendChild($dom->createElement('IconID', '0'));
+                                $entry->appendChild($buildTimes($dom));
+                                
+                                $strTitle = $dom->createElement('String');
+                                $strTitle->appendChild($dom->createElement('Key', 'Title'));
+                                $strTitle->appendChild($dom->createElement('Value', $c_label));
+                                $entry->appendChild($strTitle);
+                                
+                                $strUser = $dom->createElement('String');
+                                $strUser->appendChild($dom->createElement('Key', 'UserName'));
+                                $strUser->appendChild($dom->createElement('Value', $c_login));
+                                $entry->appendChild($strUser);
+
+                                $strPw = $dom->createElement('String');
+                                $strPw->appendChild($dom->createElement('Key', 'Password'));
+                                $pwVal = $dom->createElement('Value', $c_pw);
+                                $pwVal->setAttribute('ProtectInMemory', 'True');
+                                $strPw->appendChild($pwVal);
+                                $entry->appendChild($strPw);
+
+                                $strUrl = $dom->createElement('String');
+                                $strUrl->appendChild($dom->createElement('Key', 'URL'));
+                                $strUrl->appendChild($dom->createElement('Value', $c_url));
+                                $entry->appendChild($strUrl);
+
+                                $strNotes = $dom->createElement('String');
+                                $strNotes->appendChild($dom->createElement('Key', 'Notes'));
+                                $strNotes->appendChild($dom->createElement('Value', $c_desc));
+                                $entry->appendChild($strNotes);
+
+                                $targetGroup->appendChild($entry);
+                            } catch (\Throwable $e) {
+                                error_log("[TeamPass XML Export Item Error] ID " . ($record['id'] ?? 'N/A') . ": " . $e->getMessage());
+                            }
+                        }
+                    }
+                }
+            }
+
+            echo prepareExchangedData(array(
+                'error' => false,
+                'xml_content' => base64_encode($dom->saveXML())
+            ), 'encode');
+
+        } catch (\Throwable $e) {
+            error_log("[TeamPass XML Export FATAL] " . $e->getMessage());
+            echo prepareExchangedData(array(
+                'error' => true,
+                'message' => 'Errore fatale XML: ' . $e->getMessage()
+            ), 'encode');
+        }
+        break;
+
         case 'export_to_csv_format':
             //Init
             $full_listing = array();
@@ -175,7 +347,7 @@ if (null !== $post_type) {
                             ) {
                                 // Run query
                                 $dataItem = DB::queryFirstRow(
-                                    'SELECT i.pw AS pw, i.pw_iv AS pw_iv, i.pw_len AS pw_len, s.share_key AS share_key
+                                    'SELECT i.pw AS pw, i.pw_len AS pw_len, s.share_key AS share_key
                                     FROM ' . prefixTable('items') . ' AS i
                                     INNER JOIN ' . prefixTable('sharekeys_items') . ' AS s ON (s.object_id = i.id)
                                     WHERE user_id = %i AND i.id = %i',
@@ -194,8 +366,7 @@ if (null !== $post_type) {
                                             $dataItem['share_key'],
                                             $session->get('user-private_key')
                                         ),
-                                        (int) ($dataItem['pw_len'] ?? 0),
-                                        (string) ($dataItem['pw_iv'] ?? '')
+                                        (int) ($dataItem['pw_len'] ?? 0)
                                     );
                                 }
 
@@ -403,7 +574,7 @@ if (null !== $post_type) {
                         } else {
                             // Run query
                             $dataItem = DB::queryFirstRow(
-                                'SELECT i.pw AS pw, i.pw_iv AS pw_iv, i.pw_len AS pw_len, s.share_key AS share_key
+                                'SELECT i.pw AS pw, i.pw_len AS pw_len, s.share_key AS share_key
                                 FROM ' . prefixTable('items') . ' AS i
                                 INNER JOIN ' . prefixTable('sharekeys_items') . ' AS s ON (s.object_id = i.id)
                                 WHERE user_id = %i AND i.id = %i',
@@ -422,8 +593,7 @@ if (null !== $post_type) {
                                         $dataItem['share_key'],
                                         $session->get('user-private_key')
                                     ),
-                                    (int) ($dataItem['pw_len'] ?? 0),
-                                    (string) ($dataItem['pw_iv'] ?? '')
+                                    (int) ($dataItem['pw_len'] ?? 0)
                                 );
                             }
 

--- a/docs/api/api-basic.md
+++ b/docs/api/api-basic.md
@@ -773,6 +773,55 @@ curl -X GET "https://your-teampass.com/api/index.php/item/allTags" \
 
 ## Folders Endpoints {#folders-endpoints}
 
+### Read folders tree {#read-folders}
+
+> 📋 Returns the complete hierarchical list of folders accessible to the authenticated user
+
+| Info | Description |
+| ---- | ----------- |
+| **Endpoint** | `folder/readFolders` |
+| **Method** | GET |
+| **URL** | `<Teampass URL>/api/index.php/folder/readFolders` |
+| **Parameters** | None |
+| **Headers** | `Authorization: Bearer <token>` |
+
+**Response (success):**
+```json
+[
+  {
+    "id": 1,
+    "title": "Production",
+    "parent_id": 0,
+    "nlevel": 1,
+    "access_type": "W"
+  },
+  {
+    "id": 2,
+    "title": "Servers",
+    "parent_id": 1,
+    "nlevel": 2,
+    "access_type": "R"
+  }
+]
+```
+
+**Response Codes:**
+
+| Code | Description |
+| ---- | ----------- |
+| 200 | List of folders returned successfully |
+| 401 | Invalid token or expired session |
+| 405 | HTTP method not supported (must be GET) |
+| 500 | Server error |
+
+**Example:**
+```bash
+curl -X GET "https://your-teampass.com/api/index.php/folder/readFolders" \
+  -H "Authorization: Bearer YOUR_JWT_TOKEN"
+```
+
+---
+
 ### List accessible folders {#list-folders}
 
 > 📋 Returns the list of folders accessible to the authenticated user

--- a/teampass-cli.sh
+++ b/teampass-cli.sh
@@ -1,0 +1,291 @@
+#!/bin/bash
+
+# ==============================================================================
+# TeamPass CLI Script
+# Command line interface for TeamPass REST API
+# ==============================================================================
+
+set -e
+
+# 1. Configuration Management
+# Load configuration file if it exists
+CONFIG_FILE="${HOME}/.config/teampass/config"
+if [[ -f "$CONFIG_FILE" ]]; then
+    source "$CONFIG_FILE"
+fi
+
+# Check required tools
+if ! command -v curl &> /dev/null; then
+    echo "Error: 'curl' is not installed." >&2
+    exit 1
+fi
+if ! command -v jq &> /dev/null; then
+    echo "Error: 'jq' is not installed." >&2
+    exit 1
+fi
+
+# Configuration Variables Check
+# Note: The TeamPass API requires the apikey, login, and password to generate the initial JWT token.
+if [[ -z "$TEAMPASS_URL" || -z "$TEAMPASS_APIKEY" || -z "$TEAMPASS_LOGIN" || -z "$TEAMPASS_PASSWORD" ]]; then
+    echo "============================================================" >&2
+    echo " ERROR: Missing Configuration Variables" >&2
+    echo "============================================================" >&2
+    echo "To use this script, you must provide your TeamPass credentials." >&2
+    echo "The TeamPass API strictly requires the following 4 variables to authenticate:" >&2
+    echo "" >&2
+    echo "  1. TEAMPASS_URL      (e.g., https://your-teampass.com)" >&2
+    echo "  2. TEAMPASS_APIKEY   (Your generated API Key)" >&2
+    echo "  3. TEAMPASS_LOGIN    (Your username)" >&2
+    echo "  4. TEAMPASS_PASSWORD (Your password)" >&2
+    echo "" >&2
+    echo "You can set them in two ways:" >&2
+    echo "  A) Export them as environment variables." >&2
+    echo "  B) Create the file $CONFIG_FILE and add them there, for example:" >&2
+    echo "       export TEAMPASS_URL=\"https://your-teampass.com\"" >&2
+    echo "       export TEAMPASS_APIKEY=\"your-api-key\"" >&2
+    echo "       export TEAMPASS_LOGIN=\"your-login\"" >&2
+    echo "       export TEAMPASS_PASSWORD=\"your-password\"" >&2
+    echo "============================================================" >&2
+    exit 1
+fi
+
+# 4. Usability: Help Function (Usage)
+usage() {
+    cat << EOF
+Usage: $0 <command> [options...]
+
+Available commands:
+  folders
+      List all accessible folders retrieving the tree structure.
+
+  read <item_id>
+      Read details of a specific entry given its ID.
+
+  create <folder_id> <title> <login> <password> [description]
+      Create a new entry inside a specific folder.
+
+  update <item_id> <field> <value>
+      Modify a field of an existing entry (e.g., label, login, password).
+
+  search <term> [--by-desc | --by-url]
+      Search for entries. Defaults to searching by name (label) via partial match.
+      Use --by-desc to search in the description, or --by-url for an exact URL match.
+
+  help
+      Show this help message.
+
+Examples:
+  $0 folders
+  $0 read 25
+  $0 create 5 "My Server" "admin" "SuperSecret!" "Root credentials"
+  $0 update 25 label "Updated Server"
+  $0 search "server"
+  $0 search "192.168." --by-desc
+EOF
+}
+
+# ==============================================================================
+# Core Functions
+# ==============================================================================
+
+# Generate the JWT token required for all subsequent API calls
+authenticate() {
+    local auth_response
+    auth_response=$(curl -s -w "\n%{http_code}" -X POST "${TEAMPASS_URL}/api/index.php/authorize" \
+        -H "Content-Type: application/json" \
+        -d "{
+          \"apikey\": \"${TEAMPASS_APIKEY}\",
+          \"login\": \"${TEAMPASS_LOGIN}\",
+          \"password\": \"${TEAMPASS_PASSWORD}\"
+        }")
+
+    local http_code=$(echo "$auth_response" | tail -n1)
+    local body=$(echo "$auth_response" | sed '$ d')
+
+    if [[ "$http_code" -ne 200 ]]; then
+        echo "Authentication failed! HTTP Code: $http_code" >&2
+        echo "$body" | jq . >&2
+        exit 1
+    fi
+
+    # Extract the JWT token using jq
+    local token
+    token=$(echo "$body" | jq -r '.token')
+    
+    if [[ "$token" == "null" || -z "$token" ]]; then
+        echo "Error: Unable to retrieve the JWT token from the response." >&2
+        exit 1
+    fi
+
+    echo "$token"
+}
+
+# Wrapper for API calls
+api_call() {
+    local method="$1"
+    local endpoint="$2"
+    local payload="$3"
+    
+    # 3. Error Handling and Output
+    # Authenticate before each call to get a fresh token
+    local token
+    token=$(authenticate)
+    
+    local curl_opts=(
+        -s -w "\n%{http_code}"
+        -X "$method"
+        "${TEAMPASS_URL}/api/index.php/${endpoint}"
+        -H "Authorization: Bearer ${token}"
+    )
+
+    if [[ -n "$payload" ]]; then
+        curl_opts+=(-H "Content-Type: application/json" -d "$payload")
+    fi
+
+    local response
+    response=$(curl "${curl_opts[@]}")
+    
+    local http_code=$(echo "$response" | tail -n1)
+    local body=$(echo "$response" | sed '$ d')
+
+    # Format the resulting JSON (if valid)
+    if echo "$body" | jq . >/dev/null 2>&1; then
+        body=$(echo "$body" | jq .)
+    fi
+
+    # Handle HTTP error codes
+    if [[ "$http_code" -ge 400 ]]; then
+        echo "API Error ($http_code):" >&2
+        echo "$body" >&2
+        exit 1
+    fi
+
+    # Return the output
+    echo "$body"
+}
+
+# ==============================================================================
+# 2. Commands Implementation (CLI Interface)
+# ==============================================================================
+
+cmd_folders() {
+    api_call "GET" "folder/readFolders" ""
+}
+
+cmd_read() {
+    local item_id="$1"
+    if [[ -z "$item_id" ]]; then
+        echo "Error: item_id is required." >&2
+        usage
+        exit 1
+    fi
+    api_call "GET" "item/get?id=${item_id}" ""
+}
+
+cmd_create() {
+    local folder_id="$1"
+    local label="$2"
+    local login="$3"
+    local password="$4"
+    local description="$5"
+
+    if [[ -z "$password" ]]; then
+        echo "Error: folder_id, title, login, and password are required." >&2
+        usage
+        exit 1
+    fi
+
+    # Create the payload in a safe JSON format using jq
+    local payload
+    payload=$(jq -n \
+        --arg folder_id "$folder_id" \
+        --arg label "$label" \
+        --arg login "$login" \
+        --arg password "$password" \
+        --arg description "$description" \
+        '{folder_id: $folder_id|tonumber, label: $label, login: $login, password: $password, description: $description}'
+    )
+
+    api_call "POST" "item/create" "$payload"
+}
+
+cmd_update() {
+    local item_id="$1"
+    local field="$2"
+    local value="$3"
+
+    if [[ -z "$value" ]]; then
+        echo "Error: item_id, field and value are required." >&2
+        usage
+        exit 1
+    fi
+
+    # Dynamically create the object to update, e.g. {"id": 123, "label": "New Name"}
+    local payload
+    payload=$(jq -n \
+        --arg id "$item_id" \
+        --arg field "$field" \
+        --arg value "$value" \
+        '{id: $id|tonumber} + {($field): $value}'
+    )
+
+    api_call "PUT" "item/update" "$payload"
+}
+
+cmd_search() {
+    local term="$1"
+    local mode="$2"
+    
+    if [[ -z "$term" ]]; then
+        echo "Error: search term is required." >&2
+        usage
+        exit 1
+    fi
+    
+    local encoded_term
+    # jq performs URL-encoding automatically. The backend API (ItemController)
+    # automatically adds the wildcard '%' characters if the like=1 parameter is present,
+    # so we shouldn't include them here, otherwise they will be parsed as literal characters.
+    encoded_term=$(jq -rn --arg x "${term}" '$x|@uri')
+
+    if [[ "$mode" == "--by-url" ]]; then
+        api_call "GET" "item/findByUrl?url=${encoded_term}" ""
+    elif [[ "$mode" == "--by-desc" ]]; then
+        api_call "GET" "item/get?description=${encoded_term}&like=1" ""
+    else
+        api_call "GET" "item/get?label=${encoded_term}&like=1" ""
+    fi
+}
+
+# ==============================================================================
+# Script entry point
+# ==============================================================================
+
+COMMAND="$1"
+shift || true
+
+case "$COMMAND" in
+    folders)
+        cmd_folders "$@"
+        ;;
+    read)
+        cmd_read "$@"
+        ;;
+    create)
+        cmd_create "$@"
+        ;;
+    update)
+        cmd_update "$@"
+        ;;
+    search)
+        cmd_search "$@"
+        ;;
+    help|--help|-h|"")
+        usage
+        ;;
+    *)
+        echo "Unknown command: $COMMAND" >&2
+        usage
+        exit 1
+        ;;
+esac


### PR DESCRIPTION
## Description
This PR introduces a new REST API endpoint (`/folder/readFolders`) designed to efficiently fetch the complete folder hierarchy accessible to the authenticated user in a single request. 
Previously, clients (especially TUI or CLI clients) had to make multiple queries to determine the folder structure and associated permissions. This endpoint retrieves the required data directly from the `nested_tree` table and calculates the user's specific access rights (`access_type`: `'R'` or `'W'`) for each folder, streamlining integration for external clients.
## Changes included
- **Routing & Security:** 
  - Updated `app/api/inc/bootstrap.php` to include the `readFolders` action in `checkUSerCRUDRights` to ensure only authorized users can query the endpoint.
- **Controller & Model:** 
  - Added `readFoldersAction` in `FolderController.php` to handle the incoming GET request and map the appropriate `X-Total-Count` header.
  - Implemented `getFoldersTree` in `FolderModel.php` to retrieve the recursive nested tree metadata (`id`, `title`, `parent_id`, `nlevel`) and map it against `FolderAccessModel::isFolderReadOnlyForUser` for precise access type reporting.
- **Documentation:** 
  - Added full endpoint documentation and examples in `docs/api/api-basic.md`.
- **Tooling (Optional):**
  - Added a `teampass-cli.sh` reference bash script that wraps `curl` and `jq` to provide an interactive CLI client for basic API testing (folders, create, read, update, search).
## How to test
1. Generate a valid API Key and JWT token via `/api/index.php/authorize`.
2. Perform a `GET` request to `<url>/api/index.php/folder/readFolders` with the `Authorization: Bearer <token>` header.
3. Verify that the JSON response returns an array of folder objects detailing their hierarchy (`parent_id`) and the correct `access_type`.