### PR TITLE
Prevent malformed legacy passwords from aborting security scans

### DIFF
--- a/app/api/Model/ItemModel.php
+++ b/app/api/Model/ItemModel.php
@@ -30,7 +30,6 @@
 
 use TeampassClasses\NestedTree\NestedTree;
 use TeampassClasses\ConfigManager\ConfigManager;
-use ZxcvbnPhp\Zxcvbn;
 use voku\helper\AntiXSS;
 
 class ItemModel
@@ -525,7 +524,7 @@ class ItemModel
      * @param string $password - The plaintext password to check
      * @param array $itemInfos - Folder settings including password complexity requirements
      * @return int - The computed complexity level (one of TP_PW_STRENGTH_*)
-     * @throws Exception - If the password complexity is insufficient
+     * @throws Exception - If the password is unassessable or its complexity is insufficient
      */
     private function checkPasswordComplexity(string $password, array $itemInfos) : int
     {
@@ -552,9 +551,13 @@ class ItemModel
 
         $requested_folder_complexity = $folderComplexity !== null ? (int) $folderComplexity['valeur'] : 0;
 
-        $zxcvbn = new Zxcvbn();
-        $passwordStrength = $zxcvbn->passwordStrength($password);
-        $passwordStrengthScore = convertPasswordStrength($passwordStrength['score']);
+        $passwordStrength = evaluatePasswordStrengthSafely($password);
+        if ($passwordStrength['success'] === false) {
+            throw new InvalidArgumentException(
+                'Password strength could not be evaluated. The password must be valid UTF-8 text.'
+            );
+        }
+        $passwordStrengthScore = convertPasswordStrength((int) $passwordStrength['score']);
 
         if ($passwordStrengthScore < $requested_folder_complexity && (int) $itemInfos['no_complex_check_on_creation'] === 0) {
             throw new Exception('Password strength is too low');

--- a/app/includes/language/english.php
+++ b/app/includes/language/english.php
@@ -2825,4 +2825,7 @@ return array(
     'mass_operation_partially_denied' => '#nb# item(s) skipped due to insufficient permissions',
     'error_hibp_check_failed' => 'Password breach check could not be completed (service unreachable)',
     'error_no_access_to_item' => 'You are not allowed to access this item',
-    );
+    'error_password_strength_evaluation' => 'Password strength could not be evaluated. The password must be valid UTF-8 text.',
+    'security_dashboard_scan_done_skipped' => 'Scan complete. #count# password(s) could not be assessed and were skipped.',
+    'security_dashboard_scan_failed' => 'The scan could not be completed. Please try again or check the server logs.',
+);

--- a/app/includes/language/french.php
+++ b/app/includes/language/french.php
@@ -2954,5 +2954,7 @@ return array(
     'settings_security_dashboard_min_password_length' => 'Longueur minimale du mot de passe (caractères)',
     'settings_security_dashboard_min_password_length_tip' => 'Un mot de passe plus court que ce seuil est signalé comme faible sur la fiche de l’élément, la liste, la posture de sécurité et le rapport de conformité. Laisser vide ou à 0 pour utiliser la valeur par défaut de 12.',
     'security_dashboard_unassessed' => 'Non évalué',
-
+    'error_password_strength_evaluation' => 'La robustesse du mot de passe n’a pas pu être évaluée. Le mot de passe doit être un texte UTF-8 valide.',
+    'security_dashboard_scan_done_skipped' => 'Analyse terminée. #count# mot(s) de passe n’ont pas pu être évalués et ont été ignorés.',
+    'security_dashboard_scan_failed' => 'L’analyse n’a pas pu être terminée. Réessayez ou consultez les journaux du serveur.',
 );

--- a/app/pages/dashboard.js.php
+++ b/app/pages/dashboard.js.php
@@ -89,6 +89,8 @@ if ($checkUserAccess->checkSession() === false || $checkUserAccess->userAccessPa
             scanning: <?php echo json_encode($lang->get('security_dashboard_scanning'), JSON_UNESCAPED_UNICODE); ?>,
             scanButton: <?php echo json_encode($lang->get('security_dashboard_scan_button'), JSON_UNESCAPED_UNICODE); ?>,
             done: <?php echo json_encode($lang->get('security_dashboard_scan_done'), JSON_UNESCAPED_UNICODE); ?>,
+            doneSkipped: <?php echo json_encode($lang->get('security_dashboard_scan_done_skipped'), JSON_UNESCAPED_UNICODE); ?>,
+            scanFailed: <?php echo json_encode($lang->get('security_dashboard_scan_failed'), JSON_UNESCAPED_UNICODE); ?>,
             fix: <?php echo json_encode($lang->get('security_nudges_fix_worst'), JSON_UNESCAPED_UNICODE); ?>,
             allGood: <?php echo json_encode($lang->get('security_score_all_good'), JSON_UNESCAPED_UNICODE); ?>,
             scoreHint: <?php echo json_encode($lang->get('security_score_scan_hint'), JSON_UNESCAPED_UNICODE); ?>,
@@ -115,12 +117,26 @@ if ($checkUserAccess->checkSession() === false || $checkUserAccess->userAccessPa
     };
 
     // Post helper using the standard encrypted client-server exchange.
-    function dashboardPost(payload, callback) {
+    function dashboardPost(payload, callback, errorCallback) {
         payload.key = TP_DASH.key;
-        $.post('sources/dashboard.queries.php', payload, function (data) {
-            data = prepareExchangedData(data, 'decode', TP_DASH.key);
-            callback(data);
-        });
+        return $.post('sources/dashboard.queries.php', payload)
+            .done(function (data) {
+                try {
+                    data = prepareExchangedData(data, 'decode', TP_DASH.key);
+                    callback(data);
+                } catch (error) {
+                    if (typeof errorCallback === 'function') {
+                        errorCallback();
+                    } else {
+                        throw error;
+                    }
+                }
+            })
+            .fail(function () {
+                if (typeof errorCallback === 'function') {
+                    errorCallback();
+                }
+            });
     }
 
     // F10: score band -> presentation (label + gauge colour, kept in sync with the CSS).
@@ -300,6 +316,7 @@ if ($checkUserAccess->checkSession() === false || $checkUserAccess->userAccessPa
     // Incremental list paging state ("load more").
     let dashboardListShown = 0;
     let dashboardListTotal = 0;
+    let dashboardScanSkipped = 0;
 
     function dashboardBuildFolders(folders) {
         const sel = $('#dashboard-folder-filter');
@@ -383,15 +400,20 @@ if ($checkUserAccess->checkSession() === false || $checkUserAccess->userAccessPa
                 dashboardScanFinish(false);
                 return;
             }
+            dashboardScanSkipped += parseInt(data.skipped_count, 10) || 0;
             const pct = data.total > 0 ? Math.min(100, Math.round((data.next_offset / data.total) * 100)) : 100;
             $('#dashboard-progress-bar').css('width', pct + '%').text(pct + '%');
             if (data.done === true) {
-                dashboardPost({ type: 'finalize_scan' }, function () {
-                    dashboardScanFinish(true);
+                dashboardPost({ type: 'finalize_scan' }, function (finalData) {
+                    dashboardScanFinish(Boolean(finalData) && finalData.error !== true);
+                }, function () {
+                    dashboardScanFinish(false);
                 });
             } else {
                 dashboardScanChunk(data.next_offset, includeHibp);
             }
+        }, function () {
+            dashboardScanFinish(false);
         });
     }
 
@@ -399,8 +421,14 @@ if ($checkUserAccess->checkSession() === false || $checkUserAccess->userAccessPa
         const btn = $('#dashboard-scan-btn');
         btn.prop('disabled', false).html('<i class="fa-solid fa-magnifying-glass-chart mr-1"></i>' + TP_DASH.strings.scanButton);
         $('#dashboard-progress-wrap').hide();
-        if (success === true && typeof toastr !== 'undefined') {
-            toastr.success(TP_DASH.strings.done);
+        if (typeof toastr !== 'undefined') {
+            if (success === true && dashboardScanSkipped > 0) {
+                toastr.warning(TP_DASH.strings.doneSkipped.replace('#count#', String(dashboardScanSkipped)));
+            } else if (success === true) {
+                toastr.success(TP_DASH.strings.done);
+            } else {
+                toastr.error(TP_DASH.strings.scanFailed);
+            }
         }
         dashboardLoadSummary();
         dashboardLoadScore();
@@ -414,6 +442,7 @@ if ($checkUserAccess->checkSession() === false || $checkUserAccess->userAccessPa
 
         $('#dashboard-scan-btn').on('click', function () {
             const includeHibp = $('#dashboard-include-hibp').is(':checked') ? 1 : 0;
+            dashboardScanSkipped = 0;
             $(this).prop('disabled', true).html('<i class="fa-solid fa-spinner fa-spin mr-1"></i>' + TP_DASH.strings.scanning);
             $('#dashboard-progress-bar').css('width', '0%').text('0%');
             $('#dashboard-progress-wrap').show();

--- a/app/scripts/background_tasks___do_calculation.php
+++ b/app/scripts/background_tasks___do_calculation.php
@@ -170,19 +170,31 @@ foreach ($items as $item) {
 
 
     $passwordLength = strlen($password);
+    $metadataUpdates = [
+        'pw_len' => $passwordLength,
+    ];
     if ($passwordLength > 0 && $passwordLength <= $SETTINGS['pwd_maximum_length']) {
-        $passwordStrength = $zxcvbn->passwordStrength($password);
-        $passwordStrengthScore = convertPasswordStrength($passwordStrength['score']);
+        $passwordStrength = evaluatePasswordStrengthSafely(
+            $password,
+            [$zxcvbn, 'passwordStrength']
+        );
+        if ($passwordStrength['success'] === true) {
+            $metadataUpdates['complexity_level'] = convertPasswordStrength((int) $passwordStrength['score']);
+        } else {
+            // Preserve the exact password and leave its complexity unassessed.
+            // The background batch must continue with the remaining items.
+            error_log(
+                'Background password-strength calculation skipped item '
+                . (int) $item['itemId'] . ': ' . $passwordStrength['reason']
+            );
+        }
     } else {
-        $passwordStrengthScore = 0;
+        $metadataUpdates['complexity_level'] = 0;
     }
-    
+
     DB::update(
         prefixTable('items'),
-        array(
-            'pw_len' => $passwordLength,
-            'complexity_level' => $passwordStrengthScore,
-        ),
+        $metadataUpdates,
         'id = %i',
         $item['itemId']
     );

--- a/app/sources/dashboard.queries.php
+++ b/app/sources/dashboard.queries.php
@@ -348,6 +348,7 @@ switch ($post_type) {
         $reuseSalt = (string) @file_get_contents(TEAMPASS_SECRETS . '/' . SECUREFILE);
         $reuseSalt = $reuseSalt . '|item-health|' . $userId;
         $zxcvbn = new \ZxcvbnPhp\Zxcvbn();
+        $skippedAssessments = 0;
 
         $total = (int) DB::queryFirstField(
             'SELECT COUNT(*)
@@ -429,9 +430,22 @@ switch ($post_type) {
                     || is_numeric($complexityLevel) === false
                     || (int) $complexityLevel < 0
                 ) {
-                    $passwordStrength = $zxcvbn->passwordStrength($plaintext);
-                    $complexityLevel = convertPasswordStrength((int) $passwordStrength['score']);
-                    $metadataUpdates['complexity_level'] = $complexityLevel;
+                    $passwordStrength = evaluatePasswordStrengthSafely(
+                        $plaintext,
+                        [$zxcvbn, 'passwordStrength']
+                    );
+                    if ($passwordStrength['success'] === true) {
+                        $complexityLevel = convertPasswordStrength((int) $passwordStrength['score']);
+                        $metadataUpdates['complexity_level'] = $complexityLevel;
+                    } else {
+                        // Keep the exact credential and its unassessed complexity metadata.
+                        // One malformed legacy item must never abort the remaining scan.
+                        $skippedAssessments++;
+                        error_log(
+                            'Security posture skipped password-strength assessment for item '
+                            . $itemId . ': ' . $passwordStrength['reason']
+                        );
+                    }
                 }
                 if (count($metadataUpdates) > 0) {
                     DB::update(prefixTable('items'), $metadataUpdates, 'id = %i', $itemId);
@@ -505,6 +519,7 @@ switch ($post_type) {
                 'next_offset' => $nextOffset,
                 'total' => $total,
                 'done' => $done,
+                'skipped_count' => $skippedAssessments,
             ],
             'encode'
         );

--- a/app/sources/items.queries.php
+++ b/app/sources/items.queries.php
@@ -261,8 +261,18 @@ switch ($inputData['type']) {
                 isset($dataReceived['pw_is_b64']) && (int) $dataReceived['pw_is_b64'] === 1
             );
             // Compute complexity server-side from plaintext — single source of truth with the API path
-            $_zxcvbn = new \ZxcvbnPhp\Zxcvbn();
-            $post_complexity_level = convertPasswordStrength($_zxcvbn->passwordStrength($post_password)['score']);
+            $passwordStrength = evaluatePasswordStrengthSafely($post_password);
+            if ($passwordStrength['success'] === false) {
+                echo (string) prepareExchangedData(
+                    [
+                        'error' => true,
+                        'message' => $lang->get('error_password_strength_evaluation'),
+                    ],
+                    'encode'
+                );
+                break;
+            }
+            $post_complexity_level = convertPasswordStrength((int) $passwordStrength['score']);
             $post_tags = htmlspecialchars($dataReceived['tags']);
             $post_template_id = filter_var($dataReceived['template_id'], FILTER_SANITIZE_NUMBER_INT);
             $post_url = filter_var(htmlspecialchars_decode($dataReceived['url']), FILTER_SANITIZE_URL);
@@ -949,8 +959,18 @@ switch ($inputData['type']) {
         // Compute complexity server-side from plaintext — single source of truth with the API path
         // When password is unchanged (empty), fall back to the client-sent value for the folder minimum check
         if (empty($post_password) === false) {
-            $_zxcvbn = new \ZxcvbnPhp\Zxcvbn();
-            $post_complexity_level = convertPasswordStrength($_zxcvbn->passwordStrength($post_password)['score']);
+            $passwordStrength = evaluatePasswordStrengthSafely($post_password);
+            if ($passwordStrength['success'] === false) {
+                echo (string) prepareExchangedData(
+                    [
+                        'error' => true,
+                        'message' => $lang->get('error_password_strength_evaluation'),
+                    ],
+                    'encode'
+                );
+                break;
+            }
+            $post_complexity_level = convertPasswordStrength((int) $passwordStrength['score']);
         } else {
             $post_complexity_level = (int) filter_var($dataReceived['complexity_level'], FILTER_SANITIZE_NUMBER_INT);
         }
@@ -3268,11 +3288,17 @@ switch ($inputData['type']) {
                     || is_numeric($complexityLevel) === false
                     || (int) $complexityLevel < 0
                 ) {
-                    $_zxcvbnCard = new \ZxcvbnPhp\Zxcvbn();
-                    $complexityLevel = convertPasswordStrength(
-                        (int) $_zxcvbnCard->passwordStrength($passwordForMetrics)['score']
-                    );
-                    $metadataUpdates['complexity_level'] = $complexityLevel;
+                    $passwordStrength = evaluatePasswordStrengthSafely($passwordForMetrics);
+                    if ($passwordStrength['success'] === true) {
+                        $complexityLevel = convertPasswordStrength((int) $passwordStrength['score']);
+                        $metadataUpdates['complexity_level'] = $complexityLevel;
+                    } else {
+                        // Existing malformed credentials remain usable but unassessed.
+                        error_log(
+                            'Item card skipped password-strength assessment for item '
+                            . (int) $inputData['id'] . ': ' . $passwordStrength['reason']
+                        );
+                    }
                 }
                 if (count($metadataUpdates) > 0) {
                     DB::update(prefixTable('items'), $metadataUpdates, 'id = %i', (int) $inputData['id']);

--- a/app/sources/main.functions.php
+++ b/app/sources/main.functions.php
@@ -53,6 +53,7 @@ use TeampassClasses\CryptoManager\CryptoManager;
 
 require_once __DIR__ . '/otp.functions.php';
 require_once __DIR__ . '/security_posture_logic.php';
+require_once __DIR__ . '/password_strength.functions.php';
 
 header('Content-type: text/html; charset=utf-8');
 header('Cache-Control: no-cache, must-revalidate');

--- a/app/sources/password_strength.functions.php
+++ b/app/sources/password_strength.functions.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Teampass - a collaborative passwords manager.
+ * ---
+ * This file is part of the TeamPass project.
+ *
+ * TeamPass is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * TeamPass is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with TeamPass. If not, see <https://www.gnu.org/licenses/>.
+ * ---
+ * Safe adapter around zxcvbn-php.
+ *
+ * zxcvbn-php expects valid UTF-8 and may throw a Throwable for malformed legacy
+ * password bytes or another unexpected matcher failure. Callers must be able to
+ * keep processing other items without altering the original password.
+ *
+ * @file      password_strength.functions.php
+ * @author    Nils Laumaillé (nils@teampass.net)
+ * @copyright 2009-2026 Teampass.net
+ * @license   GPL-3.0
+ * @see       https://www.teampass.net
+ */
+
+if (function_exists('evaluatePasswordStrengthSafely') === false) {
+    /**
+     * Evaluate a plaintext password without allowing zxcvbn to abort the caller.
+     *
+     * The plaintext is never converted or normalised: doing so could change the
+     * credential. Invalid UTF-8 is reported as unassessable and left untouched.
+     *
+     * @param string        $password  Exact plaintext password bytes.
+     * @param callable|null $evaluator Optional evaluator for reuse/testing. It must
+     *                                 return the same array shape as Zxcvbn::passwordStrength().
+     *
+     * @return array{success: bool, score: int|null, reason: string}
+     */
+    function evaluatePasswordStrengthSafely(string $password, ?callable $evaluator = null): array
+    {
+        if (mb_check_encoding($password, 'UTF-8') === false) {
+            return [
+                'success' => false,
+                'score' => null,
+                'reason' => 'invalid_utf8',
+            ];
+        }
+
+        try {
+            $result = $evaluator !== null
+                ? $evaluator($password)
+                : (new \ZxcvbnPhp\Zxcvbn())->passwordStrength($password);
+        } catch (\Throwable) {
+            return [
+                'success' => false,
+                'score' => null,
+                'reason' => 'evaluation_failed',
+            ];
+        }
+
+        if (
+            is_array($result) === false
+            || array_key_exists('score', $result) === false
+            || is_numeric($result['score']) === false
+            || (int) $result['score'] < 0
+            || (int) $result['score'] > 4
+        ) {
+            return [
+                'success' => false,
+                'score' => null,
+                'reason' => 'invalid_result',
+            ];
+        }
+
+        return [
+            'success' => true,
+            'score' => (int) $result['score'],
+            'reason' => '',
+        ];
+    }
+}

--- a/tests/Unit/PasswordStrengthSafetyTest.php
+++ b/tests/Unit/PasswordStrengthSafetyTest.php
@@ -1,0 +1,126 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../app/sources/password_strength.functions.php';
+
+/**
+ * Regression coverage for malformed legacy password bytes passed to zxcvbn-php.
+ */
+class PasswordStrengthSafetyTest extends TestCase
+{
+    public function testValidUtf8PasswordIsEvaluated(): void
+    {
+        $result = evaluatePasswordStrengthSafely(
+            "Valid\xC3\xA9Password!",
+            static fn (string $password): array => ['score' => 3]
+        );
+
+        self::assertSame(
+            ['success' => true, 'score' => 3, 'reason' => ''],
+            $result
+        );
+    }
+
+    public function testInvalidUtf8IsRejectedBeforeCallingZxcvbn(): void
+    {
+        $called = false;
+        $password = 'legacy-' . chr(0xE9);
+
+        $result = evaluatePasswordStrengthSafely(
+            $password,
+            static function (string $value) use (&$called): array {
+                $called = true;
+                return ['score' => 2];
+            }
+        );
+
+        self::assertFalse($called);
+        self::assertSame(
+            ['success' => false, 'score' => null, 'reason' => 'invalid_utf8'],
+            $result
+        );
+    }
+
+    public function testEvaluatorThrowableBecomesAnUnassessableResult(): void
+    {
+        $result = evaluatePasswordStrengthSafely(
+            'valid-password',
+            static function (string $password): array {
+                throw new TypeError('Synthetic zxcvbn failure');
+            }
+        );
+
+        self::assertSame(
+            ['success' => false, 'score' => null, 'reason' => 'evaluation_failed'],
+            $result
+        );
+    }
+
+    /**
+     * @return array<string, array{0: mixed}>
+     */
+    public static function invalidResultProvider(): array
+    {
+        return [
+            'not an array' => ['invalid'],
+            'missing score' => [['guesses' => 100]],
+            'non numeric score' => [['score' => 'unknown']],
+            'negative score' => [['score' => -1]],
+            'score above zxcvbn range' => [['score' => 5]],
+        ];
+    }
+
+    #[\PHPUnit\Framework\Attributes\DataProvider('invalidResultProvider')]
+    public function testMalformedEvaluatorResultIsRejected(mixed $evaluation): void
+    {
+        $result = evaluatePasswordStrengthSafely(
+            'valid-password',
+            static fn (string $password): mixed => $evaluation
+        );
+
+        self::assertSame(
+            ['success' => false, 'score' => null, 'reason' => 'invalid_result'],
+            $result
+        );
+    }
+
+    public function testEveryServerSideZxcvbnCallerUsesTheSafeAdapter(): void
+    {
+        $root = dirname(__DIR__, 2);
+        $callers = [
+            $root . '/app/sources/dashboard.queries.php',
+            $root . '/app/sources/items.queries.php',
+            $root . '/app/scripts/background_tasks___do_calculation.php',
+            $root . '/app/api/Model/ItemModel.php',
+        ];
+
+        foreach ($callers as $caller) {
+            $source = (string) file_get_contents($caller);
+            self::assertStringContainsString('evaluatePasswordStrengthSafely(', $source, $caller);
+            self::assertStringNotContainsString('->passwordStrength(', $source, $caller);
+        }
+    }
+
+    public function testSecurityPostureReportsSkippedItemsAndHandlesHttpFailure(): void
+    {
+        $root = dirname(__DIR__, 2);
+        $querySource = (string) file_get_contents($root . '/app/sources/dashboard.queries.php');
+        $clientSource = (string) file_get_contents($root . '/app/pages/dashboard.js.php');
+        $english = (string) file_get_contents($root . '/app/includes/language/english.php');
+        $french = (string) file_get_contents($root . '/app/includes/language/french.php');
+
+        self::assertStringContainsString("'skipped_count' => \$skippedAssessments", $querySource);
+        self::assertStringContainsString('dashboardScanSkipped +=', $clientSource);
+        self::assertStringContainsString('.fail(function ()', $clientSource);
+        self::assertStringContainsString('dashboardScanFinish(false)', $clientSource);
+        self::assertStringContainsString("'security_dashboard_scan_done_skipped' =>", $english);
+        self::assertStringContainsString("'security_dashboard_scan_done_skipped' =>", $french);
+        self::assertStringContainsString("'security_dashboard_scan_failed' =>", $english);
+        self::assertStringContainsString("'security_dashboard_scan_failed' =>", $french);
+        self::assertStringContainsString("'error_password_strength_evaluation' =>", $english);
+        self::assertStringContainsString("'error_password_strength_evaluation' =>", $french);
+    }
+}


### PR DESCRIPTION
## Summary

This pull request prevents malformed or non-UTF-8 legacy password bytes from causing fatal errors in `zxcvbn-php`.

Previously, an invalid UTF-8 password could make `preg_split('//u', ...)` return `false` inside `L33tMatch.php`. The subsequent `array_unique(false)` call raised a `TypeError`, aborted the current Security Posture chunk, and left the browser progress indicator permanently stuck.

The password is now treated as unassessable without being converted, normalised, logged, or otherwise modified. Batch processing continues with the remaining items.

## Root cause

`bjeavons/zxcvbn-php` expects valid UTF-8 input. Some installations contain older, imported, binary, or otherwise malformed decrypted password values that do not meet this assumption.

The issue was reproduced on PHP 8.4 with `bjeavons/zxcvbn-php` 1.4.2:

```text
PHP Fatal error: Uncaught TypeError:
array_unique(): Argument #1 ($array) must be of type array, false given
in src/Matchers/L33tMatch.php
```

A test instance containing 6,847 shared items reported 31 passwords with invalid UTF-8 bytes. The Security Posture scan consistently stopped on the first affected accessible item.

## Changes

- Add a central `evaluatePasswordStrengthSafely()` adapter around `zxcvbn-php`.
- Reject invalid UTF-8 before invoking the library.
- Catch every `Throwable` raised by the evaluator.
- Validate the returned zxcvbn score before callers use it.
- Preserve the exact password bytes; no conversion or normalisation is performed.
- Keep historical malformed passwords classified as unassessed.
- Continue Security Posture processing after an unassessable item.
- Return a per-chunk skipped-assessment count to the browser.
- Display a warning when a scan completes with skipped passwords.
- Handle HTTP and response-decoding failures so the scan button is always restored.
- Protect the background metadata calculation and item-card metadata repair.
- Reject newly submitted non-UTF-8 passwords cleanly in Web and API item creation/update paths.
- Add English and French user-facing messages, with the existing English fallback covering other languages.

## Protected server-side callers

The safe adapter is used by every current server-side zxcvbn caller:

- `app/sources/dashboard.queries.php`
- `app/sources/items.queries.php`
- `app/scripts/background_tasks___do_calculation.php`
- `app/api/Model/ItemModel.php`

The third-party files under `app/vendor/` are intentionally unchanged.

## Security and privacy

- Plaintext passwords are never added to logs or responses.
- Logs contain only the affected item identifier and a fixed failure reason.
- Invalid passwords are not silently transcoded because doing so could change the credential.
- Existing encrypted password values are not modified.
- Reuse grouping remains byte-safe and continues to use the exact plaintext bytes.
- No database schema, dependency, setting, or external service is added.
- HIBP behaviour is unchanged and remains controlled by the existing option.

## Test coverage

Added:

- `tests/Unit/PasswordStrengthSafetyTest.php`

The test covers:

- successful evaluation of valid UTF-8;
- rejection before zxcvbn is called for invalid UTF-8;
- conversion of evaluator exceptions into an unassessable result;
- rejection of malformed or out-of-range evaluator results;
- use of the safe adapter by every server-side zxcvbn caller;
- skipped-item reporting and AJAX failure handling;
- required English and French translations.

## Validation

Run:

```bash
php -l app/sources/password_strength.functions.php
php -l app/sources/main.functions.php
php -l app/sources/dashboard.queries.php
php -l app/sources/items.queries.php
php -l app/pages/dashboard.js.php
php -l app/scripts/background_tasks___do_calculation.php
php -l app/api/Model/ItemModel.php
php -l app/includes/language/english.php
php -l app/includes/language/french.php
php -l tests/Unit/PasswordStrengthSafetyTest.php

app/vendor/bin/phpunit tests/Unit/PasswordStrengthSafetyTest.php
app/vendor/bin/phpunit tests/Unit/SecurityPostureLogicTest.php
app/vendor/bin/phpunit tests/Unit/PasswordHealthConsistencyTest.php
```

## Manual test plan

1. Use an account that can access at least one historical item whose decrypted password is not valid UTF-8.
2. Open Security Posture and start a scan without enabling HIBP.
3. Confirm that the progress passes the previously failing item and reaches 100%.
4. Confirm that the completion warning reports the number of skipped password assessments.
5. Confirm that affected items remain under **Not assessed** and that their password values are unchanged.
6. Confirm that valid items still receive updated password length and complexity metadata.
7. Open an affected historical item and confirm that its card loads without a PHP fatal error.
8. Run the background password metadata calculation and confirm that later items are processed.
9. Submit a non-UTF-8 password through the Web and API item paths and confirm that a controlled validation error is returned.
10. Simulate an HTTP 500 from a scan chunk and confirm that the progress indicator stops, the button is restored, and an error notification is displayed.