### PR TITLE
[FEATURE] Add KeePass 2.x XML export

### DIFF
--- a/app/includes/language/english.php
+++ b/app/includes/language/english.php
@@ -677,6 +677,7 @@ return array(
     'exporting_items' => 'Exporting items',
     'select_folders_to_export' => 'Select folders to export',
     'export_format_type' => 'Select the export format type',
+    'export_format_keepass_xml' => 'KeePass 2.x XML',
     'export_items' => 'Export items',
     'loading_item' => 'Loading item',
     'otv_message' => 'You can share this item with someone without a Teampass account. One-Time-View permits your guest to access basic fields of this item only once without being authenticated in Teampass. Please notice that this link is valid until one of following settings is reached. Copy and share the link below.',

--- a/app/includes/language/italian.php
+++ b/app/includes/language/italian.php
@@ -130,6 +130,7 @@ return array(
     'exporting_items' => 'Esportazione elementi',
     'select_folders_to_export' => 'Seleziona le cartelle da esportare',
     'export_format_type' => 'Seleziona il tipo di formato di esportazione',
+    'export_format_keepass_xml' => 'KeePass 2.x XML',
     'export_items' => 'Esporta elementi',
     'loading_item' => 'Caricamento elemento',
     'otv_message' => 'Puoi condividere questo elemento con qualcuno senza un account Teampass. Visualizzazione Una Tantum consente al tuo ospite di accedere ai campi di base di questo elemento solo una volta senza essere autenticato in Teampass. Tieni presente che questo collegamento è valido per un periodo di ##otv_expiration_period## giorni. Copia e condividi il link sottostante.',

--- a/app/pages/export.js.php
+++ b/app/pages/export.js.php
@@ -6,19 +6,19 @@ declare(strict_types=1);
  * Teampass - a collaborative passwords manager.
  * ---
  * This file is part of the TeamPass project.
- * 
+ *
  * TeamPass is free software: you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by
  * the Free Software Foundation, version 3 of the License.
- * 
+ *
  * TeamPass is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
- * 
+ *
  * Certain components of this file may be under different licenses. For
  * details, see the `licenses` directory or individual file headers.
  * ---
@@ -92,7 +92,7 @@ if ($checkUserAccess->checkSession() === false || $checkUserAccess->userAccessPa
         language: '<?php echo $session->get('user-language_code'); ?>'
     });
 
-    // Select2 with buttons selectall        
+    // Select2 with buttons selectall
     $.fn.select2.amd.define('select2/selectAllAdapter', [
         'select2/utils',
         'select2/dropdown',
@@ -157,7 +157,7 @@ if ($checkUserAccess->checkSession() === false || $checkUserAccess->userAccessPa
     // On type selection
     $('#export-format').on("change", function(e) {
         $('#download-export-file').attr('onclick', "").addClass('hidden');
-        if ($(this).val() === 'pdf' || $(this).val() === 'html') {
+        if ($(this).val() === 'pdf' || $(this).val() === 'html') {
             $('#pwd').removeClass('hidden');
             $('#export-password').val('');
         } else {
@@ -234,7 +234,7 @@ if ($checkUserAccess->checkSession() === false || $checkUserAccess->userAccessPa
         $("#export-folders :selected").each(function(i, selected) {
             ids.push($(selected).val());
         });
-        
+
         // No selection of folders done
         if (ids.length === 0) {
             $('#export-progress').find('span').html('<i class="fas fa-exclamation-triangle text-danger mr-2 fa-lg"></i><?php echo $lang->get('error_no_selected_folder'); ?>');
@@ -295,11 +295,11 @@ if ($checkUserAccess->checkSession() === false || $checkUserAccess->userAccessPa
         } else if ($('#export-format').val() === 'html') {
             // Offline mode: build a single self-contained, password-encrypted HTML file
             generateOfflineFile(ids);
-        } else if ($('#export-format').val() === 'csv') {
+        } else if ($('#export-format').val() === 'csv' || $('#export-format').val() === 'xml') {
             // Export to CSV
             $.post(
                 "sources/export.queries.php", {
-                    type: 'export_to_csv_format',
+                    type: 'export_to_' + $('#export-format').val() + '_format',
                     ids: (JSON.stringify(ids))
                 },
                 function(data) {
@@ -309,6 +309,21 @@ if ($checkUserAccess->checkSession() === false || $checkUserAccess->userAccessPa
                         .html('');
 
 
+                    //decrypt data
+                    data = decodeQueryReturn(data, '<?php echo $session->get('key'); ?>');
+
+                    if (data.error === true) {
+                        toastr.remove();
+                        toastr.error(
+                            data.message || '',
+                            '<?php echo $lang->get('error'); ?>', {
+                                timeOut: 5000,
+                                progressBar: true
+                            }
+                        );
+                        return;
+                    }
+
                     toastr.remove();
                     toastr.success(
                         '<?php echo $lang->get('done'); ?>',
@@ -316,12 +331,15 @@ if ($checkUserAccess->checkSession() === false || $checkUserAccess->userAccessPa
                             timeOut: 1000
                         }
                     );
-                    
-                    //decrypt data
-                    data = decodeQueryReturn(data, '<?php echo $session->get('key'); ?>');
-                    
-                    // download VSC file
-                    download(new Blob([data.csv_content]), $('#export-filename').val() + ".csv", "text/csv");//decodeURI(data[0].content)
+
+                    // download file
+                    if (data.xml_content) {
+                        var byteCharacters = atob(data.xml_content);
+                        var byteArray = Uint8Array.from(byteCharacters, c => c.charCodeAt(0));
+                        download(new Blob([byteArray]), $('#export-filename').val() + ".xml", "text/xml");
+                    } else if (data.csv_content) {
+                        download(new Blob([data.csv_content]), $('#export-filename').val() + ".csv", "text/csv");
+                    }
                 }
             );
         }

--- a/app/pages/export.php
+++ b/app/pages/export.php
@@ -6,19 +6,19 @@ declare(strict_types=1);
  * Teampass - a collaborative passwords manager.
  * ---
  * This file is part of the TeamPass project.
- * 
+ *
  * TeamPass is free software: you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by
  * the Free Software Foundation, version 3 of the License.
- * 
+ *
  * TeamPass is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
- * 
+ *
  * Certain components of this file may be under different licenses. For
  * details, see the `licenses` directory or individual file headers.
  * ---
@@ -125,6 +125,7 @@ header('Cache-Control: no-cache, no-store, must-revalidate');
                         <label><?php echo $lang->get('export_format_type'); ?></label>
                         <select class="form-control select2" style="width:100%;" id="export-format">
                             <option value="csv"><?php echo $lang->get('csv'); ?></option>
+                            <option value="xml"><?php echo $lang->get('export_format_keepass_xml'); ?></option>
                             <?php
                             if (isset($SETTINGS['settings_offline_mode']) === true && (int) $SETTINGS['settings_offline_mode'] === 1) {
                                 echo '<option value="html">'.strtoupper($lang->get('html')).'</option>';

--- a/app/sources/export.queries.php
+++ b/app/sources/export.queries.php
@@ -6,19 +6,19 @@ declare(strict_types=1);
  * Teampass - a collaborative passwords manager.
  * ---
  * This file is part of the TeamPass project.
- * 
+ *
  * TeamPass is free software: you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by
  * the Free Software Foundation, version 3 of the License.
- * 
+ *
  * TeamPass is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
- * 
+ *
  * Certain components of this file may be under different licenses. For
  * details, see the `licenses` directory or individual file headers.
  * ---
@@ -120,6 +120,221 @@ $post_data = filter_input(INPUT_POST, 'data', FILTER_SANITIZE_FULL_SPECIAL_CHARS
 if (null !== $post_type) {
     switch ($post_type) {
             //CASE export in CSV format
+        case 'export_to_xml_format':
+            try {
+                $idsRaw = $request->request->get('ids', '');
+                $dom = new DOMDocument('1.0', 'utf-8');
+                $dom->formatOutput = true;
+
+                // Helper functions for KeePass standard
+                $generateUUID = function() {
+                    return base64_encode(random_bytes(16));
+                };
+
+                $now = gmdate('Y-m-d\TH:i:s\Z');
+                $buildTimes = function($dom) use ($now) {
+                    $times = $dom->createElement('Times');
+                    $times->appendChild($dom->createElement('CreationTime', $now));
+                    $times->appendChild($dom->createElement('LastModificationTime', $now));
+                    $times->appendChild($dom->createElement('LastAccessTime', $now));
+                    $times->appendChild($dom->createElement('ExpiryTime', $now));
+                    $times->appendChild($dom->createElement('Expires', 'False'));
+                    $times->appendChild($dom->createElement('UsageCount', '0'));
+                    $times->appendChild($dom->createElement('LocationChanged', $now));
+                    return $times;
+                };
+
+                $keepassFile = $dom->createElement('KeePassFile');
+                $dom->appendChild($keepassFile);
+
+                $meta = $dom->createElement('Meta');
+                $meta->appendChild($dom->createElement('Generator', 'TeamPass Export'));
+                $keepassFile->appendChild($meta);
+
+                $root = $dom->createElement('Root');
+                $keepassFile->appendChild($root);
+
+                // Main Group (Database)
+                $mainGroup = $dom->createElement('Group');
+                $mainGroup->appendChild($dom->createElement('UUID', $generateUUID()));
+                $mainGroup->appendChild($dom->createElement('Name', 'TeamPass Export'));
+                $mainGroup->appendChild($dom->createElement('IconID', '49'));
+                $mainGroup->appendChild($buildTimes($dom));
+                $mainGroup->appendChild($dom->createElement('IsExpanded', 'True'));
+                $root->appendChild($mainGroup);
+
+                if (!empty($idsRaw)) {
+                    $decodedIds = json_decode(html_entity_decode($idsRaw), true);
+                    if (is_array($decodedIds)) {
+                        $forbidden = (array) $session->get('user-forbiden_personal_folders');
+                        $accessible = (array) $session->get('user-accessible_folders');
+
+                        $validIds = [];
+                        foreach ($decodedIds as $id) {
+                            if (!in_array($id, $forbidden) && in_array($id, $accessible)) {
+                                $validIds[] = $id;
+                            }
+                        }
+
+                        $groupNodes = [];
+                        foreach ($validIds as $id) {
+                            $title = 'Root';
+                            $parentId = -1;
+
+                            if (intval($id) > 0) {
+                                $folderRow = DB::queryFirstRow('SELECT id, parent_id, title FROM ' . prefixTable('nested_tree') . ' WHERE id = %i', intval($id));
+                                if ($folderRow) {
+                                    $title = $folderRow['title'] ?? 'Folder';
+                                    $parentId = $folderRow['parent_id'];
+                                } else {
+                                    continue;
+                                }
+                            }
+
+                            $gNode = $dom->createElement('Group');
+                            $gNode->appendChild($dom->createElement('UUID', $generateUUID()));
+                            $gNode->appendChild($dom->createElement('Name', htmlspecialchars((string) $title, ENT_XML1 | ENT_SUBSTITUTE, 'UTF-8')));
+                            $gNode->appendChild($dom->createElement('IconID', '48'));
+                            $gNode->appendChild($buildTimes($dom));
+                            $gNode->appendChild($dom->createElement('IsExpanded', 'True'));
+
+                            $groupNodes[$id] = [
+                                'node' => $gNode,
+                                'parent_id' => $parentId,
+                            ];
+                        }
+
+                        foreach ($groupNodes as $id => $data) {
+                            $pId = $data['parent_id'];
+                            if (isset($groupNodes[$pId])) {
+                                $groupNodes[$pId]['node']->appendChild($data['node']);
+                            } else {
+                                $mainGroup->appendChild($data['node']);
+                            }
+                        }
+
+                        foreach ($validIds as $id) {
+                            if (!isset($groupNodes[$id])) {
+                                continue;
+                            }
+                            $targetGroup = $groupNodes[$id]['node'];
+
+                            $rows = DB::query(
+                                'SELECT i.id, i.id_tree, i.restricted_to, i.label, i.description, i.login, i.url
+                                FROM ' . prefixTable('items') . ' AS i
+                                WHERE i.inactif = 0 AND i.id_tree = %i',
+                                intval($id)
+                            );
+                            foreach ($rows as $record) {
+                                // Item-level restriction check
+                                if (
+                                    !(
+                                        in_array((int) $record['id_tree'], (array) $session->get('user-personal_visible_folders')) === true
+                                        || (
+                                            in_array((int) $record['id_tree'], (array) $session->get('user-accessible_folders')) === true
+                                            && (
+                                                empty($record['restricted_to']) === true
+                                                || in_array((string) $session->get('user-id'), explode(';', (string) $record['restricted_to'])) === true
+                                            )
+                                        )
+                                    )
+                                ) {
+                                    continue;
+                                }
+
+                                $dataItem = DB::queryFirstRow(
+                                    'SELECT i.pw AS pw, i.pw_iv AS pw_iv, i.pw_len AS pw_len, s.share_key AS share_key, s.increment_id AS increment_id
+                                    FROM ' . prefixTable('items') . ' AS i
+                                    INNER JOIN ' . prefixTable('sharekeys_items') . ' AS s ON (s.object_id = i.id)
+                                    WHERE s.user_id = %i AND i.id = %i',
+                                    $session->get('user-id'),
+                                    $record['id']
+                                );
+
+                                $pw = '';
+                                if (DB::count() > 0 && !empty($dataItem['pw'])) {
+                                    $pw = teampassDecryptPasswordValue(
+                                        $dataItem['pw'],
+                                        decryptUserObjectKeyWithMigration(
+                                            $dataItem['share_key'],
+                                            $session->get('user-private_key'),
+                                            $session->get('user-public_key'),
+                                            (int) $dataItem['increment_id'],
+                                            'sharekeys_items'
+                                        ),
+                                        (int) ($dataItem['pw_len'] ?? 0),
+                                        (string) ($dataItem['pw_iv'] ?? '')
+                                    );
+                                }
+
+                                $c_label = htmlspecialchars((string) html_entity_decode((string) ($record['label'] ?? ''), ENT_QUOTES, 'UTF-8'), ENT_XML1 | ENT_SUBSTITUTE, 'UTF-8');
+                                $c_login = htmlspecialchars((string) html_entity_decode((string) ($record['login'] ?? ''), ENT_QUOTES, 'UTF-8'), ENT_XML1 | ENT_SUBSTITUTE, 'UTF-8');
+                                $c_pw    = htmlspecialchars((string) html_entity_decode($pw, ENT_QUOTES, 'UTF-8'), ENT_XML1 | ENT_SUBSTITUTE, 'UTF-8');
+                                $c_url   = htmlspecialchars((string) htmlspecialchars_decode((string) ($record['url'] ?? '')), ENT_XML1 | ENT_SUBSTITUTE, 'UTF-8');
+                                $c_desc  = htmlspecialchars((string) html_entity_decode((string) ($record['description'] ?? ''), ENT_QUOTES, 'UTF-8'), ENT_XML1 | ENT_SUBSTITUTE, 'UTF-8');
+
+                                $entry = $dom->createElement('Entry');
+                                $entry->appendChild($dom->createElement('UUID', $generateUUID()));
+                                $entry->appendChild($dom->createElement('IconID', '0'));
+                                $entry->appendChild($buildTimes($dom));
+
+                                $strTitle = $dom->createElement('String');
+                                $strTitle->appendChild($dom->createElement('Key', 'Title'));
+                                $strTitle->appendChild($dom->createElement('Value', $c_label));
+                                $entry->appendChild($strTitle);
+
+                                $strUser = $dom->createElement('String');
+                                $strUser->appendChild($dom->createElement('Key', 'UserName'));
+                                $strUser->appendChild($dom->createElement('Value', $c_login));
+                                $entry->appendChild($strUser);
+
+                                $strPw = $dom->createElement('String');
+                                $strPw->appendChild($dom->createElement('Key', 'Password'));
+                                $pwVal = $dom->createElement('Value', $c_pw);
+                                $pwVal->setAttribute('ProtectInMemory', 'True');
+                                $strPw->appendChild($pwVal);
+                                $entry->appendChild($strPw);
+
+                                $strUrl = $dom->createElement('String');
+                                $strUrl->appendChild($dom->createElement('Key', 'URL'));
+                                $strUrl->appendChild($dom->createElement('Value', $c_url));
+                                $entry->appendChild($strUrl);
+
+                                $strNotes = $dom->createElement('String');
+                                $strNotes->appendChild($dom->createElement('Key', 'Notes'));
+                                $strNotes->appendChild($dom->createElement('Value', $c_desc));
+                                $entry->appendChild($strNotes);
+
+                                $targetGroup->appendChild($entry);
+
+                                logItems(
+                                    $SETTINGS,
+                                    (int) $record['id'],
+                                    (string) $record['label'],
+                                    $session->get('user-id'),
+                                    'at_export',
+                                    $session->get('user-login'),
+                                    'xml'
+                                );
+                            }
+                        }
+                    }
+                }
+
+                echo prepareExchangedData(array(
+                    'error' => false,
+                    'xml_content' => base64_encode($dom->saveXML()),
+                ), 'encode');
+
+            } catch (\Throwable $e) {
+                error_log('[TeamPass XML Export FATAL] ' . $e->getMessage());
+                echo prepareExchangedData(array(
+                    'error' => true,
+                    'message' => $lang->get('an_error_occurred'),
+                ), 'encode');
+            }
+            break;
+
         case 'export_to_csv_format':
             //Init
             $full_listing = array();
@@ -248,7 +463,7 @@ if (null !== $post_type) {
                                             array_push($arr_trees, $rec_parent_tree['title']);
                                         }
                                     }
-                                    
+
                                     $arr_trees = array_reverse($arr_trees);
                                 }
 
@@ -290,7 +505,7 @@ if (null !== $post_type) {
             foreach ($full_listing as $value) {
                 $tmp .= array2csv($value);
             }
-            
+
             // deepcode ignore XSS: Data is encrypted before being sent to the client
             echo prepareExchangedData(
                 array(
@@ -507,7 +722,7 @@ if (null !== $post_type) {
             );
             break;
 
-        
+
 
         case 'finalize_export_pdf':
             // Check KEY
@@ -533,8 +748,8 @@ if (null !== $post_type) {
 
             // query
             $rows = DB::query(
-                'SELECT * 
-                FROM ' . prefixTable('export') . ' 
+                'SELECT *
+                FROM ' . prefixTable('export') . '
                 WHERE export_tag = %s',
                 $dataReceived['export_tag']
             );
@@ -578,7 +793,7 @@ if (null !== $post_type) {
 
                 // set auto page breaks
                 $pdf->SetAutoPageBreak(TRUE, PDF_MARGIN_BOTTOM);
-                
+
                 // set image scale factor
                 $pdf->setImageScale(PDF_IMAGE_SCALE_RATIO);
 
@@ -759,7 +974,7 @@ if (null !== $post_type) {
 
                     // Decrypt the password through the user's sharekey (migration-aware)
                     $dataItem = DB::queryFirstRow(
-                        'SELECT i.pw AS pw, i.pw_len AS pw_len, s.share_key AS share_key, s.increment_id AS sharekey_id
+                        'SELECT i.pw AS pw, i.pw_iv AS pw_iv, i.pw_len AS pw_len, s.share_key AS share_key, s.increment_id AS sharekey_id
                         FROM ' . prefixTable('items') . ' AS i
                         INNER JOIN ' . prefixTable('sharekeys_items') . ' AS s ON (s.object_id = i.id)
                         WHERE s.user_id = %i AND i.id = %i',
@@ -778,7 +993,8 @@ if (null !== $post_type) {
                                 (int) $dataItem['sharekey_id'],
                                 'sharekeys_items'
                             ),
-                            (int) ($dataItem['pw_len'] ?? 0)
+                            (int) ($dataItem['pw_len'] ?? 0),
+                            (string) ($dataItem['pw_iv'] ?? '')
                         );
                     }
 


### PR DESCRIPTION
## 1. Branch Rebase & Repository Cleanup
* Switched to branch `pr-5295` targeting `origin/develop`.

## 2. Restored AES v2 Metadata (`pw_iv`) across Export Paths *(Blocking Point 2)*
* Restored `i.pw_iv AS pw_iv` in `SELECT` statements for:
  * **CSV export path** (`export_to_csv_format`)
  * **PDF export path** (`export_prepare_data`)
  * **HTML export path** (`export_to_html_format`)
* Restored `(string) ($dataItem['pw_iv'] ?? '')` as the 4th argument in `teampassDecryptPasswordValue()` across CSV, PDF, and HTML export paths so AES v2 encrypted passwords decrypt correctly.

## 3. XML Password Decryption & Key Migration *(Blocking Point 3)*
* Updated item sharekey query in `export_to_xml_format` to include `s.increment_id AS increment_id`, `i.pw_iv AS pw_iv`, and `i.pw_len AS pw_len`.
* Replaced `base64_decode(doDataDecryption(...))` with:

```php
$pw = teampassDecryptPasswordValue(
    $dataItem['pw'],
    decryptUserObjectKeyWithMigration(
        $dataItem['share_key'],
        $session->get('user-private_key'),
        $session->get('user-public_key'),
        (int) $dataItem['increment_id'],
        'sharekeys_items'
    ),
    (int) ($dataItem['pw_len'] ?? 0),
    (string) ($dataItem['pw_iv'] ?? '')
);
```

## 4. Item-Level Restriction Check *(Blocking Authorization Point 4)*
* Updated XML items query to select `i.restricted_to`.
* Added item-level visibility & restriction check inside `export_to_xml_format`:

```php
if (
    !(
        in_array((int) $record['id_tree'], (array) $session->get('user-personal_visible_folders')) === true
        || (
            in_array((int) $record['id_tree'], (array) $session->get('user-accessible_folders')) === true
            && (
                empty($record['restricted_to']) === true
                || in_array((string) $session->get('user-id'), explode(';', (string) $record['restricted_to'])) === true
            )
        )
    )
) {
    continue;
}
```

## 5. Audit Logging for XML Export *(Blocking Point 5)*
* Added `logItems` call for each item exported in `export_to_xml_format`:

```php
logItems(
    $SETTINGS,
    (int) $record['id'],
    (string) $record['label'],
    $session->get('user-id'),
    'at_export',
    $session->get('user-login'),
    'xml'
);
```

## 6. Client Error Message Security *(Blocking Point 6)*
* Replaced raw exception message leak with generic error message:

```php
} catch (\Throwable $e) {
    error_log('[TeamPass XML Export FATAL] ' . $e->getMessage());
    echo prepareExchangedData(array(
        'error' => true,
        'message' => $lang->get('an_error_occurred'),
    ), 'encode');
}
```

## 7. English Localization & Code Cleanups *(Blocking Point 7 & Minor Points)*
* **Translations:** Translated remaining Italian comments to English (e.g., `// Helper functions for KeePass standard`, `// Main Group (Database)`).
* **Templates:** Updated `export.php` to use `<?php echo $lang->get('export_format_keepass_xml'); ?>` and aligned indentation.
* **Frontend:** Fixed JS error handling in `export.js.php`: added early `if (data.error === true)` check prior to success toast.
* **Performance:** Optimized JS byte conversion using `Uint8Array.from(byteCharacters, c => c.charCodeAt(0))`.
* **Encoding:** Used `ENT_XML1 | ENT_SUBSTITUTE` with `htmlspecialchars()` to prevent dropping passwords on invalid UTF-8 sequences.
* **Refactoring:** Removed `@ini_set('memory_limit', '-1')`, `@set_time_limit(0)`, and `while (ob_get_level() > 0) { ob_end_clean(); }`.
* **Static Analysis:** Removed dead coalescing `$pw ?? ''` to satisfy PHPStan level 4.