### PR TITLE
Fix Security Posture authorization, password health consistency, and warning contrast

### DIFF
--- a/app/config/include.php
+++ b/app/config/include.php
@@ -101,6 +101,7 @@ define('TP_PW_STRENGTH_2', 20);
 define('TP_PW_STRENGTH_3', 38);
 define('TP_PW_STRENGTH_4', 48);
 define('TP_PW_STRENGTH_5', 60);
+define('TP_SECURITY_PASSWORD_MIN_LENGTH', 12);
 define('MIN_PHP_VERSION', '8.2');
 define('MIN_MYSQL_VERSION', '8.0.13');
 define('MIN_MARIADB_VERSION', '10.2.1');

--- a/app/core/security-nudges.js.php
+++ b/app/core/security-nudges.js.php
@@ -122,7 +122,7 @@ $lang = new Language($session->get('user-language') ?? 'english');
                 var fixLink = 'index.php?page=items&group=' + folderId + '&id=' + itemId + '&action=edit'
                 var $fix = $('<a>')
                     .attr('href', fixLink)
-                    .addClass('btn btn-sm btn-light ml-1')
+                    .addClass('btn btn-sm btn-light text-dark ml-1')
                     .html('<i class="fa-solid fa-wrench mr-1"></i>' + L.fix)
                 $banner.find('.tp-nudge-actions').append($fix)
             }

