### PR TITLE
Remove user-manager ability to assign all roles

### DIFF
--- a/app/sources/users.queries.php
+++ b/app/sources/users.queries.php
@@ -1229,7 +1229,6 @@ if (null !== $post_type) {
                 // only see the roles they personally hold.
                 if (
                     (int) $session->get('user-admin') === 1
-                    || (int) $session->get('user-manager') === 1
                     || (int) $session->get('user-can_manage_all_users') === 1
                 ) {
                     $rows = DB::query(


### PR DESCRIPTION
Admins (user-admin) and "Teampass managers" (user-can_manage_all_users) should see all roles.

The if() clause also included "Managers" (user-manager) but these should only see their own roles.

EDITS:
Removed the OR for user-manager so now they can only add roles that they are a member of.
This has been tested and appears to work as intended.