### PR TITLE
Api expose server version and folder management capabilities

### DIFF
--- a/app/api/Controller/Api/FolderController.php
+++ b/app/api/Controller/Api/FolderController.php
@@ -24,6 +24,7 @@
  */
 
 use Symfony\Component\HttpFoundation\Request AS symfonyRequest;
+use TeampassClasses\ConfigManager\ConfigManager;
 
 class FolderController extends BaseController
 {
@@ -221,10 +222,14 @@ class FolderController extends BaseController
                 $userId = (string) $userData['id'];
                 $username = $userData['username'];
                 $writableFolders = [];
+                $configManager = new ConfigManager();
+                $settings = $configManager->getAllSettings();
+                $enableUserCanCreateFolders = isset($settings['enable_user_can_create_folders']) === true
+                    && (int) $settings['enable_user_can_create_folders'] === 1;
 
                 if (empty($userFolders) === false) {
                     $rows = DB::query(
-                        'SELECT nt.id AS folder_id, nt.title, nt.nlevel, nt.parent_id, nt.nleft
+                        'SELECT nt.id AS folder_id, nt.title, nt.nlevel, nt.parent_id, nt.nleft, nt.personal_folder
                         FROM ' . prefixTable('nested_tree') . ' AS nt
                         WHERE nt.id IN %li
                         ORDER BY nt.nleft ASC',
@@ -239,6 +244,16 @@ class FolderController extends BaseController
                         // Single resolution per folder — is_readonly and the granular
                         // flags below all derive from it (no extra query).
                         $access = $folderAccessModel->getFolderAccessLevelForUser($folderId, (int) $userData['id']);
+                        $isPersonal = (int) $row['personal_folder'] === 1;
+                        $isPersonalRoot = $isPersonal === true && (int) $row['parent_id'] === 0;
+                        $managementCapabilities = $folderAccessModel->getFolderManagementCapabilities(
+                            $userData,
+                            $isPersonal,
+                            $isPersonalRoot,
+                            $access['type'] === 'R',
+                            true,
+                            $enableUserCanCreateFolders
+                        );
                         $writableFolders[] = [
                             'id' => $folderId,
                             'label' => $row['title'] === $userId ? $username : $row['title'],
@@ -257,6 +272,14 @@ class FolderController extends BaseController
                             'can_create' => $access['create'] ? 1 : 0,
                             'can_edit' => $access['edit'] ? 1 : 0,
                             'can_delete' => $access['delete'] ? 1 : 0,
+                            // Folder-domain metadata and folder-management capabilities.
+                            // These are UI hints only; mutation routes re-run every check.
+                            'is_personal' => $isPersonal ? 1 : 0,
+                            'is_personal_root' => $isPersonalRoot ? 1 : 0,
+                            'can_create_subfolder' => $managementCapabilities['can_create_subfolder'] ? 1 : 0,
+                            'can_rename_folder' => $managementCapabilities['can_rename_folder'] ? 1 : 0,
+                            'can_move_folder' => $managementCapabilities['can_move_folder'] ? 1 : 0,
+                            'can_delete_folder' => $managementCapabilities['can_delete_folder'] ? 1 : 0,
                         ];
                     }
                 }

--- a/app/api/Model/FolderAccessModel.php
+++ b/app/api/Model/FolderAccessModel.php
@@ -198,6 +198,83 @@ class FolderAccessModel
     }
 
     /**
+     * Returns true when the user passes the global folder-management gate.
+     *
+     * This mirrors the gate used by FolderManager and the API create/update/delete
+     * adapters. Folder-specific access, read-only state, personal-root protection
+     * and per-operation API permissions are evaluated separately.
+     *
+     * @param array $userData JWT user data
+     * @param bool $isPersonal Whether the folder/target belongs to the personal domain
+     * @param bool $enableUserCanCreateFolders Current enable_user_can_create_folders setting
+     * @return bool
+     */
+    public function hasFolderManagementPrivilege(
+        array $userData,
+        bool $isPersonal,
+        bool $enableUserCanCreateFolders
+    ): bool
+    {
+        return $isPersonal === true
+            || (int) ($userData['is_admin'] ?? 0) === 1
+            || (int) ($userData['is_manager'] ?? 0) === 1
+            || (int) ($userData['user_can_manage_all_users'] ?? 0) === 1
+            || $enableUserCanCreateFolders === true
+            || (int) ($userData['user_can_create_root_folder'] ?? 0) === 1;
+    }
+
+    /**
+     * Build the folder-management capabilities advertised to API clients.
+     *
+     * These flags describe source-folder eligibility only. In particular,
+     * can_move_folder does not validate a future destination; updateFolder()
+     * remains responsible for destination access, read-only, cycle, domain and
+     * root checks when the mutation is attempted.
+     *
+     * @param array $userData JWT user data, including current API CRUD permissions
+     * @param bool $isPersonal Whether the folder belongs to the personal domain
+     * @param bool $isPersonalRoot Whether the folder is a protected personal root
+     * @param bool $isReadOnly Whether the effective folder access type is R
+     * @param bool $hasEffectiveAccess Whether the source folder is effectively accessible
+     * @param bool $enableUserCanCreateFolders Current enable_user_can_create_folders setting
+     * @return array{
+     *     can_create_subfolder: bool,
+     *     can_rename_folder: bool,
+     *     can_move_folder: bool,
+     *     can_delete_folder: bool
+     * }
+     */
+    public function getFolderManagementCapabilities(
+        array $userData,
+        bool $isPersonal,
+        bool $isPersonalRoot,
+        bool $isReadOnly,
+        bool $hasEffectiveAccess,
+        bool $enableUserCanCreateFolders
+    ): array
+    {
+        $canManage = $hasEffectiveAccess === true
+            && $isReadOnly === false
+            && $this->hasFolderManagementPrivilege(
+                $userData,
+                $isPersonal,
+                $enableUserCanCreateFolders
+            );
+        $canMutateSource = $canManage === true && $isPersonalRoot === false;
+
+        return [
+            'can_create_subfolder' => $canManage === true
+                && (int) ($userData['allowed_to_create'] ?? 0) === 1,
+            'can_rename_folder' => $canMutateSource === true
+                && (int) ($userData['allowed_to_update'] ?? 0) === 1,
+            'can_move_folder' => $canMutateSource === true
+                && (int) ($userData['allowed_to_update'] ?? 0) === 1,
+            'can_delete_folder' => $canMutateSource === true
+                && (int) ($userData['allowed_to_delete'] ?? 0) === 1,
+        ];
+    }
+
+    /**
      * Returns true when the user can read the given item (folder access or restricted-items list).
      *
      * @param array $userData JWT user data (id, folders_list, restricted_items_list)

--- a/app/api/Model/FolderModel.php
+++ b/app/api/Model/FolderModel.php
@@ -322,6 +322,22 @@ class FolderModel
             return $this->apiError(422, 'Invalid parameters');
         }
 
+        $configManager = new ConfigManager();
+        $settings = $configManager->getAllSettings();
+        if ($folderAccessModel->hasFolderManagementPrivilege(
+            [
+                'is_admin' => $is_admin,
+                'is_manager' => $is_manager,
+                'user_can_create_root_folder' => $user_can_create_root_folder,
+                'user_can_manage_all_users' => $user_can_manage_all_users,
+            ],
+            $isPersonal === 1,
+            isset($settings['enable_user_can_create_folders']) === true
+                && (int) $settings['enable_user_can_create_folders'] === 1
+        ) === false) {
+            return $this->apiError(403, 'Access denied: insufficient permissions to create a folder');
+        }
+
         // Create folder
         require_once API_ROOT_PATH . '/../sources/folders.class.php';
         $lang = new Language();
@@ -454,8 +470,7 @@ class FolderModel
 
         // Personal root protection — cannot be renamed or moved
         $isPersonalRoot = (int) $folder['parent_id'] === 0
-            && (int) $folder['personal_folder'] === 1
-            && (string) $folder['title'] === (string) $userId;
+            && (int) $folder['personal_folder'] === 1;
         if ($isPersonalRoot === true && ($titleChanged === true || $parentChanged === true)) {
             return $this->apiError(403, 'A personal root folder cannot be renamed or moved');
         }
@@ -556,14 +571,12 @@ class FolderModel
         }
 
         // Global permission gate
-        if (!(
-            $isPersonal === 1
-            || (int) ($userData['is_admin'] ?? 0) === 1
-            || (int) ($userData['is_manager'] ?? 0) === 1
-            || (int) ($userData['user_can_manage_all_users'] ?? 0) === 1
-            || (isset($SETTINGS['enable_user_can_create_folders']) === true && (int) $SETTINGS['enable_user_can_create_folders'] === 1)
-            || (int) ($userData['user_can_create_root_folder'] ?? 0) === 1
-        )) {
+        if ($folderAccessModel->hasFolderManagementPrivilege(
+            $userData,
+            $isPersonal === 1,
+            isset($SETTINGS['enable_user_can_create_folders']) === true
+                && (int) $SETTINGS['enable_user_can_create_folders'] === 1
+        ) === false) {
             return $this->apiError(403, 'Access denied: insufficient permissions to update this folder');
         }
 
@@ -653,14 +666,12 @@ class FolderModel
         $isPersonal = (int) $folder['personal_folder'] === 1;
 
         // Global permission gate — same expression as the web delete handler
-        if (!(
-            $isPersonal === true
-            || (int) ($userData['is_admin'] ?? 0) === 1
-            || (int) ($userData['is_manager'] ?? 0) === 1
-            || (int) ($userData['user_can_manage_all_users'] ?? 0) === 1
-            || (isset($SETTINGS['enable_user_can_create_folders']) === true && (int) $SETTINGS['enable_user_can_create_folders'] === 1)
-            || (int) ($userData['user_can_create_root_folder'] ?? 0) === 1
-        )) {
+        if ($folderAccessModel->hasFolderManagementPrivilege(
+            $userData,
+            $isPersonal,
+            isset($SETTINGS['enable_user_can_create_folders']) === true
+                && (int) $SETTINGS['enable_user_can_create_folders'] === 1
+        ) === false) {
             return $this->apiError(403, 'Access denied: insufficient permissions to delete this folder');
         }
 

--- a/app/api/openapi.json
+++ b/app/api/openapi.json
@@ -720,8 +720,8 @@
         "/folder/writableFolders": {
             "get": {
                 "operationId": "folderWritableFolders",
-                "summary": "List accessible folders with read-only flag, in tree order",
-                "description": "Historical name — returns ALL accessible folders; check 'is_readonly' on each entry. Rows are ordered by 'position' (MPTT pre-order), so parent_id + level + position rebuild the exact folder hierarchy, sibling order included.",
+                "summary": "List accessible folders with item and folder-management capabilities",
+                "description": "Historical name — returns ALL accessible folders. access_type, is_readonly, can_create, can_edit and can_delete describe operations on items contained in the folder. The can_*_folder fields describe folder-management UI capabilities and never replace the authoritative checks performed by POST /folder/create, PUT /folder/update and DELETE /folder/delete. Rows are ordered by 'position' (MPTT pre-order), so parent_id + level + position rebuild the exact folder hierarchy, sibling order included.",
                 "responses": {
                     "200": {
                         "description": "Flat folder list",
@@ -1567,6 +1567,26 @@
             },
             "WritableFolder": {
                 "type": "object",
+                "required": [
+                    "id",
+                    "label",
+                    "level",
+                    "parent_id",
+                    "first_position",
+                    "position",
+                    "complexity",
+                    "is_readonly",
+                    "access_type",
+                    "can_create",
+                    "can_edit",
+                    "can_delete",
+                    "is_personal",
+                    "is_personal_root",
+                    "can_create_subfolder",
+                    "can_rename_folder",
+                    "can_move_folder",
+                    "can_delete_folder"
+                ],
                 "properties": {
                     "id": {
                         "type": "integer"
@@ -1600,11 +1620,15 @@
                     },
                     "is_readonly": {
                         "type": "integer",
-                        "description": "1 when the resolved access type is R. ND/NE/NDNE are NOT read-only — check can_edit / can_delete."
+                        "description": "1 when the resolved item access type is R. ND/NE/NDNE are NOT read-only — check can_edit and can_delete.",
+                        "enum": [
+                            0,
+                            1
+                        ]
                     },
                     "access_type": {
                         "type": "string",
-                        "description": "Effective access level, least-permissive-wins across all the user's roles (R > NDNE > NE = ND > W).",
+                        "description": "Effective access level for items contained in this folder, least-permissive-wins across all the user's roles (R > NDNE > NE = ND > W).",
                         "enum": [
                             "R",
                             "W",
@@ -1615,15 +1639,75 @@
                     },
                     "can_create": {
                         "type": "integer",
-                        "description": "1 when the user may create items in this folder (false only for R)."
+                        "description": "Item right: 1 when the user may create an item in this folder (false only for R). This does not authorize creating a subfolder.",
+                        "enum": [
+                            0,
+                            1
+                        ]
                     },
                     "can_edit": {
                         "type": "integer",
-                        "description": "1 when the user may edit existing items (false for NE, NDNE and R)."
+                        "description": "Item right: 1 when the user may edit existing items in this folder (false for NE, NDNE and R). This does not authorize renaming or moving the folder.",
+                        "enum": [
+                            0,
+                            1
+                        ]
                     },
                     "can_delete": {
                         "type": "integer",
-                        "description": "1 when the user may delete items (false for ND, NDNE and R)."
+                        "description": "Item right: 1 when the user may delete items in this folder (false for ND, NDNE and R). This does not authorize deleting the folder.",
+                        "enum": [
+                            0,
+                            1
+                        ]
+                    },
+                    "is_personal": {
+                        "type": "integer",
+                        "description": "1 when the folder belongs to the current user's personal folder domain; 0 for the shared domain.",
+                        "enum": [
+                            0,
+                            1
+                        ]
+                    },
+                    "is_personal_root": {
+                        "type": "integer",
+                        "description": "1 for the protected root of the personal folder domain. A personal root cannot be renamed, moved or deleted.",
+                        "enum": [
+                            0,
+                            1
+                        ]
+                    },
+                    "can_create_subfolder": {
+                        "type": "integer",
+                        "description": "Folder-management hint: 1 when POST /folder/create may use this folder as its parent according to the current access, read-only state, API create permission and global folder-management rules. The create route performs the final validation.",
+                        "enum": [
+                            0,
+                            1
+                        ]
+                    },
+                    "can_rename_folder": {
+                        "type": "integer",
+                        "description": "Folder-management hint: 1 when the source folder is eligible for rename according to the current access, read-only state, API update permission, global folder-management rules and personal-root protection. PUT /folder/update performs the final validation.",
+                        "enum": [
+                            0,
+                            1
+                        ]
+                    },
+                    "can_move_folder": {
+                        "type": "integer",
+                        "description": "Folder-management hint for the source only: 1 when the source folder is eligible to move. PUT /folder/update separately validates the chosen destination, including access, read-only state, cycles, personal/shared domain boundaries and root permission.",
+                        "enum": [
+                            0,
+                            1
+                        ]
+                    },
+                    "can_delete_folder": {
+                        "type": "integer",
+                        "description": "Folder-management hint: 1 when the source folder is eligible for deletion according to the current access, read-only state, API delete permission, global folder-management rules and personal-root protection. DELETE /folder/delete performs the final validation.",
+                        "enum": [
+                            0,
+                            1
+                        ]
                     }
                 }
             },
@@ -1689,9 +1773,33 @@
                     "application/json": {
                         "schema": {
                             "type": "object",
+                            "required": [
+                                "token",
+                                "teampass_version",
+                                "teampass_version_major",
+                                "teampass_version_minor"
+                            ],
                             "properties": {
                                 "token": {
                                     "type": "string"
+                                },
+                                "teampass_version": {
+                                    "type": "string",
+                                    "description": "Complete TeamPass server release version returned in the response body, outside the JWT.",
+                                    "pattern": "^\\d+\\.\\d+\\.\\d+\\.\\d+$",
+                                    "example": "3.2.1.2"
+                                },
+                                "teampass_version_major": {
+                                    "type": "string",
+                                    "description": "Base TeamPass server version (major.minor.patch) returned in the response body.",
+                                    "pattern": "^\\d+\\.\\d+\\.\\d+$",
+                                    "example": "3.2.1"
+                                },
+                                "teampass_version_minor": {
+                                    "type": "string",
+                                    "description": "Final TeamPass release revision component returned in the response body.",
+                                    "pattern": "^\\d+$",
+                                    "example": "2"
                                 }
                             }
                         }
@@ -1704,6 +1812,14 @@
                     "application/json": {
                         "schema": {
                             "type": "object",
+                            "required": [
+                                "extension_fqdn",
+                                "extension_key",
+                                "extension_url",
+                                "teampass_version",
+                                "teampass_version_major",
+                                "teampass_version_minor"
+                            ],
                             "properties": {
                                 "extension_fqdn": {
                                     "type": "string"
@@ -1711,8 +1827,26 @@
                                 "extension_key": {
                                     "type": "string"
                                 },
-                                "cpassman_url": {
+                                "extension_url": {
                                     "type": "string"
+                                },
+                                "teampass_version": {
+                                    "type": "string",
+                                    "description": "Complete TeamPass server release version, refreshed independently of authentication.",
+                                    "pattern": "^\\d+\\.\\d+\\.\\d+\\.\\d+$",
+                                    "example": "3.2.1.2"
+                                },
+                                "teampass_version_major": {
+                                    "type": "string",
+                                    "description": "Base TeamPass server version (major.minor.patch).",
+                                    "pattern": "^\\d+\\.\\d+\\.\\d+$",
+                                    "example": "3.2.1"
+                                },
+                                "teampass_version_minor": {
+                                    "type": "string",
+                                    "description": "Final TeamPass release revision component.",
+                                    "pattern": "^\\d+$",
+                                    "example": "2"
                                 }
                             }
                         }

--- a/tests/Unit/Api/FolderEndpointsRegressionTest.php
+++ b/tests/Unit/Api/FolderEndpointsRegressionTest.php
@@ -442,6 +442,23 @@ class FolderEndpointsRegressionTest extends TestCase
         );
     }
 
+    public function testFolderManagementCapabilitiesReuseTheMutationGate(): void
+    {
+        $controller = $this->readSource('/app/api/Controller/Api/FolderController.php');
+        $model = $this->readSource('/app/api/Model/FolderModel.php');
+
+        self::assertStringContainsString(
+            'getFolderManagementCapabilities(',
+            $controller,
+            'writableFolders must use the authoritative capability evaluator'
+        );
+        self::assertSame(
+            3,
+            substr_count($model, 'hasFolderManagementPrivilege('),
+            'create, update and delete must all reuse the same global management gate'
+        );
+    }
+
     public function testOpenApiDocumentsNewPaths(): void
     {
         $spec = json_decode($this->readSource('/app/api/openapi.json'), true);

--- a/tests/Unit/Api/OpenApiContractTest.php
+++ b/tests/Unit/Api/OpenApiContractTest.php
@@ -202,6 +202,89 @@ class OpenApiContractTest extends TestCase
         self::assertStringContainsString('$intSuccessStatus = 201;', $folderController);
     }
 
+    public function testServerVersionFieldsMatchRuntimeResponses(): void
+    {
+        $spec = $this->getSpec();
+        $responses = $spec['components']['responses'];
+        $versionFields = [
+            'teampass_version',
+            'teampass_version_major',
+            'teampass_version_minor',
+        ];
+        $runtimeSources = [
+            (string) file_get_contents(__DIR__ . '/../../../app/api/Model/AuthModel.php'),
+            (string) file_get_contents(__DIR__ . '/../../../app/api/Model/MiscModel.php'),
+        ];
+
+        foreach (['JwtToken', 'ExtensionSettings'] as $responseName) {
+            $schema = $responses[$responseName]['content']['application/json']['schema'];
+            $properties = $schema['properties'] ?? [];
+            $required = $schema['required'] ?? [];
+
+            foreach ($versionFields as $field) {
+                self::assertArrayHasKey($field, $properties, "$responseName must document $field");
+                self::assertSame('string', $properties[$field]['type'] ?? null);
+                self::assertContains($field, $required, "$responseName must require $field");
+                self::assertNotEmpty($properties[$field]['description'] ?? '');
+            }
+        }
+        foreach ($runtimeSources as $runtimeSource) {
+            foreach ($versionFields as $field) {
+                self::assertStringContainsString(
+                    "'$field' =>",
+                    $runtimeSource,
+                    "Runtime response must keep $field while OpenAPI requires it"
+                );
+            }
+        }
+
+        $jwtRequired = $responses['JwtToken']['content']['application/json']['schema']['required'];
+        self::assertContains('token', $jwtRequired);
+
+        $extensionSchema = $responses['ExtensionSettings']['content']['application/json']['schema'];
+        self::assertArrayHasKey('extension_url', $extensionSchema['properties']);
+        self::assertArrayNotHasKey('cpassman_url', $extensionSchema['properties']);
+        self::assertContains('extension_url', $extensionSchema['required']);
+    }
+
+    public function testWritableFolderSeparatesItemRightsFromFolderManagementCapabilities(): void
+    {
+        $spec = $this->getSpec();
+        $schema = $spec['components']['schemas']['WritableFolder'];
+        $properties = $schema['properties'] ?? [];
+        $required = $schema['required'] ?? [];
+
+        foreach (['can_create', 'can_edit', 'can_delete'] as $field) {
+            self::assertArrayHasKey($field, $properties);
+            self::assertStringContainsString('Item right:', $properties[$field]['description'] ?? '');
+            self::assertSame([0, 1], $properties[$field]['enum'] ?? null);
+        }
+
+        foreach ([
+            'is_personal',
+            'is_personal_root',
+            'can_create_subfolder',
+            'can_rename_folder',
+            'can_move_folder',
+            'can_delete_folder',
+        ] as $field) {
+            self::assertArrayHasKey($field, $properties, "WritableFolder must document $field");
+            self::assertSame('integer', $properties[$field]['type'] ?? null);
+            self::assertSame([0, 1], $properties[$field]['enum'] ?? null);
+            self::assertContains($field, $required, "WritableFolder must require $field");
+            self::assertNotEmpty($properties[$field]['description'] ?? '');
+        }
+
+        self::assertStringContainsString(
+            'source only',
+            $properties['can_move_folder']['description']
+        );
+        self::assertStringContainsString(
+            'performs the final validation',
+            $properties['can_delete_folder']['description']
+        );
+    }
+
     public function testNoCustomReasonPhrasesLeft(): void
     {
         // REST-1/REST-4 guard: the legacy non-standard status lines must not come back

--- a/tests/Unit/FolderAccessModelTest.php
+++ b/tests/Unit/FolderAccessModelTest.php
@@ -7,6 +7,41 @@ require_once __DIR__ . '/../../app/api/Model/FolderAccessModel.php';
 
 class FolderAccessModelTest extends TestCase
 {
+    /**
+     * @param array<string,int> $overrides
+     * @return array<string,int>
+     */
+    private function userData(array $overrides = []): array
+    {
+        return array_merge([
+            'is_admin' => 0,
+            'is_manager' => 0,
+            'user_can_manage_all_users' => 0,
+            'user_can_create_root_folder' => 0,
+            'allowed_to_create' => 1,
+            'allowed_to_update' => 1,
+            'allowed_to_delete' => 1,
+        ], $overrides);
+    }
+
+    /**
+     * @return array{
+     *     can_create_subfolder: bool,
+     *     can_rename_folder: bool,
+     *     can_move_folder: bool,
+     *     can_delete_folder: bool
+     * }
+     */
+    private function allManagementCapabilities(bool $value): array
+    {
+        return [
+            'can_create_subfolder' => $value,
+            'can_rename_folder' => $value,
+            'can_move_folder' => $value,
+            'can_delete_folder' => $value,
+        ];
+    }
+
     public function testNormalizeFolderIdsFromCsv(): void
     {
         $model = new FolderAccessModel();
@@ -46,5 +81,172 @@ class FolderAccessModelTest extends TestCase
         self::assertIsString($source);
 
         self::assertSame(3, substr_count($source, 'other_personal.parent_id = 0'));
+    }
+
+    public function testUnprivilegedSharedFolderHasNoManagementCapabilities(): void
+    {
+        $model = new FolderAccessModel();
+
+        self::assertSame(
+            $this->allManagementCapabilities(false),
+            $model->getFolderManagementCapabilities(
+                $this->userData(),
+                false,
+                false,
+                false,
+                true,
+                false
+            )
+        );
+    }
+
+    public function testAdministratorAndManagerPassTheGlobalManagementGate(): void
+    {
+        $model = new FolderAccessModel();
+
+        foreach ([
+            'administrator' => ['is_admin' => 1],
+            'manager' => ['is_manager' => 1],
+            'manage-all user' => ['user_can_manage_all_users' => 1],
+            'root-folder creator' => ['user_can_create_root_folder' => 1],
+        ] as $label => $privilege) {
+            self::assertSame(
+                $this->allManagementCapabilities(true),
+                $model->getFolderManagementCapabilities(
+                    $this->userData($privilege),
+                    false,
+                    false,
+                    false,
+                    true,
+                    false
+                ),
+                $label
+            );
+        }
+    }
+
+    public function testGlobalSettingEnablesSharedFolderManagement(): void
+    {
+        $model = new FolderAccessModel();
+
+        self::assertSame(
+            $this->allManagementCapabilities(true),
+            $model->getFolderManagementCapabilities(
+                $this->userData(),
+                false,
+                false,
+                false,
+                true,
+                true
+            )
+        );
+    }
+
+    public function testPersonalFolderDoesNotRequireGlobalManagementPrivilege(): void
+    {
+        $model = new FolderAccessModel();
+
+        self::assertSame(
+            $this->allManagementCapabilities(true),
+            $model->getFolderManagementCapabilities(
+                $this->userData(),
+                true,
+                false,
+                false,
+                true,
+                false
+            )
+        );
+    }
+
+    public function testPersonalRootOnlyAllowsCreatingASubfolder(): void
+    {
+        $model = new FolderAccessModel();
+
+        self::assertSame(
+            [
+                'can_create_subfolder' => true,
+                'can_rename_folder' => false,
+                'can_move_folder' => false,
+                'can_delete_folder' => false,
+            ],
+            $model->getFolderManagementCapabilities(
+                $this->userData(),
+                true,
+                true,
+                false,
+                true,
+                false
+            )
+        );
+    }
+
+    public function testReadOnlyOrInaccessibleFolderHasNoManagementCapabilities(): void
+    {
+        $model = new FolderAccessModel();
+        $admin = $this->userData(['is_admin' => 1]);
+
+        self::assertSame(
+            $this->allManagementCapabilities(false),
+            $model->getFolderManagementCapabilities($admin, false, false, true, true, false)
+        );
+        self::assertSame(
+            $this->allManagementCapabilities(false),
+            $model->getFolderManagementCapabilities($admin, false, false, false, false, false)
+        );
+    }
+
+    public function testApiCrudPermissionsDisableOnlyTheirFolderOperations(): void
+    {
+        $model = new FolderAccessModel();
+
+        self::assertSame(
+            [
+                'can_create_subfolder' => false,
+                'can_rename_folder' => true,
+                'can_move_folder' => true,
+                'can_delete_folder' => true,
+            ],
+            $model->getFolderManagementCapabilities(
+                $this->userData(['is_admin' => 1, 'allowed_to_create' => 0]),
+                false,
+                false,
+                false,
+                true,
+                false
+            )
+        );
+        self::assertSame(
+            [
+                'can_create_subfolder' => true,
+                'can_rename_folder' => false,
+                'can_move_folder' => false,
+                'can_delete_folder' => true,
+            ],
+            $model->getFolderManagementCapabilities(
+                $this->userData(['is_admin' => 1, 'allowed_to_update' => 0]),
+                false,
+                false,
+                false,
+                true,
+                false
+            )
+        );
+        self::assertSame(
+            [
+                'can_create_subfolder' => true,
+                'can_rename_folder' => true,
+                'can_move_folder' => true,
+                'can_delete_folder' => false,
+            ],
+            $model->getFolderManagementCapabilities(
+                $this->userData(['is_admin' => 1, 'allowed_to_delete' => 0]),
+                false,
+                false,
+                false,
+                true,
+                false
+            )
+        );
     }
 }


### PR DESCRIPTION
## Summary

- Document the TeamPass server version fields returned by authentication and extension settings responses.
- Expose explicit folder-management capabilities from `/folder/writableFolders`.
- Preserve the existing item-right semantics of `can_create`, `can_edit`, and `can_delete`.
- Add reliable personal-domain metadata with `is_personal` and `is_personal_root`.
- Reuse a shared API folder-management privilege evaluator across create, update, and delete operations.
- Correct the ExtensionSettings contract to document the existing `extension_url` response field.

## Behavior

The new management fields are informational UI hints. The server remains authoritative and revalidates all permissions when a mutation is attempted.

`can_move_folder` only describes source-folder eligibility. The update endpoint still validates the selected destination, including access, read-only state, cycles, personal/shared boundaries, and root permissions.

The change is additive and requires no database migration.

## Testing

- PHP syntax checks
- 166 API/unit tests, 809 assertions
- Targeted PHPStan level 4 analysis
- OpenAPI JSON validation