--- a/app/includes/language/english.php
+++ b/app/includes/language/english.php
@@ -2631,6 +2631,7 @@ return array(
     'security_dashboard_scanned_users' => 'Users scanned',
     'security_dashboard_admin_zk_note' => 'Aggregated counts only. Per-user reused/unreadable figures come from each user\'s own scan; no password is ever read across users.',
     'security_dashboard_weak' => 'Weak',
+    'security_dashboard_unassessed' => 'Not assessed',
     'security_dashboard_reused' => 'Reused',
     'security_dashboard_breached' => 'Breached',
     'security_dashboard_overdue' => 'Overdue',

--- a/app/includes/language/french.php
+++ b/app/includes/language/french.php
@@ -2565,6 +2565,7 @@ return array(
     'security_dashboard_scanned_users' => 'Utilisateurs analysés',
     'security_dashboard_admin_zk_note' => 'Compteurs agrégés uniquement. Les chiffres de réutilisation/illisibilité par utilisateur proviennent de l’analyse de chaque utilisateur ; aucun mot de passe n’est lu entre utilisateurs.',
     'security_dashboard_weak' => 'Faible',
+    'security_dashboard_unassessed' => 'Non évalué',
     'security_dashboard_reused' => 'Réutilisé',
     'security_dashboard_breached' => 'Compromis',
     'security_dashboard_overdue' => 'Expiré',

--- a/app/pages/dashboard.js.php
+++ b/app/pages/dashboard.js.php
@@ -104,6 +104,7 @@ if ($checkUserAccess->checkSession() === false || $checkUserAccess->userAccessPa
         },
         flags: {
             flag_weak: { label: <?php echo json_encode($lang->get('security_dashboard_weak'), JSON_UNESCAPED_UNICODE); ?>, cls: 'badge-warning' },
+            flag_unassessed: { label: <?php echo json_encode($lang->get('security_dashboard_unassessed'), JSON_UNESCAPED_UNICODE); ?>, cls: 'badge-secondary' },
             flag_reused: { label: <?php echo json_encode($lang->get('security_dashboard_reused'), JSON_UNESCAPED_UNICODE); ?>, cls: 'badge-warning' },
             flag_breached: { label: <?php echo json_encode($lang->get('security_dashboard_breached'), JSON_UNESCAPED_UNICODE); ?>, cls: 'badge-danger' },
             flag_overdue: { label: <?php echo json_encode($lang->get('security_dashboard_overdue'), JSON_UNESCAPED_UNICODE); ?>, cls: 'badge-warning' },
@@ -142,7 +143,7 @@ if ($checkUserAccess->checkSession() === false || $checkUserAccess->userAccessPa
             scored += '<li>' + esc(label) + ' <span class="text-muted">(×' + (parseInt(w[k], 10) || 0) + ')</span></li>';
         });
         let notCounted = '';
-        ['no_expiry', 'overshared'].forEach(function (k) {
+        ['unassessed', 'no_expiry', 'overshared'].forEach(function (k) {
             const meta = TP_DASH.flags['flag_' + k];
             notCounted += '<li>' + esc(meta ? meta.label : k) + '</li>';
         });

--- a/app/pages/dashboard.php
+++ b/app/pages/dashboard.php
@@ -177,6 +177,7 @@ header('Cache-Control: no-cache, no-store, must-revalidate');
                     <?php
                     $cards = [
                         ['key' => 'weak', 'icon' => 'fa-thermometer-empty', 'color' => 'bg-warning'],
+                        ['key' => 'unassessed', 'icon' => 'fa-circle-question', 'color' => 'bg-secondary'],
                         ['key' => 'reused', 'icon' => 'fa-clone', 'color' => 'bg-warning'],
                         ['key' => 'breached', 'icon' => 'fa-triangle-exclamation', 'color' => 'bg-danger'],
                         ['key' => 'overdue', 'icon' => 'fa-clock-rotate-left', 'color' => 'bg-warning'],

--- a/app/pages/items.js.php
+++ b/app/pages/items.js.php
@@ -5725,58 +5725,91 @@ $bip39Wordlist = loadBip39Wordlist($session->get('user-language') ?? 'english');
 <?php } ?>
     }
 
+    let healthBadgeRequestGeneration = 0
+
     /**
      * F8 — decorate at-risk items in the current list with a single health marker.
      * Complements (never duplicates) the item-card HIBP badge shown only when an item
-     * is opened. Metadata-only; driven by the per-user item_health flags via get_folder_flags.
+     * is opened. Metadata-only; combines live item metadata and per-user scan flags.
      */
     function applyHealthBadges() {
-        var ids = [];
+        const requestGeneration = ++healthBadgeRequestGeneration
+        const ids = []
         $('#teampass_items_list tr[data-item-id]').each(function () {
-            var id = parseInt($(this).data('item-id'), 10);
-            if (id > 0) ids.push(id);
-        });
-        if (ids.length === 0) return;
+            const id = parseInt($(this).data('item-id'), 10)
+            if (id > 0 && ids.indexOf(id) === -1) ids.push(id)
+        })
 
-        var nudgeLabels = {
+        $('#teampass_items_list .tp-item-health-marker').tooltip('dispose').remove()
+        if (ids.length === 0) return
+
+        const nudgeLabels = {
             breached: '<?php echo addslashes($lang->get('security_dashboard_breached')); ?>',
             weak: '<?php echo addslashes($lang->get('security_dashboard_weak')); ?>',
+            unassessed: '<?php echo addslashes($lang->get('security_dashboard_unassessed')); ?>',
             reused: '<?php echo addslashes($lang->get('security_dashboard_reused')); ?>',
             overdue: '<?php echo addslashes($lang->get('security_dashboard_overdue')); ?>'
-        };
-        var badgeTitlePrefix = '<?php echo addslashes($lang->get('security_nudges_list_badge_title')); ?>';
-        var nudgeSessionKey = '<?php echo $session->get('key'); ?>';
+        }
+        const badgeTitlePrefix = '<?php echo addslashes($lang->get('security_nudges_list_badge_title')); ?>'
+        const nudgeSessionKey = '<?php echo $session->get('key'); ?>'
+        const requests = []
 
-        $.post('sources/dashboard.queries.php', { type: 'get_folder_flags', item_ids: ids.join(','), key: nudgeSessionKey }, function (response) {
-            var data;
-            try {
-                data = prepareExchangedData(response, 'decode', nudgeSessionKey);
-            } catch (e) {
-                return;
-            }
-            if (!data || data.error === true || !data.flags) return;
+        // The endpoint intentionally accepts at most 500 ids. Chunk the full rendered list and
+        // merge every response so progressively loaded or very large folders remain complete.
+        for (let offset = 0; offset < ids.length; offset += 500) {
+            const chunk = ids.slice(offset, offset + 500)
+            requests.push(new Promise(function (resolve) {
+                $.post(
+                    'sources/dashboard.queries.php',
+                    {type: 'get_folder_flags', item_ids: chunk.join(','), key: nudgeSessionKey}
+                ).done(function (response) {
+                    try {
+                        const data = prepareExchangedData(response, 'decode', nudgeSessionKey)
+                        resolve(data && data.error !== true && data.flags ? data.flags : {})
+                    } catch (e) {
+                        resolve({})
+                    }
+                }).fail(function () {
+                    resolve({})
+                })
+            }))
+        }
 
-            Object.keys(data.flags).forEach(function (itemId) {
-                var f = data.flags[itemId];
-                var labels = [];
-                if (f.breached === 1) labels.push(nudgeLabels.breached);
-                if (f.weak === 1) labels.push(nudgeLabels.weak);
-                if (f.reused === 1) labels.push(nudgeLabels.reused);
-                if (f.overdue === 1) labels.push(nudgeLabels.overdue);
-                if (labels.length === 0) return;
+        Promise.all(requests).then(function (responses) {
+            // Ignore responses from a folder/list generation that has already been replaced.
+            if (requestGeneration !== healthBadgeRequestGeneration) return
 
-                var $container = $('#list-item-row_' + itemId + ' .icon-container');
-                if ($container.length === 0 || $container.find('.tp-item-health-marker').length > 0) return;
+            const flags = {}
+            responses.forEach(function (responseFlags) {
+                Object.keys(responseFlags).forEach(function (itemId) {
+                    flags[itemId] = responseFlags[itemId]
+                })
+            })
 
-                var cls = f.breached === 1 ? 'text-danger' : 'text-warning';
+            Object.keys(flags).forEach(function (itemId) {
+                const f = flags[itemId]
+                const labels = []
+                if (f.breached === 1) labels.push(nudgeLabels.breached)
+                if (f.weak === 1) labels.push(nudgeLabels.weak)
+                if (f.unassessed === 1) labels.push(nudgeLabels.unassessed)
+                if (f.reused === 1) labels.push(nudgeLabels.reused)
+                if (f.overdue === 1) labels.push(nudgeLabels.overdue)
+                if (labels.length === 0) return
+
+                const $container = $('#list-item-row_' + itemId + ' .icon-container')
+                if ($container.length === 0) return
+
+                const cls = f.breached === 1
+                    ? 'text-danger'
+                    : (f.weak === 1 || f.reused === 1 || f.overdue === 1 ? 'text-warning' : 'text-secondary')
                 $container.append(
                     $('<i>')
                         .addClass('fa-solid fa-shield-halved mr-1 infotip tp-item-health-marker ' + cls)
                         .attr('title', badgeTitlePrefix + ' — ' + labels.join(', '))
-                );
-                $container.find('.tp-item-health-marker').tooltip();
-            });
-        });
+                )
+                $container.find('.tp-item-health-marker').tooltip()
+            })
+        })
     }
 
     $(document).on('click', '.open-folder', function() {
@@ -6594,18 +6627,19 @@ $bip39Wordlist = loadBip39Wordlist($session->get('user-language') ?? 'english');
                     // is not shown here — the HIBP badge already covers it on the card.
                     const $pwBadge = $('#card-item-pwd-security-badge')
                     const pwHealth = data.pw_health
-                    if (pwHealth && (pwHealth.weak === 1 || pwHealth.reused === 1)) {
+                    if (pwHealth && (pwHealth.weak === 1 || pwHealth.unassessed === 1 || pwHealth.reused === 1)) {
                         const pwIssues = []
                         if (pwHealth.weak === 1) pwIssues.push('<?php echo addslashes($lang->get('security_dashboard_weak')); ?>')
+                        if (pwHealth.unassessed === 1) pwIssues.push('<?php echo addslashes($lang->get('security_dashboard_unassessed')); ?>')
                         if (pwHealth.reused === 1) pwIssues.push('<?php echo addslashes($lang->get('security_dashboard_reused')); ?>')
                         $pwBadge
-                            .removeClass('hidden badge-success badge-danger')
-                            .addClass('badge-warning infotip')
+                            .removeClass('hidden badge-success badge-danger badge-warning badge-secondary')
+                            .addClass((pwHealth.weak === 1 || pwHealth.reused === 1 ? 'badge-warning' : 'badge-secondary') + ' infotip')
                             .attr('title', '<?php echo addslashes($lang->get('security_nudges_list_badge_title')); ?>' + ' — ' + pwIssues.join(', '))
                             .html('<i class="fa-solid fa-shield-halved mr-1 infotip"></i>')
                         $pwBadge.find('.infotip').tooltip()
                     } else {
-                        $pwBadge.addClass('hidden').removeClass('badge-success badge-danger badge-warning')
+                        $pwBadge.addClass('hidden').removeClass('badge-success badge-danger badge-warning badge-secondary')
                     }
 
                     $('#card-item-login').html(data.login);

--- a/app/scripts/background_tasks___do_calculation.php
+++ b/app/scripts/background_tasks___do_calculation.php
@@ -115,7 +115,7 @@ foreach ($ret as $folder) {
 
 // Get user key
 $userKey = DB::queryFirstRow(
-    'SELECT u.pw, pk.private_key
+    'SELECT u.pw, u.public_key, pk.private_key
     FROM '.prefixTable('users').' AS u
     LEFT JOIN '.prefixTable('user_private_keys').' AS pk ON (u.id = pk.user_id AND pk.is_current = 1)
     WHERE u.id = %i',
@@ -131,7 +131,10 @@ $items = DB::query(
     FROM '.prefixTable('items').' AS i
     WHERE i.pw != ""
     AND i.perso = 0
-    AND ((i.pw_len = %i OR i.pw_len IS NULL) OR (i.complexity_level = %i OR i.complexity_level IS NULL))
+    AND (
+        (i.pw_len = %i OR i.pw_len IS NULL)
+        OR (i.complexity_level = %i OR i.complexity_level IS NULL OR i.complexity_level = "")
+    )
     LIMIT 0, 100',
     0,
     -1
@@ -139,7 +142,7 @@ $items = DB::query(
 foreach ($items as $item) {
     // Get item key
     $itemKey = DB::queryFirstRow(
-        'SELECT share_key
+        'SELECT share_key, increment_id
         FROM ' . prefixTable('sharekeys_items') . '
         WHERE user_id = %i AND object_id = %i',
         TP_USER_ID,
@@ -147,16 +150,19 @@ foreach ($items as $item) {
     );
 
     // if no key, continue
-    if ($itemKey['share_key'] === null) {
+    if (is_array($itemKey) === false || empty($itemKey['share_key']) === true) {
         continue;
     }
 
     // decrypt password
     $password = teampassDecryptPasswordValue(
         $item['pw'],
-        decryptUserObjectKey(
+        decryptUserObjectKeyWithMigration(
             $itemKey['share_key'],
             $userPrivateKey,
+            (string) $userKey['public_key'],
+            (int) $itemKey['increment_id'],
+            'sharekeys_items'
         ),
         (int) ($item['pw_len'] ?? 0),
         (string) ($item['pw_iv'] ?? '')

--- a/app/sources/dashboard.queries.php
+++ b/app/sources/dashboard.queries.php
@@ -111,10 +111,9 @@ $post_include_hibp = (int) $request->request->filter('include_hibp', 0, FILTER_S
 $userId = (int) $session->get('user-id');
 $nowTs = time();
 
-// Folder-level guard. Every query below is scoped by sharekey, which makes this page the place
-// where a stray sharekey would become visible: a personal item of another user must never be
-// listed here even if the current account happens to hold a key for it.
-$personalScopeSql = personalScopeSqlForUser($userId);
+// A sharekey is cryptographic material, not an authorization grant. Every posture query below
+// also applies the user's current folder grants, denials, personal tree and item restrictions.
+$accessScopeSql = securityPostureItemAccessSql($userId);
 
 // Over-shared threshold (number of users above which an item is considered widely shared).
 $oversharedThreshold = (int) ($SETTINGS['security_dashboard_overshared_threshold'] ?? 10);
@@ -181,7 +180,8 @@ switch ($post_type) {
             INNER JOIN ' . prefixTable('nested_tree') . ' AS n ON (n.id = i.id_tree)' .
             $logJoinSql . $shareCountJoinSql . '
             LEFT JOIN ' . prefixTable('item_health') . ' AS ih ON (ih.item_id = i.id AND ih.user_id = %i)
-            WHERE i.inactif = 0 AND i.deleted_at IS NULL' . $personalScopeSql;
+            WHERE i.inactif = 0 AND i.deleted_at IS NULL
+                AND ' . $accessScopeSql;
         $flagSumSql = '(t.flag_weak + t.flag_no_expiry + t.flag_overdue + t.flag_overshared + t.flag_breached + t.flag_reused + t.flag_orphaned)';
 
         // Paging window for the flagged-items list (incremental "load more").
@@ -253,7 +253,8 @@ switch ($post_type) {
                 INNER JOIN ' . prefixTable('sharekeys_items') . ' AS sk ON (sk.object_id = i.id AND sk.user_id = %i)
                 INNER JOIN ' . prefixTable('nested_tree') . ' AS n ON (n.id = i.id_tree)' .
                 $logJoinSql . $shareCountJoinSql . '
-                WHERE i.inactif = 0 AND i.deleted_at IS NULL' . $personalScopeSql,
+                WHERE i.inactif = 0 AND i.deleted_at IS NULL
+                    AND ' . $accessScopeSql,
                 $userId,
                 'at_creation',
                 'at_modification',
@@ -263,11 +264,17 @@ switch ($post_type) {
             // Reused/orphaned and last-scan come from the persisted per-user table.
             $healthAgg = DB::queryFirstRow(
                 'SELECT
-                    COALESCE(SUM(flag_reused), 0) AS reused,
-                    COALESCE(SUM(flag_orphaned), 0) AS orphaned,
-                    COALESCE(MAX(last_scan_at), 0) AS last_scan
-                FROM ' . prefixTable('item_health') . '
-                WHERE user_id = %i',
+                    COALESCE(SUM(ih.flag_reused), 0) AS reused,
+                    COALESCE(SUM(ih.flag_orphaned), 0) AS orphaned,
+                    COALESCE(MAX(ih.last_scan_at), 0) AS last_scan
+                FROM ' . prefixTable('item_health') . ' AS ih
+                INNER JOIN ' . prefixTable('items') . ' AS i ON (i.id = ih.item_id)
+                INNER JOIN ' . prefixTable('sharekeys_items') . ' AS sk
+                    ON (sk.object_id = i.id AND sk.user_id = ih.user_id)
+                WHERE ih.user_id = %i
+                    AND i.inactif = 0
+                    AND i.deleted_at IS NULL
+                    AND ' . $accessScopeSql,
                 $userId
             );
 
@@ -341,7 +348,8 @@ switch ($post_type) {
             'SELECT COUNT(*)
             FROM ' . prefixTable('items') . ' AS i
             INNER JOIN ' . prefixTable('sharekeys_items') . ' AS sk ON (sk.object_id = i.id AND sk.user_id = %i)
-            WHERE i.inactif = 0 AND i.deleted_at IS NULL' . $personalScopeSql,
+            WHERE i.inactif = 0 AND i.deleted_at IS NULL
+                AND ' . $accessScopeSql,
             $userId
         );
 
@@ -355,7 +363,8 @@ switch ($post_type) {
             INNER JOIN ' . prefixTable('sharekeys_items') . ' AS sk ON (sk.object_id = i.id AND sk.user_id = %i)
             INNER JOIN ' . prefixTable('nested_tree') . ' AS n ON (n.id = i.id_tree)' .
             $logJoinSql . $shareCountJoinSql . '
-            WHERE i.inactif = 0 AND i.deleted_at IS NULL' . $personalScopeSql . '
+            WHERE i.inactif = 0 AND i.deleted_at IS NULL
+                AND ' . $accessScopeSql . '
             ORDER BY i.id ASC
             LIMIT %i OFFSET %i',
             $userId,
@@ -470,7 +479,7 @@ switch ($post_type) {
 
     /*
      * CASE
-     * Finalise the scan: compute reuse flags from the buckets, prune stale rows.
+     * Finalise the scan: prune stale rows and compute reuse flags from the buckets.
      */
     case 'finalize_scan':
         if ($post_key !== $session->get('key')) {
@@ -478,30 +487,8 @@ switch ($post_type) {
             break;
         }
 
-        // Reset, then flag every item whose bucket has more than one member
-        // (canonical logic shared with the save-time refresh).
+        // The canonical finalizer first prunes inaccessible/stale rows, then recomputes reuse.
         finalizeUserReuseFlags($userId);
-
-        // Hygiene: drop rows for items the user can no longer access.
-        DB::query(
-            'DELETE ih FROM ' . prefixTable('item_health') . ' AS ih
-            LEFT JOIN ' . prefixTable('sharekeys_items') . ' AS sk ON (sk.object_id = ih.item_id AND sk.user_id = ih.user_id)
-            WHERE ih.user_id = %i AND sk.increment_id IS NULL',
-            $userId
-        );
-
-        // Hygiene: drop rows that fell out of the folder scope (stray sharekey on another
-        // user's personal item), so the persisted counts converge with the live queries.
-        $foreignPersonalFolders = getForeignPersonalFolderIds($userId);
-        if (count($foreignPersonalFolders) > 0) {
-            DB::query(
-                'DELETE ih FROM ' . prefixTable('item_health') . ' AS ih
-                INNER JOIN ' . prefixTable('items') . ' AS i ON (i.id = ih.item_id)
-                WHERE ih.user_id = %i AND i.id_tree IN %li',
-                $userId,
-                $foreignPersonalFolders
-            );
-        }
 
         // F10: freeze the score snapshot so the dashboard can show "+N since last scan".
         // Computed after the reuse flags are finalised, so `reused` is accurate.
@@ -620,7 +607,9 @@ switch ($post_type) {
             INNER JOIN ' . prefixTable('nested_tree') . ' AS n ON (n.id = i.id_tree)' .
             $logJoinSql . '
             LEFT JOIN ' . prefixTable('item_health') . ' AS ih ON (ih.item_id = i.id AND ih.user_id = %i)
-            WHERE i.inactif = 0 AND i.deleted_at IS NULL' . $personalScopeSql . ' AND i.id IN %li',
+            WHERE i.inactif = 0 AND i.deleted_at IS NULL
+                AND ' . $accessScopeSql . '
+                AND i.id IN %li',
             $userId, 'at_creation', 'at_modification', 'at_pw%', $userId, $itemIds
         );
 

--- a/app/sources/dashboard.queries.php
+++ b/app/sources/dashboard.queries.php
@@ -120,12 +120,11 @@ $oversharedThreshold = (int) ($SETTINGS['security_dashboard_overshared_threshold
 if ($oversharedThreshold <= 0) {
     $oversharedThreshold = 10;
 }
-// "Weak" = password strength strictly below "medium".
-$weakThreshold = TP_PW_STRENGTH_3;
-
 // Reusable SQL fragments — all metadata-only (no decryption, no plaintext).
 $lastRelevantSql = 'COALESCE(NULLIF(l.last_relevant_date, 0), NULLIF(CAST(i.created_at AS UNSIGNED), 0), 0)';
-$flagWeakSql = "(CASE WHEN i.complexity_level <> '' AND CAST(i.complexity_level AS SIGNED) >= 0 AND CAST(i.complexity_level AS SIGNED) < " . (int) $weakThreshold . " THEN 1 ELSE 0 END)";
+$passwordHealthSql = securityPasswordHealthSql();
+$flagWeakSql = $passwordHealthSql['weak'];
+$flagUnassessedSql = $passwordHealthSql['unassessed'];
 $flagNoExpirySql = '(CASE WHEN n.renewal_period <= 0 THEN 1 ELSE 0 END)';
 $flagOverdueSql = '(CASE WHEN n.renewal_period > 0 AND ' . $lastRelevantSql . ' > 0 AND (' . $lastRelevantSql . ' + n.renewal_period * ' . TP_ONE_DAY_SECONDS . ') <= ' . (int) $nowTs . ' THEN 1 ELSE 0 END)';
 $flagOversharedSql = '(CASE WHEN COALESCE(sc.share_count, 0) > ' . (int) $oversharedThreshold . ' THEN 1 ELSE 0 END)';
@@ -157,7 +156,8 @@ switch ($post_type) {
 
         // Flag whitelist -> derived-table column. Filters the list to one issue type.
         $flagColumns = [
-            'weak' => 't.flag_weak', 'reused' => 't.flag_reused', 'breached' => 't.flag_breached',
+            'weak' => 't.flag_weak', 'unassessed' => 't.flag_unassessed',
+            'reused' => 't.flag_reused', 'breached' => 't.flag_breached',
             'overdue' => 't.flag_overdue', 'no_expiry' => 't.flag_no_expiry',
             'overshared' => 't.flag_overshared', 'orphaned' => 't.flag_orphaned',
         ];
@@ -169,6 +169,7 @@ switch ($post_type) {
         $flaggedInnerSql =
             'SELECT i.id, i.label, i.id_tree,
                 ' . $flagWeakSql . ' AS flag_weak,
+                ' . $flagUnassessedSql . ' AS flag_unassessed,
                 ' . $flagNoExpirySql . ' AS flag_no_expiry,
                 ' . $flagOverdueSql . ' AS flag_overdue,
                 ' . $flagOversharedSql . ' AS flag_overshared,
@@ -182,7 +183,7 @@ switch ($post_type) {
             LEFT JOIN ' . prefixTable('item_health') . ' AS ih ON (ih.item_id = i.id AND ih.user_id = %i)
             WHERE i.inactif = 0 AND i.deleted_at IS NULL
                 AND ' . $accessScopeSql;
-        $flagSumSql = '(t.flag_weak + t.flag_no_expiry + t.flag_overdue + t.flag_overshared + t.flag_breached + t.flag_reused + t.flag_orphaned)';
+        $flagSumSql = '(t.flag_weak + t.flag_unassessed + t.flag_no_expiry + t.flag_overdue + t.flag_overshared + t.flag_breached + t.flag_reused + t.flag_orphaned)';
 
         // Paging window for the flagged-items list (incremental "load more").
         $listLimit = ($post_limit > 0 && $post_limit <= 200) ? $post_limit : 50;
@@ -192,7 +193,7 @@ switch ($post_type) {
         $rows = DB::query(
             'SELECT t.* FROM (' . $flaggedInnerSql . $folderClauseSql . ') AS t
             WHERE ' . $flagSumSql . ' > 0' . $flagFilterSql . '
-            ORDER BY (t.flag_breached + t.flag_reused) DESC, t.flag_weak DESC, t.id DESC
+            ORDER BY (t.flag_breached + t.flag_reused) DESC, t.flag_weak DESC, t.flag_unassessed DESC, t.id DESC
             LIMIT %i OFFSET %i',
             $userId, 'at_creation', 'at_modification', 'at_pw%', $userId, $listLimit, $listOffset
         );
@@ -219,6 +220,7 @@ switch ($post_type) {
                 'label' => (string) $r['label'],
                 'path' => implode(' › ', $path),
                 'flag_weak' => (int) $r['flag_weak'],
+                'flag_unassessed' => (int) $r['flag_unassessed'],
                 'flag_no_expiry' => (int) $r['flag_no_expiry'],
                 'flag_overdue' => (int) $r['flag_overdue'],
                 'flag_overshared' => (int) $r['flag_overshared'],
@@ -245,6 +247,7 @@ switch ($post_type) {
                 'SELECT
                     COUNT(*) AS total,
                     SUM(' . $flagWeakSql . ') AS weak,
+                    SUM(' . $flagUnassessedSql . ') AS unassessed,
                     SUM(' . $flagNoExpirySql . ') AS no_expiry,
                     SUM(' . $flagOverdueSql . ') AS overdue,
                     SUM(' . $flagOversharedSql . ') AS overshared,
@@ -302,6 +305,7 @@ switch ($post_type) {
             $response['counts'] = [
                 'total' => (int) ($summary['total'] ?? 0),
                 'weak' => (int) ($summary['weak'] ?? 0),
+                'unassessed' => (int) ($summary['unassessed'] ?? 0),
                 'no_expiry' => (int) ($summary['no_expiry'] ?? 0),
                 'overdue' => (int) ($summary['overdue'] ?? 0),
                 'overshared' => (int) ($summary['overshared'] ?? 0),
@@ -343,6 +347,7 @@ switch ($post_type) {
         // collide in the stored reuse bucket (no cross-user correlation).
         $reuseSalt = (string) @file_get_contents(TEAMPASS_SECRETS . '/' . SECUREFILE);
         $reuseSalt = $reuseSalt . '|item-health|' . $userId;
+        $zxcvbn = new \ZxcvbnPhp\Zxcvbn();
 
         $total = (int) DB::queryFirstField(
             'SELECT COUNT(*)
@@ -354,7 +359,7 @@ switch ($post_type) {
         );
 
         $rows = DB::query(
-            'SELECT i.id, i.pw, i.pw_iv, i.complexity_level, i.created_at, i.hibp_status,
+            'SELECT i.id, i.pw, i.pw_iv, i.pw_len, i.complexity_level, i.created_at, i.hibp_status,
                 n.renewal_period,
                 ' . $lastRelevantSql . ' AS last_relevant_date,
                 COALESCE(sc.share_count, 0) AS share_count,
@@ -378,9 +383,7 @@ switch ($post_type) {
         foreach ($rows as $r) {
             $itemId = (int) $r['id'];
 
-            // Metadata flags (no decryption needed).
-            $cl = (string) $r['complexity_level'];
-            $flagWeak = ($cl !== '' && (int) $cl >= 0 && (int) $cl < $weakThreshold) ? 1 : 0;
+            // Metadata flags not related to password strength.
             $renewal = (int) $r['renewal_period'];
             $flagNoExpiry = ($renewal <= 0) ? 1 : 0;
             $base = (int) $r['last_relevant_date'];
@@ -409,7 +412,31 @@ switch ($post_type) {
                 }
             }
 
+            $complexityLevel = $r['complexity_level'];
+            $passwordLength = $r['pw_len'] === null ? null : (int) $r['pw_len'];
             if ($plaintext !== '') {
+                $actualPasswordLength = strlen($plaintext);
+                $metadataUpdates = [];
+                $passwordLengthChanged = $passwordLength !== $actualPasswordLength;
+                if ($passwordLengthChanged === true) {
+                    $passwordLength = $actualPasswordLength;
+                    $metadataUpdates['pw_len'] = $actualPasswordLength;
+                }
+                if (
+                    $passwordLengthChanged === true
+                    || $complexityLevel === null
+                    || $complexityLevel === ''
+                    || is_numeric($complexityLevel) === false
+                    || (int) $complexityLevel < 0
+                ) {
+                    $passwordStrength = $zxcvbn->passwordStrength($plaintext);
+                    $complexityLevel = convertPasswordStrength((int) $passwordStrength['score']);
+                    $metadataUpdates['complexity_level'] = $complexityLevel;
+                }
+                if (count($metadataUpdates) > 0) {
+                    DB::update(prefixTable('items'), $metadataUpdates, 'id = %i', $itemId);
+                }
+
                 $reuseGroup = substr(hash_hmac('sha256', $plaintext, $reuseSalt), 0, 32);
 
                 if ($post_include_hibp === 1) {
@@ -430,6 +457,12 @@ switch ($post_type) {
                     }
                 }
             }
+            $passwordHealthStatus = securityPasswordHealthStatus(
+                is_int($complexityLevel) || is_string($complexityLevel) ? $complexityLevel : null,
+                $passwordLength,
+                (string) $r['pw'] !== ''
+            );
+            $flagWeak = $passwordHealthStatus === 'weak' ? 1 : 0;
 
             // Persist per-user flags. flag_reused is left untouched here (finalised later).
             DB::query(
@@ -568,7 +601,7 @@ switch ($post_type) {
      * CASE
      * F8 — per-item health flags for the items-list badge. Complements (never
      * duplicates) the item-card HIBP badge by marking at-risk rows at a glance.
-     * Input: item_ids (CSV). Output: { item_id: {breached,weak,reused,overdue} }
+     * Input: item_ids (CSV). Output: { item_id: {breached,weak,unassessed,reused,overdue} }
      * for flagged items only. Metadata-only, scoped to the user's own entitlement.
      */
     case 'get_folder_flags':
@@ -599,6 +632,7 @@ switch ($post_type) {
         $flagRows = DB::query(
             'SELECT i.id,
                 ' . $flagWeakSql . ' AS flag_weak,
+                ' . $flagUnassessedSql . ' AS flag_unassessed,
                 ' . $flagOverdueSql . ' AS flag_overdue,
                 ' . $flagBreachedSql . ' AS flag_breached,
                 COALESCE(ih.flag_reused, 0) AS flag_reused
@@ -616,13 +650,15 @@ switch ($post_type) {
         $flags = [];
         foreach ($flagRows as $fr) {
             $w = (int) $fr['flag_weak'];
+            $u = (int) $fr['flag_unassessed'];
             $o = (int) $fr['flag_overdue'];
             $b = (int) $fr['flag_breached'];
             $re = (int) $fr['flag_reused'];
-            if ($w + $o + $b + $re > 0) {
+            if ($w + $u + $o + $b + $re > 0) {
                 $flags[(string) (int) $fr['id']] = [
                     'breached' => $b,
                     'weak' => $w,
+                    'unassessed' => $u,
                     'reused' => $re,
                     'overdue' => $o,
                 ];

--- a/app/sources/items.queries.php
+++ b/app/sources/items.queries.php
@@ -3243,16 +3243,21 @@ switch ($inputData['type']) {
             $arrData['label'] = $dataItem['label'] === '' ? '' : $dataItem['label'];
             $pwLength = strlen($passwordForMetrics);
             $arrData['pw_length'] = $pwLength;
-            // Per-item health marker (replaces the old binary pw_is_secure shield): the same
-            // posture signals used by the Security Posture Dashboard (F1), surfaced on the card.
-            // - weak: complexity below "medium" (TP_PW_STRENGTH_3) OR length < 12 (card-only,
-            //   uses the decrypted value available here — the dashboard has no plaintext).
-            // - reused: from the per-user scan (item_health), only when the dashboard is enabled.
+            // Use the same metadata classification as the list and Security Posture. Unknown
+            // legacy values remain "unassessed" until a deep scan or background backfill repairs
+            // them; they must not be reported as weak solely because -1 is below the threshold.
             // breached is intentionally excluded — the HIBP badge already shows it on the card.
-            if ($pwLength === 0) {
-                $arrData['pw_health'] = null; // empty password → no marker
+            $storedPasswordLength = $dataItem['pw_len'] === null ? null : (int) $dataItem['pw_len'];
+            $passwordHealthStatus = securityPasswordHealthStatus(
+                is_int($dataItem['complexity_level']) || is_string($dataItem['complexity_level'])
+                    ? $dataItem['complexity_level']
+                    : null,
+                $storedPasswordLength,
+                (string) $dataItem['pw'] !== ''
+            );
+            if ($passwordHealthStatus === 'empty') {
+                $arrData['pw_health'] = null;
             } else {
-                $flagWeak = (intval($dataItem['complexity_level']) < TP_PW_STRENGTH_3 || $pwLength < 12) ? 1 : 0;
                 $flagReused = 0;
                 if ((int) ($SETTINGS['security_dashboard_enabled'] ?? 0) === 1) {
                     $flagReused = (int) DB::queryFirstField(
@@ -3262,7 +3267,11 @@ switch ($inputData['type']) {
                         (int) $inputData['id']
                     );
                 }
-                $arrData['pw_health'] = ['weak' => $flagWeak, 'reused' => $flagReused];
+                $arrData['pw_health'] = [
+                    'weak' => $passwordHealthStatus === 'weak' ? 1 : 0,
+                    'unassessed' => $passwordHealthStatus === 'unassessed' ? 1 : 0,
+                    'reused' => $flagReused,
+                ];
             }
 
             // HIBP cached status (no API call here — async check is triggered by the JS)
@@ -8371,11 +8380,16 @@ switch ($inputData['type']) {
                 break;
             }
 
-            // Load item and verify user has access via sharekey
+            // A sharekey is required for decryption but is not an authorization grant. Apply the
+            // same current folder and item restrictions as Security Posture before decrypting.
+            $hibpAccessScopeSql = securityPostureItemAccessSql((int) $session->get('user-id'));
             $hibpItem = DB::queryFirstRow(
-                'SELECT pw, pw_iv, hibp_status, hibp_checked_at
-                FROM ' . prefixTable('items') . '
-                WHERE id = %i',
+                'SELECT i.pw, i.pw_iv, i.hibp_status, i.hibp_checked_at
+                FROM ' . prefixTable('items') . ' AS i
+                WHERE i.id = %i
+                    AND i.inactif = 0
+                    AND i.deleted_at IS NULL
+                    AND ' . $hibpAccessScopeSql,
                 $hibpItemId
             );
             if ($hibpItem === null) {

--- a/app/sources/main.functions.php
+++ b/app/sources/main.functions.php
@@ -721,13 +721,11 @@ function getForeignPersonalFolderIds(int $userId): array
 }
 
 /**
- * Build the SQL condition keeping a security-posture query inside the items a user may legitimately
- * see, whatever sharekeys he holds.
+ * Build the legacy personal-folder SQL guard used by security-posture queries.
  *
- * The posture queries (dashboard, nudges, score) are scoped by sharekey only, which makes them the
- * place where a stray sharekey becomes visible. This fragment adds the folder-level guard so
- * another user's personal item can never surface there. Runs both in a web session and in the CLI
- * background worker, so it derives everything from the database (no session).
+ * This helper only excludes another user's personal folders. It does not check shared-folder
+ * grants, explicit denials, or item restrictions and must therefore not be used as an
+ * authorization decision. Use securityPostureItemAccessSql() for posture access checks.
  *
  * @param int    $userId    User the query is run for.
  * @param string $itemAlias SQL alias of the items table in the caller's query.
@@ -743,6 +741,124 @@ function personalScopeSqlForUser(int $userId, string $itemAlias = 'i'): string
 
     // Values are folder ids cast to int - safe to embed.
     return ' AND ' . $itemAlias . '.id_tree NOT IN (' . implode(',', $foreignPersonalFolders) . ')';
+}
+
+/**
+ * Build the SQL predicate limiting Security Posture data to items the user may read.
+ *
+ * A sharekey proves that the user can cryptographically unwrap an item key, but it is not an
+ * authorization grant. This predicate mirrors TeamPass read visibility from database state so it
+ * can be reused both in web requests and CLI workers where no user session is available:
+ * direct folder grants or readable role grants, explicit folder denials, the user's personal
+ * folder tree, and per-item user/role restrictions.
+ *
+ * The caller must already join the items table with the alias supplied in $itemAlias.
+ *
+ * @param int    $userId    User whose read access is evaluated.
+ * @param string $itemAlias SQL alias of the items table in the caller's query.
+ *
+ * @return string Parenthesized SQL predicate without a leading AND.
+ */
+function securityPostureItemAccessSql(int $userId, string $itemAlias = 'i'): string
+{
+    if ($userId <= 0 || preg_match('/^[A-Za-z_][A-Za-z0-9_]*$/', $itemAlias) !== 1) {
+        return '(1 = 0)';
+    }
+
+    $userId = (int) $userId;
+
+    // Values interpolated below are a validated SQL alias and an integer user id.
+    return '(
+        (
+            (
+                EXISTS (
+                    SELECT 1
+                    FROM ' . prefixTable('users') . ' AS posture_personal_user
+                    WHERE posture_personal_user.id = ' . $userId . '
+                        AND posture_personal_user.personal_folder = 1
+                )
+                AND EXISTS (
+                    SELECT 1
+                    FROM ' . prefixTable('misc') . ' AS posture_personal_setting
+                    WHERE posture_personal_setting.type = \'admin\'
+                        AND posture_personal_setting.intitule = \'enable_pf_feature\'
+                        AND posture_personal_setting.valeur = \'1\'
+                )
+                AND EXISTS (
+                    SELECT 1
+                    FROM ' . prefixTable('nested_tree') . ' AS posture_item_folder
+                    INNER JOIN ' . prefixTable('nested_tree') . ' AS posture_own_root
+                        ON posture_own_root.personal_folder = 1
+                        AND posture_own_root.parent_id = 0
+                        AND posture_own_root.title = \'' . $userId . '\'
+                        AND posture_item_folder.nleft >= posture_own_root.nleft
+                        AND posture_item_folder.nright <= posture_own_root.nright
+                    WHERE posture_item_folder.id = ' . $itemAlias . '.id_tree
+                )
+            )
+            OR (
+                ' . $itemAlias . '.perso = 0
+                AND EXISTS (
+                    SELECT 1
+                    FROM ' . prefixTable('nested_tree') . ' AS posture_shared_folder
+                    WHERE posture_shared_folder.id = ' . $itemAlias . '.id_tree
+                )
+                AND NOT EXISTS (
+                    SELECT 1
+                    FROM ' . prefixTable('nested_tree') . ' AS posture_item_folder
+                    INNER JOIN ' . prefixTable('nested_tree') . ' AS posture_personal_anchor
+                        ON posture_personal_anchor.personal_folder = 1
+                        AND posture_personal_anchor.parent_id = 0
+                        AND posture_item_folder.nleft >= posture_personal_anchor.nleft
+                        AND posture_item_folder.nright <= posture_personal_anchor.nright
+                    WHERE posture_item_folder.id = ' . $itemAlias . '.id_tree
+                )
+                AND NOT EXISTS (
+                    SELECT 1
+                    FROM ' . prefixTable('users_groups_forbidden') . ' AS posture_forbidden
+                    WHERE posture_forbidden.user_id = ' . $userId . '
+                        AND posture_forbidden.group_id = ' . $itemAlias . '.id_tree
+                )
+                AND (
+                    EXISTS (
+                        SELECT 1
+                        FROM ' . prefixTable('users_groups') . ' AS posture_direct_grant
+                        WHERE posture_direct_grant.user_id = ' . $userId . '
+                            AND posture_direct_grant.group_id = ' . $itemAlias . '.id_tree
+                    )
+                    OR EXISTS (
+                        SELECT 1
+                        FROM ' . prefixTable('users_roles') . ' AS posture_user_role
+                        INNER JOIN ' . prefixTable('roles_values') . ' AS posture_role_grant
+                            ON posture_role_grant.role_id = posture_user_role.role_id
+                            AND posture_role_grant.folder_id = ' . $itemAlias . '.id_tree
+                            AND posture_role_grant.type IN (\'W\', \'ND\', \'NE\', \'NDNE\', \'R\')
+                        WHERE posture_user_role.user_id = ' . $userId . '
+                    )
+                )
+            )
+        )
+        AND (
+            (
+                COALESCE(' . $itemAlias . '.restricted_to, \'\') = \'\'
+                AND NOT EXISTS (
+                    SELECT 1
+                    FROM ' . prefixTable('restriction_to_roles') . ' AS posture_any_restricted_role
+                    WHERE posture_any_restricted_role.item_id = ' . $itemAlias . '.id
+                )
+            )
+            OR CONCAT(\';\', COALESCE(' . $itemAlias . '.restricted_to, \'\'), \';\')
+                LIKE \'%;' . $userId . ';%\'
+            OR EXISTS (
+                SELECT 1
+                FROM ' . prefixTable('restriction_to_roles') . ' AS posture_restricted_role
+                INNER JOIN ' . prefixTable('users_roles') . ' AS posture_restricted_user_role
+                    ON posture_restricted_user_role.role_id = posture_restricted_role.role_id
+                    AND posture_restricted_user_role.user_id = ' . $userId . '
+                WHERE posture_restricted_role.item_id = ' . $itemAlias . '.id
+            )
+        )
+    )';
 }
 
 
@@ -1235,6 +1351,7 @@ function securityNudgeComputeCounts(int $userId): array
 {
     $nowTs = time();
     $weakThreshold = TP_PW_STRENGTH_3;
+    $accessScopeSql = securityPostureItemAccessSql($userId);
 
     // Metadata-only flag expressions (identical semantics to the dashboard).
     $lastRelevantSql = 'COALESCE(NULLIF(l.last_relevant_date, 0), NULLIF(CAST(i.created_at AS UNSIGNED), 0), 0)';
@@ -1263,7 +1380,8 @@ function securityNudgeComputeCounts(int $userId): array
         INNER JOIN ' . prefixTable('nested_tree') . ' AS n ON (n.id = i.id_tree)' .
         $logJoinSql . '
         LEFT JOIN ' . prefixTable('item_health') . ' AS ih ON (ih.item_id = i.id AND ih.user_id = %i)
-        WHERE i.inactif = 0 AND i.deleted_at IS NULL' . personalScopeSqlForUser($userId);
+        WHERE i.inactif = 0 AND i.deleted_at IS NULL
+            AND ' . $accessScopeSql;
 
     $agg = DB::queryFirstRow(
         'SELECT
@@ -1293,7 +1411,15 @@ function securityNudgeComputeCounts(int $userId): array
     }
 
     $lastScan = (int) DB::queryFirstField(
-        'SELECT COALESCE(MAX(last_scan_at), 0) FROM ' . prefixTable('item_health') . ' WHERE user_id = %i',
+        'SELECT COALESCE(MAX(ih.last_scan_at), 0)
+        FROM ' . prefixTable('item_health') . ' AS ih
+        INNER JOIN ' . prefixTable('items') . ' AS i ON (i.id = ih.item_id)
+        INNER JOIN ' . prefixTable('sharekeys_items') . ' AS sk
+            ON (sk.object_id = i.id AND sk.user_id = ih.user_id)
+        WHERE ih.user_id = %i
+            AND i.inactif = 0
+            AND i.deleted_at IS NULL
+            AND ' . $accessScopeSql,
         $userId
     );
 
@@ -1311,11 +1437,11 @@ function securityNudgeComputeCounts(int $userId): array
 /**
  * Re-derive the per-user `reused` flags in item_health from the stored reuse buckets.
  *
- * Resets flag_reused for the user, then sets it back to 1 for every item whose
- * reuse_group has more than one member. Shared by the dashboard deep scan
- * (`dashboard.queries.php` `finalize_scan`) and the save-time incremental refresh
- * (`refreshItemHealthAfterSave`) so both use one canonical definition of "reused"
- * and never drift.
+ * Prunes rows for stale or currently unauthorized items, resets flag_reused for the user, then
+ * sets it back to 1 for every item whose reuse_group has more than one member. Shared by the
+ * dashboard deep scan (`dashboard.queries.php` `finalize_scan`) and the save-time incremental
+ * refresh (`refreshItemHealthAfterSave`) so both use one canonical definition of "reused" and
+ * never drift.
  *
  * @param int $userId User whose reuse flags are recomputed.
  *
@@ -1323,6 +1449,27 @@ function securityNudgeComputeCounts(int $userId): array
  */
 function finalizeUserReuseFlags(int $userId): void
 {
+    $accessScopeSql = securityPostureItemAccessSql($userId);
+
+    // Remove stale or unauthorized rows before deriving reuse groups. Otherwise an inaccessible
+    // item could make an accessible item appear reused until a later scan.
+    DB::query(
+        'DELETE ih
+        FROM ' . prefixTable('item_health') . ' AS ih
+        LEFT JOIN ' . prefixTable('items') . ' AS i ON (i.id = ih.item_id)
+        LEFT JOIN ' . prefixTable('sharekeys_items') . ' AS sk
+            ON (sk.object_id = ih.item_id AND sk.user_id = ih.user_id)
+        WHERE ih.user_id = %i
+            AND (
+                i.id IS NULL
+                OR sk.increment_id IS NULL
+                OR i.inactif <> 0
+                OR i.deleted_at IS NOT NULL
+                OR NOT ' . $accessScopeSql . '
+            )',
+        $userId
+    );
+
     // Reset, then flag every item whose bucket has more than one member.
     DB::query(
         'UPDATE ' . prefixTable('item_health') . ' SET flag_reused = 0 WHERE user_id = %i',
@@ -1513,13 +1660,15 @@ function securityScoreCompute(int $userId): array
     $maxWeight = 10;
 
     $counts = securityNudgeComputeCounts($userId);
+    $accessScopeSql = securityPostureItemAccessSql($userId);
 
     // Total credentials the user can read — the score denominator.
     $totalItems = (int) DB::queryFirstField(
         'SELECT COUNT(*)
         FROM ' . prefixTable('items') . ' AS i
         INNER JOIN ' . prefixTable('sharekeys_items') . ' AS sk ON (sk.object_id = i.id AND sk.user_id = %i)
-        WHERE i.inactif = 0 AND i.deleted_at IS NULL' . personalScopeSqlForUser($userId),
+        WHERE i.inactif = 0 AND i.deleted_at IS NULL
+            AND ' . $accessScopeSql,
         $userId
     );
 

--- a/app/sources/main.functions.php
+++ b/app/sources/main.functions.php
@@ -744,6 +744,88 @@ function personalScopeSqlForUser(int $userId, string $itemAlias = 'i'): string
 }
 
 /**
+ * Classify password health from the metadata stored with an item.
+ *
+ * A non-empty ciphertext with a zero stored length is treated as unassessed because this is the
+ * legacy metadata pattern for passwords whose length was never backfilled. Empty passwords stored
+ * without ciphertext remain a distinct, non-weak state.
+ *
+ * @param int|string|null $complexityLevel  Stored zxcvbn-derived complexity level.
+ * @param int|null        $passwordLength   Stored password length.
+ * @param bool            $hasStoredPassword Whether the item contains password ciphertext.
+ *
+ * @return string One of: empty, unassessed, weak, healthy.
+ */
+function securityPasswordHealthStatus(
+    int|string|null $complexityLevel,
+    ?int $passwordLength,
+    bool $hasStoredPassword
+): string
+{
+    if (
+        $complexityLevel === null
+        || $complexityLevel === ''
+        || is_numeric($complexityLevel) === false
+        || (int) $complexityLevel < 0
+        || $passwordLength === null
+        || $passwordLength < 0
+        || ($hasStoredPassword === true && $passwordLength === 0)
+    ) {
+        return 'unassessed';
+    }
+
+    if ($passwordLength === 0) {
+        return 'empty';
+    }
+
+    if (
+        (int) $complexityLevel < TP_PW_STRENGTH_3
+        || $passwordLength < TP_SECURITY_PASSWORD_MIN_LENGTH
+    ) {
+        return 'weak';
+    }
+
+    return 'healthy';
+}
+
+/**
+ * Build canonical SQL expressions for password-health metadata.
+ *
+ * @param string $itemAlias SQL alias of the items table in the caller's query.
+ *
+ * @return array{weak:string,unassessed:string} CASE expressions returning zero or one.
+ */
+function securityPasswordHealthSql(string $itemAlias = 'i'): array
+{
+    if (preg_match('/^[A-Za-z_][A-Za-z0-9_]*$/', $itemAlias) !== 1) {
+        return [
+            'weak' => '(CASE WHEN 1 = 0 THEN 1 ELSE 0 END)',
+            'unassessed' => '(CASE WHEN 1 = 1 THEN 1 ELSE 0 END)',
+        ];
+    }
+
+    $assessedSql = '('
+        . $itemAlias . '.complexity_level IS NOT NULL'
+        . ' AND ' . $itemAlias . '.complexity_level <> \'\''
+        . ' AND ' . $itemAlias . '.complexity_level REGEXP \'^-?[0-9]+$\''
+        . ' AND CAST(' . $itemAlias . '.complexity_level AS SIGNED) >= 0'
+        . ' AND ' . $itemAlias . '.pw_len IS NOT NULL'
+        . ' AND CAST(' . $itemAlias . '.pw_len AS SIGNED) >= 0'
+        . ' AND NOT (CAST(' . $itemAlias . '.pw_len AS SIGNED) = 0'
+        . ' AND COALESCE(' . $itemAlias . '.pw, \'\') <> \'\')'
+        . ')';
+
+    return [
+        'weak' => '(CASE WHEN ' . $assessedSql
+            . ' AND CAST(' . $itemAlias . '.pw_len AS SIGNED) > 0'
+            . ' AND (CAST(' . $itemAlias . '.complexity_level AS SIGNED) < ' . (int) TP_PW_STRENGTH_3
+            . ' OR CAST(' . $itemAlias . '.pw_len AS SIGNED) < ' . (int) TP_SECURITY_PASSWORD_MIN_LENGTH
+            . ') THEN 1 ELSE 0 END)',
+        'unassessed' => '(CASE WHEN NOT ' . $assessedSql . ' THEN 1 ELSE 0 END)',
+    ];
+}
+
+/**
  * Build the SQL predicate limiting Security Posture data to items the user may read.
  *
  * A sharekey proves that the user can cryptographically unwrap an item key, but it is not an
@@ -1345,17 +1427,18 @@ function prepareSendingEmail(
  *
  * @param int $userId User to compute the posture for.
  *
- * @return array{weak:int,overdue:int,breached:int,reused:int,total_flagged:int,last_scan:int,worst_item:array{id:int,folder_id:int}|null}
+ * @return array{weak:int,unassessed:int,overdue:int,breached:int,reused:int,total_flagged:int,last_scan:int,worst_item:array{id:int,folder_id:int}|null}
  */
 function securityNudgeComputeCounts(int $userId): array
 {
     $nowTs = time();
-    $weakThreshold = TP_PW_STRENGTH_3;
     $accessScopeSql = securityPostureItemAccessSql($userId);
+    $passwordHealthSql = securityPasswordHealthSql();
 
     // Metadata-only flag expressions (identical semantics to the dashboard).
     $lastRelevantSql = 'COALESCE(NULLIF(l.last_relevant_date, 0), NULLIF(CAST(i.created_at AS UNSIGNED), 0), 0)';
-    $flagWeakSql = "(CASE WHEN i.complexity_level <> '' AND CAST(i.complexity_level AS SIGNED) >= 0 AND CAST(i.complexity_level AS SIGNED) < " . (int) $weakThreshold . " THEN 1 ELSE 0 END)";
+    $flagWeakSql = $passwordHealthSql['weak'];
+    $flagUnassessedSql = $passwordHealthSql['unassessed'];
     $flagOverdueSql = '(CASE WHEN n.renewal_period > 0 AND ' . $lastRelevantSql . ' > 0 AND (' . $lastRelevantSql . ' + n.renewal_period * ' . TP_ONE_DAY_SECONDS . ') <= ' . (int) $nowTs . ' THEN 1 ELSE 0 END)';
     $flagBreachedSql = '(CASE WHEN i.hibp_status = 2 THEN 1 ELSE 0 END)';
 
@@ -1372,6 +1455,7 @@ function securityNudgeComputeCounts(int $userId): array
     $innerSql =
         'SELECT i.id, i.id_tree,
             ' . $flagWeakSql . ' AS flag_weak,
+            ' . $flagUnassessedSql . ' AS flag_unassessed,
             ' . $flagOverdueSql . ' AS flag_overdue,
             ' . $flagBreachedSql . ' AS flag_breached,
             COALESCE(ih.flag_reused, 0) AS flag_reused
@@ -1386,6 +1470,7 @@ function securityNudgeComputeCounts(int $userId): array
     $agg = DB::queryFirstRow(
         'SELECT
             COALESCE(SUM(t.flag_weak), 0) AS weak,
+            COALESCE(SUM(t.flag_unassessed), 0) AS unassessed,
             COALESCE(SUM(t.flag_overdue), 0) AS overdue,
             COALESCE(SUM(t.flag_breached), 0) AS breached,
             COALESCE(SUM(t.flag_reused), 0) AS reused,
@@ -1425,6 +1510,7 @@ function securityNudgeComputeCounts(int $userId): array
 
     return [
         'weak' => (int) ($agg['weak'] ?? 0),
+        'unassessed' => (int) ($agg['unassessed'] ?? 0),
         'overdue' => (int) ($agg['overdue'] ?? 0),
         'breached' => (int) ($agg['breached'] ?? 0),
         'reused' => (int) ($agg['reused'] ?? 0),
@@ -1525,7 +1611,6 @@ function refreshItemHealthAfterSave(int $itemId, int $userId, string $plaintextP
     }
 
     $nowTs = time();
-    $weakThreshold = TP_PW_STRENGTH_3;
     $oversharedThreshold = (int) ($SETTINGS['security_dashboard_overshared_threshold'] ?? 10);
     if ($oversharedThreshold <= 0) {
         $oversharedThreshold = 10;
@@ -1583,7 +1668,12 @@ function refreshItemHealthAfterSave(int $itemId, int $userId, string $plaintextP
     }
 
     $cl = (string) $row['complexity_level'];
-    $flagWeak = ($cl !== '' && (int) $cl >= 0 && (int) $cl < $weakThreshold) ? 1 : 0;
+    $passwordHealthStatus = securityPasswordHealthStatus(
+        $cl,
+        strlen($plaintextPassword),
+        $plaintextPassword !== ''
+    );
+    $flagWeak = $passwordHealthStatus === 'weak' ? 1 : 0;
     $renewal = (int) $row['renewal_period'];
     $flagNoExpiry = ($renewal <= 0) ? 1 : 0;
     $base = (int) $row['last_relevant_date'];
@@ -1651,7 +1741,7 @@ function refreshItemHealthAfterSave(int $itemId, int $userId, string $plaintextP
  *
  * @param int $userId User to score.
  *
- * @return array{score:int,band:string,total_items:int,scanned:bool,last_scan:int,delta:int|null,delta_at:int,counts:array{breached:int,reused:int,weak:int,overdue:int,total:int},weights:array{breached:int,reused:int,weak:int,overdue:int},top3:array<int,array{key:string,count:int}>,worst_item:array{id:int,folder_id:int}|null}
+ * @return array{score:int,band:string,total_items:int,scanned:bool,last_scan:int,delta:int|null,delta_at:int,counts:array{breached:int,reused:int,weak:int,unassessed:int,overdue:int,total:int},weights:array{breached:int,reused:int,weak:int,overdue:int},top3:array<int,array{key:string,count:int}>,worst_item:array{id:int,folder_id:int}|null}
  */
 function securityScoreCompute(int $userId): array
 {
@@ -1705,6 +1795,8 @@ function securityScoreCompute(int $userId): array
         ['key' => 'reused', 'count' => (int) $counts['reused'], 'w' => $weights['reused'] * (int) $counts['reused']],
         ['key' => 'weak', 'count' => (int) $counts['weak'], 'w' => $weights['weak'] * (int) $counts['weak']],
         ['key' => 'overdue', 'count' => (int) $counts['overdue'], 'w' => $weights['overdue'] * (int) $counts['overdue']],
+        // Unknown metadata is surfaced for remediation but does not reduce the score.
+        ['key' => 'unassessed', 'count' => (int) $counts['unassessed'], 'w' => 0],
     ];
     usort($contrib, static function (array $a, array $b): int {
         return $b['w'] <=> $a['w'];
@@ -1738,6 +1830,7 @@ function securityScoreCompute(int $userId): array
             'breached' => (int) $counts['breached'],
             'reused' => (int) $counts['reused'],
             'weak' => (int) $counts['weak'],
+            'unassessed' => (int) $counts['unassessed'],
             'overdue' => (int) $counts['overdue'],
             'total' => (int) $counts['total_flagged'],
         ],

--- a/app/sources/reports.functions.php
+++ b/app/sources/reports.functions.php
@@ -127,7 +127,7 @@ function reportsPeriodBounds(?string $start, ?string $end, int $now): array
  * preserving zero-knowledge between users in the admin view.
  *
  * The report separates two families of flags:
- *  - **live** flags (weak, breached, overshared, overdue, no_expiry) are
+ *  - **live** flags (weak, unassessed, breached, overshared, overdue, no_expiry) are
  *    recomputed from item metadata at report time — always current, no scan
  *    needed. Their percentage base is the whole live population.
  *  - **scan** flags (reused, orphaned) can only come from the deep health

--- a/app/sources/reports.queries.php
+++ b/app/sources/reports.queries.php
@@ -219,7 +219,7 @@ switch ($post_type) {
     /*
      * POSTURE SUMMARY — aggregated health flags (metadata only, no item name)
      *
-     * Metadata-derived flags (weak, breached, overshared, overdue, no_expiry)
+     * Metadata-derived flags (weak, unassessed, breached, overshared, overdue, no_expiry)
      * are recomputed LIVE here so the report is always current — no dependency
      * on when the last deep scan ran. Only reused/orphaned genuinely require
      * the deep scan (a decryption context the report handler does not have),
@@ -227,7 +227,7 @@ switch ($post_type) {
      */
     case 'report_posture_summary':
         $nowTs = time();
-        $weakThreshold = (int) TP_PW_STRENGTH_3;
+        $passwordHealthSql = securityPasswordHealthSql();
         $oversharedThreshold = (int) ($SETTINGS['security_dashboard_overshared_threshold'] ?? 10);
         if ($oversharedThreshold <= 0) {
             $oversharedThreshold = 10;
@@ -240,8 +240,8 @@ switch ($post_type) {
         $live = DB::queryFirstRow(
             'SELECT
                 COUNT(*) AS total,
-                SUM(CASE WHEN i.complexity_level <> \'\' AND CAST(i.complexity_level AS SIGNED) >= 0
-                    AND CAST(i.complexity_level AS SIGNED) < ' . $weakThreshold . ' THEN 1 ELSE 0 END) AS weak,
+                SUM(' . $passwordHealthSql['weak'] . ') AS weak,
+                SUM(' . $passwordHealthSql['unassessed'] . ') AS unassessed,
                 SUM(CASE WHEN i.hibp_status = 2 THEN 1 ELSE 0 END) AS breached,
                 SUM(CASE WHEN COALESCE(sc.share_count, 0) > ' . $oversharedThreshold . ' THEN 1 ELSE 0 END) AS overshared,
                 SUM(CASE WHEN n.renewal_period <= 0 THEN 1 ELSE 0 END) AS no_expiry,
@@ -279,6 +279,7 @@ switch ($post_type) {
         $summary = reportsPostureSummary(
             [
                 'weak' => (int) ($live['weak'] ?? 0),
+                'unassessed' => (int) ($live['unassessed'] ?? 0),
                 'breached' => (int) ($live['breached'] ?? 0),
                 'overshared' => (int) ($live['overshared'] ?? 0),
                 'overdue' => (int) ($live['overdue'] ?? 0),

--- a/public/assets/css/teampass.css
+++ b/public/assets/css/teampass.css
@@ -109,6 +109,21 @@
     flex: 1;
 }
 
+/* Keep password-health shields readable on highlighted favorite rows. */
+.list-item-row.bg-yellow .tp-item-health-marker.text-warning,
+.list-item-row.bg-yellow .tp-item-health-marker.text-secondary {
+    color: #343a40 !important;
+}
+
+/* Selected rows use a black cell background, so restore light semantic colours there. */
+.list-item-row.bg-yellow .list-item-description.bg-black .tp-item-health-marker.text-warning {
+    color: #ffc107 !important;
+}
+
+.list-item-row.bg-yellow .list-item-description.bg-black .tp-item-health-marker.text-secondary {
+    color: #adb5bd !important;
+}
+
 .list-item-actions {
     position: absolute;
     top: 8px;

--- a/tests/Unit/PasswordHealthConsistencyTest.php
+++ b/tests/Unit/PasswordHealthConsistencyTest.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Static regression guards for password-health consistency, authorization, and presentation.
+ */
+class PasswordHealthConsistencyTest extends TestCase
+{
+    private function source(string $relativePath): string
+    {
+        $path = __DIR__ . '/../../' . $relativePath;
+        self::assertFileExists($path);
+        $source = file_get_contents($path);
+        self::assertIsString($source);
+
+        return $source;
+    }
+
+    public function testMinimumLengthAndCanonicalClassifiersAreDefinedOnce(): void
+    {
+        $config = $this->source('app/config/include.php');
+        $functions = $this->source('app/sources/main.functions.php');
+
+        self::assertStringContainsString("define('TP_SECURITY_PASSWORD_MIN_LENGTH', 12);", $config);
+        self::assertStringContainsString('function securityPasswordHealthStatus(', $functions);
+        self::assertStringContainsString('function securityPasswordHealthSql(', $functions);
+        self::assertStringContainsString("return 'unassessed';", $functions);
+        self::assertStringContainsString('TP_SECURITY_PASSWORD_MIN_LENGTH', $functions);
+        self::assertStringContainsString('.pw_len', $functions);
+    }
+
+    public function testDashboardCardAndReportsUseTheCanonicalClassification(): void
+    {
+        $dashboard = $this->source('app/sources/dashboard.queries.php');
+        $items = $this->source('app/sources/items.queries.php');
+        $reports = $this->source('app/sources/reports.queries.php');
+
+        self::assertStringContainsString('$passwordHealthSql = securityPasswordHealthSql();', $dashboard);
+        self::assertStringContainsString('flag_unassessed', $dashboard);
+        self::assertStringContainsString('securityPasswordHealthStatus(', $items);
+        self::assertStringContainsString("'unassessed' => \$passwordHealthStatus === 'unassessed' ? 1 : 0", $items);
+        self::assertStringContainsString('$passwordHealthSql = securityPasswordHealthSql();', $reports);
+        self::assertStringNotContainsString('$pwLength < 12', $items);
+    }
+
+    public function testDeepScanRepairsLegacyPasswordMetadata(): void
+    {
+        $dashboard = $this->source('app/sources/dashboard.queries.php');
+        $backgroundTask = $this->source('app/scripts/background_tasks___do_calculation.php');
+
+        self::assertStringContainsString('i.pw_len, i.complexity_level', $dashboard);
+        self::assertStringContainsString('$actualPasswordLength = strlen($plaintext);', $dashboard);
+        self::assertStringContainsString('new \ZxcvbnPhp\Zxcvbn()', $dashboard);
+        self::assertStringContainsString("\$metadataUpdates['pw_len']", $dashboard);
+        self::assertStringContainsString("\$metadataUpdates['complexity_level']", $dashboard);
+        self::assertStringContainsString(
+            "DB::update(prefixTable('items'), \$metadataUpdates, 'id = %i', \$itemId);",
+            $dashboard
+        );
+        self::assertStringContainsString('decryptUserObjectKeyWithMigration(', $backgroundTask);
+        self::assertStringContainsString('i.complexity_level = ""', $backgroundTask);
+    }
+
+    public function testItemsListRequestsEveryBadgeChunkAndIgnoresStaleResponses(): void
+    {
+        $itemsJs = $this->source('app/pages/items.js.php');
+
+        self::assertStringContainsString('let healthBadgeRequestGeneration = 0', $itemsJs);
+        self::assertStringContainsString('offset += 500', $itemsJs);
+        self::assertStringContainsString('Promise.all(requests)', $itemsJs);
+        self::assertStringContainsString('requestGeneration !== healthBadgeRequestGeneration', $itemsJs);
+        self::assertStringContainsString('.tp-item-health-marker', $itemsJs);
+    }
+
+    public function testPasswordHealthActionsAndMarkersKeepReadableContrast(): void
+    {
+        $nudges = $this->source('app/core/security-nudges.js.php');
+        $stylesheet = $this->source('public/assets/css/teampass.css');
+
+        self::assertStringContainsString('btn btn-sm btn-light text-dark ml-1', $nudges);
+        self::assertStringContainsString(
+            '.list-item-row.bg-yellow .tp-item-health-marker.text-warning',
+            $stylesheet
+        );
+        self::assertStringContainsString(
+            '.list-item-row.bg-yellow .tp-item-health-marker.text-secondary',
+            $stylesheet
+        );
+        self::assertStringContainsString(
+            '.list-item-row.bg-yellow .list-item-description.bg-black .tp-item-health-marker.text-warning',
+            $stylesheet
+        );
+        self::assertStringContainsString(
+            '.list-item-row.bg-yellow .list-item-description.bg-black .tp-item-health-marker.text-secondary',
+            $stylesheet
+        );
+    }
+
+    public function testHibpAuthorizationIsCheckedBeforeSharekeyDecryption(): void
+    {
+        $items = $this->source('app/sources/items.queries.php');
+        $caseStart = strpos($items, "case 'check_hibp_password':");
+        self::assertIsInt($caseStart);
+        $caseSource = substr($items, $caseStart);
+
+        $authorizationPosition = strpos($caseSource, 'securityPostureItemAccessSql(');
+        $decryptionPosition = strpos($caseSource, 'decryptUserObjectKeyWithMigration(');
+        self::assertIsInt($authorizationPosition);
+        self::assertIsInt($decryptionPosition);
+        self::assertLessThan($decryptionPosition, $authorizationPosition);
+        self::assertStringContainsString('AND i.inactif = 0', $caseSource);
+        self::assertStringContainsString('AND i.deleted_at IS NULL', $caseSource);
+    }
+}

--- a/tests/Unit/SecurityPostureAuthorizationTest.php
+++ b/tests/Unit/SecurityPostureAuthorizationTest.php
@@ -1,0 +1,165 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Static regression guards for the Security Posture authorization boundary.
+ *
+ * Security Posture needs an item sharekey to perform its checks, but holding that key does not
+ * grant access to the item. These tests lock the database-backed authorization predicate and its
+ * use by every dashboard, nudge, score, and persisted-health path.
+ */
+class SecurityPostureAuthorizationTest extends TestCase
+{
+    private function mainFunctionsSource(): string
+    {
+        $path = __DIR__ . '/../../app/sources/main.functions.php';
+        self::assertFileExists($path);
+        $source = file_get_contents($path);
+        self::assertIsString($source);
+
+        return $source;
+    }
+
+    private function dashboardSource(): string
+    {
+        $path = __DIR__ . '/../../app/sources/dashboard.queries.php';
+        self::assertFileExists($path);
+        $source = file_get_contents($path);
+        self::assertIsString($source);
+
+        return $source;
+    }
+
+    public function testCanonicalPredicateRequiresFolderAuthorizationBeyondSharekey(): void
+    {
+        $source = $this->mainFunctionsSource();
+
+        self::assertStringContainsString(
+            'function securityPostureItemAccessSql(int $userId, string $itemAlias',
+            $source
+        );
+        self::assertStringContainsString("prefixTable('users_groups')", $source);
+        self::assertStringContainsString("prefixTable('users_roles')", $source);
+        self::assertStringContainsString("prefixTable('roles_values')", $source);
+        self::assertStringContainsString('posture_shared_folder.id =', $source);
+        self::assertStringContainsString(
+            "posture_role_grant.type IN (\\'W\\', \\'ND\\', \\'NE\\', \\'NDNE\\', \\'R\\')",
+            $source
+        );
+    }
+
+    public function testInvalidPredicateInputsFailClosed(): void
+    {
+        $source = $this->mainFunctionsSource();
+
+        self::assertStringContainsString(
+            "preg_match('/^[A-Za-z_][A-Za-z0-9_]*$/', \$itemAlias) !== 1",
+            $source
+        );
+        self::assertStringContainsString("return '(1 = 0)';", $source);
+    }
+
+    public function testExplicitFolderDenialHasPriorityOverAllSharedFolderGrants(): void
+    {
+        $source = $this->mainFunctionsSource();
+
+        self::assertStringContainsString("prefixTable('users_groups_forbidden')", $source);
+        self::assertStringContainsString('posture_forbidden.user_id = ', $source);
+        self::assertStringContainsString(
+            'posture_forbidden.group_id = \' . $itemAlias . \'.id_tree',
+            $source
+        );
+    }
+
+    public function testPersonalItemsAreLimitedToTheOwnersRootTree(): void
+    {
+        $source = $this->mainFunctionsSource();
+
+        self::assertStringContainsString('posture_own_root.personal_folder = 1', $source);
+        self::assertStringContainsString('posture_own_root.parent_id = 0', $source);
+        self::assertStringContainsString('posture_own_root.title =', $source);
+        self::assertStringContainsString('posture_personal_user.personal_folder = 1', $source);
+        self::assertStringContainsString(
+            "posture_personal_setting.intitule = \\'enable_pf_feature\\'",
+            $source
+        );
+        self::assertStringContainsString(
+            'posture_item_folder.nleft >= posture_own_root.nleft',
+            $source
+        );
+        self::assertStringContainsString(
+            'posture_item_folder.nright <= posture_own_root.nright',
+            $source
+        );
+        self::assertStringContainsString('$itemAlias . \'.perso = 0', $source);
+    }
+
+    public function testItemUserAndRoleRestrictionsCanOnlyNarrowFolderAccess(): void
+    {
+        $source = $this->mainFunctionsSource();
+        $folderScope = strpos($source, 'posture_direct_grant.user_id');
+        $restrictionScope = strpos($source, 'posture_any_restricted_role.item_id');
+
+        self::assertIsInt($folderScope);
+        self::assertIsInt($restrictionScope);
+        self::assertLessThan($restrictionScope, $folderScope);
+        self::assertStringContainsString("prefixTable('restriction_to_roles')", $source);
+        self::assertStringContainsString('COALESCE(\' . $itemAlias . \'.restricted_to', $source);
+        self::assertStringContainsString('posture_restricted_user_role.user_id = ', $source);
+    }
+
+    public function testDashboardNeverUsesTheLegacyPersonalOnlyGuard(): void
+    {
+        $source = $this->dashboardSource();
+
+        self::assertStringNotContainsString('personalScopeSqlForUser(', $source);
+        self::assertStringContainsString(
+            '$accessScopeSql = securityPostureItemAccessSql($userId);',
+            $source
+        );
+        self::assertGreaterThanOrEqual(
+            7,
+            substr_count($source, '$accessScopeSql'),
+            'All list, summary, health, deep-scan and folder-badge queries must be scoped'
+        );
+    }
+
+    public function testNudgeAndScoreQueriesUseTheSameAuthorizationPredicate(): void
+    {
+        $source = $this->mainFunctionsSource();
+        $nudgeStart = strpos($source, 'function securityNudgeComputeCounts');
+        $finalizerStart = strpos($source, 'function finalizeUserReuseFlags');
+        $scoreStart = strpos($source, 'function securityScoreCompute');
+
+        self::assertIsInt($nudgeStart);
+        self::assertIsInt($finalizerStart);
+        self::assertIsInt($scoreStart);
+
+        $nudgeSource = substr($source, $nudgeStart, $finalizerStart - $nudgeStart);
+        $scoreSource = substr($source, $scoreStart);
+        self::assertStringContainsString('securityPostureItemAccessSql($userId)', $nudgeSource);
+        self::assertStringContainsString('securityPostureItemAccessSql($userId)', $scoreSource);
+    }
+
+    public function testFinalizerPrunesUnauthorizedHealthRowsBeforeReuseIsDerived(): void
+    {
+        $source = $this->mainFunctionsSource();
+        $finalizerStart = strpos($source, 'function finalizeUserReuseFlags');
+        $refreshStart = strpos($source, 'function refreshItemHealthAfterSave');
+
+        self::assertIsInt($finalizerStart);
+        self::assertIsInt($refreshStart);
+        $finalizerSource = substr($source, $finalizerStart, $refreshStart - $finalizerStart);
+
+        $deletePosition = strpos($finalizerSource, 'DELETE ih');
+        $reuseResetPosition = strpos($finalizerSource, 'SET flag_reused = 0');
+        self::assertIsInt($deletePosition);
+        self::assertIsInt($reuseResetPosition);
+        self::assertLessThan($reuseResetPosition, $deletePosition);
+        self::assertStringContainsString('OR NOT \' . $accessScopeSql', $finalizerSource);
+        self::assertStringContainsString("prefixTable('sharekeys_items')", $finalizerSource);
+    }
+}


### PR DESCRIPTION
## Summary

This change prevents Security Posture from listing, scanning, or counting items that the current
user cannot access through their current TeamPass permissions. It also makes password-health
classification consistent between the item card, the item list, Security Posture, proactive
nudges, compliance reports, and deep scans. Small, scoped contrast fixes keep the proactive
remediation action and password-health shields readable on the affected user views.

The fix keeps `sharekeys_items` as a cryptographic prerequisite but no longer treats possession of
a sharekey as an authorization grant. Security Posture now combines the sharekey requirement with
the user's effective folder and item permissions.

Password health now uses one canonical rule:

- minimum password length: 12 characters;
- weak: assessed metadata with complexity below `TP_PW_STRENGTH_3` or length below 12;
- not assessed: missing, invalid, or legacy metadata such as `complexity_level = -1`;
- empty: a known empty password, kept distinct from weak and not assessed.

## Root cause

Security Posture selected active items by joining them to `sharekeys_items` for the current user.
Its only additional folder safeguard excluded personal folders belonging to other users.

This assumption is not valid for shared items:

- a sharekey is an encrypted copy of an item key, not a record of current authorization;
- sharekeys may remain after role or direct-folder assignments change;
- TeamPass may distribute sharekeys more broadly than the set of users currently authorized to
  browse a shared folder, so newly created users can also hold keys for inaccessible items;
- the normal item endpoints independently enforce folder visibility and item restrictions, but the
  Security Posture queries did not.

As a result, a user with no direct folder grant, no readable role grant, and no normal access to a
folder could still see the item's label and path in Security Posture when a sharekey existed.

The personal sharekey remediation script is useful for foreign keys on personal items, but it
cannot correct this shared-item authorization issue: removing all shared-item keys held by users
without current access would conflict with TeamPass key-distribution and recovery workflows.

### Password-health classification

The item card and the metadata-only views did not use the same weak-password rule:

- the card classified the decrypted password as weak when `intval(complexity_level)` was below the
  medium threshold or its live length was below 12;
- the list and Security Posture only checked a non-negative stored `complexity_level`;
- stored `pw_len` was not part of the list or posture classification;
- an unknown legacy value such as `complexity_level = -1` therefore appeared weak on the card but
  had no weak badge in the list or Security Posture;
- list-badge requests were capped at 500 item IDs while the client sent the entire rendered list in
  one request, so items beyond that boundary could remain undecorated;
- progressively loaded and sorted lists could apply late responses to a newer folder generation.

The concrete lab example (`item_id = 10606`) had `complexity_level = -1`, `pw_len = 0`, and no
`item_health` row. This is unassessed legacy metadata, not evidence that the password is weak or
healthy.

## Security impact

Before this change, Security Posture could disclose metadata for inaccessible items, including
their labels and folder paths. A deep scan could also decrypt such items in the user's request
context to calculate health indicators, although plaintext passwords were not returned by the
endpoint.

The on-demand HIBP endpoint had the same adjacent authorization weakness: it accepted possession
of an item sharekey as sufficient proof of access before decrypting the password. It now verifies
the canonical current folder and item authorization first.

The corrected boundary is:

```text
valid sharekey
AND active item
AND current folder read access
AND current item-restriction access
```

## Changes

### Canonical database-backed authorization predicate

Added `securityPostureItemAccessSql()` in `app/sources/main.functions.php`. It can run both in a web
session and in background workers and enforces:

- access to the user's own enabled personal-folder tree, resolved through the nested-set boundaries
  of the top-level personal root;
- for shared items, either a direct `users_groups` folder grant or a readable role grant from
  `users_roles` and `roles_values`;
- readable role types `W`, `ND`, `NE`, `NDNE`, and `R`;
- absolute priority for an explicit `users_groups_forbidden` denial;
- exclusion of another user's personal tree even if a direct or role grant is inconsistent;
- per-item `restricted_to` user restrictions;
- per-item `restriction_to_roles` role restrictions;
- fail-closed behavior for an invalid user ID or SQL table alias.

Item restrictions only narrow access. They never make an otherwise inaccessible folder visible.

### Security Posture query coverage

Applied the same predicate to:

- the paginated flagged-item list;
- the global metadata summary;
- persisted reused/orphaned totals and the last-scan timestamp;
- deep-scan item counts and scan chunks;
- per-folder item badges;
- proactive security nudge counts and worst-item selection;
- the Security Posture score denominator.

This keeps all user-facing posture calculations aligned with the same effective authorization
rules.

### Persisted health cleanup

`finalizeUserReuseFlags()` now removes stale `item_health` rows before deriving reuse groups when:

- the item no longer exists;
- the user no longer holds the required sharekey;
- the item is inactive or deleted;
- the user no longer satisfies the canonical authorization predicate.

Pruning first is important: an inaccessible stale item can no longer cause an accessible item with
the same reuse bucket to be falsely marked as reused.

The dashboard finalization handler now delegates this cleanup to the canonical finalizer, so manual
deep scans and save-time incremental refreshes use the same behavior.

### Canonical password-health classification

Added `TP_SECURITY_PASSWORD_MIN_LENGTH` with a value of 12 and two shared helpers in
`app/sources/main.functions.php`:

- `securityPasswordHealthStatus()` classifies PHP-side metadata as `empty`, `unassessed`, `weak`,
  or `healthy`;
- `securityPasswordHealthSql()` produces the matching MySQL expressions for `flag_weak` and
  `flag_unassessed`.

The canonical rule is now consumed by:

- item-card health data;
- item-list health badges;
- Security Posture lists, filters, counts, and score context;
- proactive nudge weak counts;
- save-time `item_health` refreshes;
- deep-scan persisted weak flags;
- the administrative posture compliance report.

Unassessed items are visible as a dedicated neutral badge and Security Posture card. They are not
silently treated as weak and do not reduce the security score. They are nevertheless included in
the score's remediation list so a score of 100 does not imply that every item was assessed.

### Legacy metadata repair

The in-session deep scan now:

- reads `pw_len` together with `complexity_level`;
- compares the stored length with the decrypted password length;
- recalculates zxcvbn complexity when the stored length changed or the complexity value is missing,
  invalid, or negative;
- updates only the metadata fields that need repair;
- calculates the persisted weak flag from the repaired canonical metadata.

The existing `background_tasks___do_calculation.php` backfill now also selects empty complexity
values, handles a missing TP_USER sharekey safely, and uses migration-aware sharekey decryption.
It continues to repair shared non-personal items in bounded batches; personal items are repaired
when their owner runs a deep scan.

### Complete and race-safe item-list badges

`applyHealthBadges()` now:

- clears markers before rebuilding the current list state;
- deduplicates item IDs;
- splits requests into the endpoint's defensive 500-ID batches;
- merges all batch responses;
- ignores responses from an older folder or progressive-list generation;
- displays the dedicated unassessed state in neutral styling.

### User-interface warning contrast

Two scoped presentation fixes improve readability without changing password-health semantics:

- the light remediation action beside `Review` in the post-login security nudge explicitly uses
  dark text instead of inheriting an unreadable light foreground;
- warning and unassessed health shields use a dark foreground when an item row has the yellow
  favorite highlight, while the existing light semantic colors are restored when the selected
  item cell switches to a black background.

Breached-password markers retain their red semantic color, and rows without the favorite
highlight are unchanged.

### HIBP authorization

`check_hibp_password` now applies `securityPostureItemAccessSql()` to an active, non-deleted item
before retrieving or decrypting the user's sharekey. A stale sharekey alone can no longer trigger
password decryption or an HIBP lookup.

## Compatibility

- Compatible with PHP 8.2+.
- Uses correlated `EXISTS` predicates supported by MySQL 5.7+ and MariaDB 10.7+.
- Compatible with `ONLY_FULL_GROUP_BY`.
- No schema, migration, installer, upgrader, configuration, or dependency changes.
- No change to sharekey generation or distribution.
- No plaintext password is added to any query, log, response, or persisted record.
- Existing language files fall back to the new English label; French includes a native
  `Non évalué` translation.

## Tests

Added `tests/Unit/SecurityPostureAuthorizationTest.php` with regression guards covering:

- direct and role-based folder authorization;
- explicit folder-denial priority;
- personal-folder ownership and nested-set containment;
- item-level user and role restrictions;
- use of the canonical predicate by dashboard, deep-scan, nudge, and score paths;
- pruning of unauthorized health rows before reuse derivation.

Added `tests/Unit/PasswordHealthConsistencyTest.php` with regression guards covering:

- the shared 12-character minimum and canonical classifiers;
- use of the same classification by dashboard, card, and compliance report paths;
- the explicit unassessed state;
- deep-scan repair of legacy length and complexity metadata;
- complete 500-ID client batching and stale-response protection;
- readable contrast for the post-login remediation action and health shields on highlighted
  favorite rows;
- HIBP authorization before sharekey decryption.

Recommended command:

```bash
php ./app/vendor/bin/phpunit tests/Unit/SecurityPostureAuthorizationTest.php
php ./app/vendor/bin/phpunit tests/Unit/PasswordHealthConsistencyTest.php
```

The test files were added and their invariants were checked statically in the provided Windows source
snapshot. PHPUnit and PHPStan could not be executed there because no PHP runtime, Docker runtime,
or installed WSL distribution was available; the bundled Composer command wrappers therefore
cannot run in this environment.

## Manual validation

1. Use a non-admin test user that holds a sharekey for an item but has no direct grant or readable
   role on the item's folder.
2. Confirm that the item is absent from the normal item browser.
3. Open Security Posture and confirm that the item is absent from the list, totals, folder filter,
   and score denominator.
4. Run a deep scan and confirm that the item is not processed.
5. Grant a readable role or a direct folder assignment and confirm that the item becomes visible in
   both the normal browser and Security Posture.
6. Add an explicit folder denial and confirm that the item disappears from Security Posture even
   when another grant remains.
7. Validate an unrestricted item, a user-restricted item, a role-restricted item, the user's own
   personal item, and another user's personal item.
8. Change the user's role after a completed scan, finalize another scan, and confirm that stale
   `item_health` rows do not affect reused/orphaned counts.
9. Open an accessible legacy item with `complexity_level = -1` and `pw_len = 0`; confirm that the
   item card, item list, and Security Posture all show `Not assessed`, not `Weak`.
10. Run a deep scan and confirm that `pw_len` and `complexity_level` are repaired, then confirm that
    the three views consistently show either `Weak` or no password-health warning.
11. Validate an assessed password of at least 12 characters below the complexity threshold, a
    strong password shorter than 12 characters, a healthy password, and a known empty password.
12. Load a folder or progressive search containing more than 500 rendered items and confirm that
    health markers are present on eligible items on both sides of the 500-item boundary.
13. Navigate between folders while badge requests are in flight and confirm that no marker from
    the previous folder is applied to the current list.
14. Retain a stale sharekey while removing the user's item authorization, call the HIBP action, and
    confirm that it is rejected before decryption.
15. Trigger the post-login security nudge with a worst item and confirm that the light remediation
    action beside `Review` has readable dark text.
16. Mark an item with a weak, reused, or overdue-password warning as a favorite and confirm that its
    shield remains visible on the yellow row; select the row and confirm that the shield also
    remains visible on the black selected-item cell.
17. Repeat the favorite-row check with an unassessed item and confirm that its neutral shield is
    readable in both row states.

## Risk and rollback

The authorization change intentionally fails closed if database permission records are
inconsistent. The password-health change may temporarily increase the number of visible findings
because unknown legacy metadata is now shown honestly as unassessed and stored password length is
part of the weak rule.

The contrast overrides are limited to the security nudge's light action and health markers inside
yellow favorite rows. They do not change authorization, stored health data, or badge selection.

Deep scans and the existing background calculation task can write repaired `pw_len` and
`complexity_level` values. These are derived metadata only; encrypted passwords are unchanged.
Rollback consists of reverting the predicate integrations, health helpers, UI handling, scan
backfill, and pre-reuse cleanup. No database schema rollback is required.
