### PR TITLE
Fix legacy HTML entities displayed in Utilities logs

### DIFF
--- a/app/includes/language/french.php
+++ b/app/includes/language/french.php
@@ -3012,7 +3012,7 @@ return array(
     'ops_hibp_occurrences' => 'occurrences HIBP',
     'ops_hibp_disabled' => 'La vérification Have I Been Pwned est désactivée. Les statuts déjà en cache restent affichés lorsqu’ils existent.',
     'ops_hibp_interval' => 'revérification tous les {days} jour(s)',
-    'ops_kpi_complexity_unknown' => 'Unknown complexity',
+    'ops_kpi_complexity_unknown' => 'Compléxité inconnue',
     'ops_kpi_created_period' => 'Créés sur la période',
     'ops_kpi_created_weak' => 'Créés faibles',
     'ops_activity_summary' => 'Synthèse de l’activité',

--- a/app/pages/utilities.logs.js.php
+++ b/app/pages/utilities.logs.js.php
@@ -350,13 +350,17 @@ if ($checkUserAccess->checkSession() === false || $checkUserAccess->userAccessPa
     }
 
     /**
-     * Escape a DataTables value before displaying it as HTML.
+     * Decode a legacy entity layer and escape the value before displaying it as HTML.
      *
      * @param {*} value Value to escape.
      * @return {string}
      */
     function escapeAuthenticationLockoutValue(value) {
-        return $('<div/>').text(value === null || value === undefined ? '' : value.toString()).html();
+        const normalizedValue = decodeHtmlEntities(
+            value === null || value === undefined ? '' : value.toString()
+        );
+
+        return $('<div/>').text(normalizedValue).html();
     }
 
     /**

--- a/app/sources/kb.queries.php
+++ b/app/sources/kb.queries.php
@@ -2250,10 +2250,10 @@ switch ($type) {
         foreach ($pagedRows as $row) {
             $dataRows[] = [
                 date(($SETTINGS['date_format'] ?? 'Y-m-d') . ' ' . ($SETTINGS['time_format'] ?? 'H:i:s'), (int) ($row['date'] ?? time())),
-                (string) ($row['label'] ?? ''),
-                (string) ($row['user_login'] ?? ''),
-                (string) ($row['action'] ?? ''),
-                (string) ($row['reason'] ?? ''),
+                normalizeLogDisplayValue($row['label'] ?? ''),
+                normalizeLogDisplayValue($row['user_login'] ?? ''),
+                normalizeLogDisplayValue($row['action'] ?? ''),
+                normalizeLogDisplayValue($row['reason'] ?? ''),
             ];
         }
 

--- a/app/sources/logs.datatables.php
+++ b/app/sources/logs.datatables.php
@@ -57,16 +57,6 @@ function tpDatatableJsonCell($value): string
 }
 
 /**
- * Normalize a display value: decode HTML entities then re-encode for safe output.
- */
-function normalizeBackgroundTaskDisplayValue($value): string
-{
-    $decodedValue = html_entity_decode((string) $value, ENT_QUOTES | ENT_HTML5, 'UTF-8');
-
-    return htmlspecialchars($decodedValue, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8', false);
-}
-
-/**
  * Return the display name for a user ID, or a user-slash icon if not found.
  */
 function getBackgroundTaskUserDisplayFromUserId($userId): string
@@ -87,13 +77,13 @@ function getBackgroundTaskUserDisplayFromUserId($userId): string
     }
 
     $displayName = trim(
-        normalizeBackgroundTaskDisplayValue($dataUser['name'] ?? '')
+        normalizeLogDisplayValue($dataUser['name'] ?? '')
         . ' ' .
-        normalizeBackgroundTaskDisplayValue($dataUser['lastname'] ?? '')
+        normalizeLogDisplayValue($dataUser['lastname'] ?? '')
     );
 
     if ($displayName === '') {
-        $displayName = trim(normalizeBackgroundTaskDisplayValue($dataUser['login'] ?? ''));
+        $displayName = trim(normalizeLogDisplayValue($dataUser['login'] ?? ''));
     }
 
     return $displayName === '' ? "<i class='fa-solid fa-user-slash'></i>" : $displayName;
@@ -117,7 +107,7 @@ function resolveBackgroundTaskUserDisplay(array $arguments, string $processType)
     if ($processType === 'send_email') {
         $receiverName = trim((string) ($arguments['receiver_name'] ?? ($arguments['login'] ?? '')));
         if ($receiverName !== '') {
-            return normalizeBackgroundTaskDisplayValue($receiverName);
+            return normalizeLogDisplayValue($receiverName);
         }
 
         $email = trim((string) ($arguments['receivers'] ?? ($arguments['email'] ?? '')));
@@ -132,13 +122,13 @@ function resolveBackgroundTaskUserDisplay(array $arguments, string $processType)
 
             if (DB::count() > 0 && $dataUser !== null) {
                 $displayName = trim(
-                    normalizeBackgroundTaskDisplayValue($dataUser['name'] ?? '')
+                    normalizeLogDisplayValue($dataUser['name'] ?? '')
                     . ' ' .
-                    normalizeBackgroundTaskDisplayValue($dataUser['lastname'] ?? '')
+                    normalizeLogDisplayValue($dataUser['lastname'] ?? '')
                 );
 
                 if ($displayName === '') {
-                    $displayName = trim(normalizeBackgroundTaskDisplayValue($dataUser['login'] ?? ''));
+                    $displayName = trim(normalizeLogDisplayValue($dataUser['login'] ?? ''));
                 }
 
                 if ($displayName !== '') {
@@ -146,7 +136,7 @@ function resolveBackgroundTaskUserDisplay(array $arguments, string $processType)
                 }
             }
 
-            return normalizeBackgroundTaskDisplayValue($email);
+            return normalizeLogDisplayValue($email);
         }
 
         return "<i class='fa-solid fa-user-slash'></i>";
@@ -294,22 +284,21 @@ if (isset($params['action']) && $params['action'] === 'connections') {
         //col1
         $sOutput .= '"'.date($SETTINGS['date_format'].' '.$SETTINGS['time_format'], (int) $record['date']).'", ';
         //col2
-        $sOutput .= tpDatatableJsonCell(str_replace([chr(10), chr(13)], [' ', ' '], htmlspecialchars(stripslashes((string) $record['label']), ENT_QUOTES))).', ';
+        $sOutput .= tpDatatableJsonCell(normalizeLogDisplayValue(str_replace([chr(10), chr(13)], [' ', ' '], stripslashes((string) $record['label'])))).', ';
         //col3 (Source)
         $field1 = isset($record['field_1']) ? trim((string) $record['field_1']) : '';
         $isApi = ($field1 === 'api') || (strpos($field1, 'tp_src=api') !== false);
         $sourceLabel = $isApi ? 'API/Extension' : 'Web';
         $sOutput .= '"'.htmlspecialchars($sourceLabel, ENT_QUOTES).'", ';
         //col4
-        $record = secureOutput($record, ['login', 'name', 'lastname', 'who']);
         if (!empty($record['login'])) {
             $fullname = trim(
-                (string) ($record['name'] ?? '') . ' ' .
-                (string) ($record['lastname'] ?? '')
+                normalizeLogDisplayValue($record['name'] ?? '') . ' ' .
+                normalizeLogDisplayValue($record['lastname'] ?? '')
             );
-            $sOutput .= tpDatatableJsonCell(($fullname !== '' ? $fullname . ' ' : '') . '[' . $record['login'] . ']');
+            $sOutput .= tpDatatableJsonCell(($fullname !== '' ? $fullname . ' ' : '') . '[' . normalizeLogDisplayValue($record['login']) . ']');
         } else {
-            $sOutput .= tpDatatableJsonCell('IP: ' . (string) $record['who']);
+            $sOutput .= tpDatatableJsonCell('IP: ' . normalizeLogDisplayValue($record['who'] ?? ''));
         }
         //Finish the line
         $sOutput .= '],';
@@ -377,14 +366,13 @@ if (isset($params['action']) && $params['action'] === 'connections') {
         $sOutput .= '[';
     }
     foreach ($rows as $record) {
-        $record = secureOutput($record, ['login', 'label']);
         $sOutput .= '[';
         //col1
         $sOutput .= '"'.date($SETTINGS['date_format'].' '.$SETTINGS['time_format'], (int) $record['date']).'", ';
         //col2
-        $sOutput .= tpDatatableJsonCell(str_replace([chr(10), chr(13)], [' ', ' '], (string) $record['label'])).', ';
+        $sOutput .= tpDatatableJsonCell(normalizeLogDisplayValue(str_replace([chr(10), chr(13)], [' ', ' '], (string) $record['label']))).', ';
         //col3
-        $sOutput .= tpDatatableJsonCell((string) $record['login']);
+        $sOutput .= tpDatatableJsonCell(normalizeLogDisplayValue($record['login'] ?? ''));
         //Finish the line
         $sOutput .= '],';
     }
@@ -451,14 +439,13 @@ if (isset($params['action']) && $params['action'] === 'connections') {
         $sOutput .= '[';
     }
     foreach ($rows as $record) {
-        $record = secureOutput($record, ['login', 'label']);
         $sOutput .= '[';
         //col1
         $sOutput .= '"'.date($SETTINGS['date_format'].' '.$SETTINGS['time_format'], (int) $record['date']).'", ';
         //col2
-        $sOutput .= tpDatatableJsonCell(trim((string) $record['label'])).', ';
+        $sOutput .= tpDatatableJsonCell(normalizeLogDisplayValue(trim((string) $record['label']))).', ';
         //col3
-        $sOutput .= tpDatatableJsonCell(trim((string) $record['login']));
+        $sOutput .= tpDatatableJsonCell(normalizeLogDisplayValue(trim((string) $record['login'])));
         //Finish the line
         $sOutput .= '],';
     }
@@ -522,13 +509,12 @@ if (isset($params['action']) && $params['action'] === 'connections') {
     $sOutput .= '"iTotalDisplayRecords": '.$iTotal.', ';
     $sOutput .= '"aaData": [ ';
     foreach ($rows as $record) {
-        $record = secureOutput($record, ['login', 'label']);
         $get_item_in_list = true;
         $sOutput_item = '[';
         //col1
         $sOutput_item .= '"'.date($SETTINGS['date_format'].' '.$SETTINGS['time_format'], (int) $record['date']).'", ';
         //col2
-        $sOutput_item .= tpDatatableJsonCell((string) $record['login']).', ';
+        $sOutput_item .= tpDatatableJsonCell(normalizeLogDisplayValue($record['login'] ?? '')).', ';
         //col3
         if ($record['label'] === 'at_user_added') {
             $cell = $lang->get('user_creation');
@@ -538,7 +524,7 @@ if (isset($params['action']) && $params['action'] === 'connections') {
             $cell = $lang->get('user_updated');
         } elseif (strpos($record['label'], 'at_user_email_changed') !== false) {
             $change = explode(':', $record['label']);
-            $cell = $lang->get('log_user_email_changed').' '.secureOutput($change[1]);
+            $cell = $lang->get('log_user_email_changed').' '.($change[1] ?? '');
         } elseif ($record['label'] === 'at_user_new_keys') {
             $cell = $lang->get('new_keys_generated');
         } elseif ($record['label'] === 'at_user_keys_download') {
@@ -550,10 +536,10 @@ if (isset($params['action']) && $params['action'] === 'connections') {
         } else {
             $cell = (string) $record['label'];
         }
-        $sOutput_item .= tpDatatableJsonCell($cell).' ';
+        $sOutput_item .= tpDatatableJsonCell(normalizeLogDisplayValue($cell)).' ';
         //col4
         if ($record['label'] === 'authentication_lockout_removed') {
-            $sOutput_item .= ', '.tpDatatableJsonCell((string) ($record['field_1'] ?? '')).' ';
+            $sOutput_item .= ', '.tpDatatableJsonCell(normalizeLogDisplayValue($record['field_1'] ?? '')).' ';
         } elseif (empty($record['field_1']) === false) {
             // get user name
             $info = DB::queryFirstRow(
@@ -562,8 +548,11 @@ if (isset($params['action']) && $params['action'] === 'connections') {
                     WHERE u.id = %i',
                     $record['field_1']
             );
-            $info = secureOutput($info ?? [], ['name', 'lastname']);
-            $sOutput_item .= ', '.tpDatatableJsonCell(empty($info['name']) === false ? (string) $info['name'].' '.$info['lastname'] : 'Removed user ('.$record['field_1'].')').' ';
+            $sOutput_item .= ', '.tpDatatableJsonCell(
+                empty($info['name']) === false
+                    ? normalizeLogDisplayValue($info['name']).' '.normalizeLogDisplayValue($info['lastname'] ?? '')
+                    : normalizeLogDisplayValue('Removed user ('.$record['field_1'].')')
+            ).' ';
         } else {
             $sOutput_item .= ', "" ';
         }
@@ -630,7 +619,6 @@ if (isset($params['action']) && $params['action'] === 'connections') {
     $sOutput .= '"iTotalDisplayRecords": '.$iTotal.', ';
     $sOutput .= '"aaData": [ ';
     foreach ($rows as $record) {
-        $record = secureOutput($record, ['label', 'folder', 'name', 'lastname', 'login']);
         $get_item_in_list = true;
         $sOutput_item = '[';
         //col1
@@ -638,11 +626,15 @@ if (isset($params['action']) && $params['action'] === 'connections') {
         //col3
         $sOutput_item .= '"'.trim((string) $record['id']).'", ';
         //col3
-        $sOutput_item .= tpDatatableJsonCell(trim((string) $record['label'])).', ';
+        $sOutput_item .= tpDatatableJsonCell(normalizeLogDisplayValue(trim((string) $record['label']))).', ';
         //col2
-        $sOutput_item .= tpDatatableJsonCell(trim((string) $record['folder'])).', ';
+        $sOutput_item .= tpDatatableJsonCell(normalizeLogDisplayValue(trim((string) $record['folder']))).', ';
         //col2
-        $sOutput_item .= tpDatatableJsonCell(trim((string) $record['name']).' '.trim((string) $record['lastname']).' ['.trim((string) $record['login']).']').', ';
+        $sOutput_item .= tpDatatableJsonCell(
+            normalizeLogDisplayValue(trim((string) $record['name'])).' '.
+            normalizeLogDisplayValue(trim((string) $record['lastname'])).' ['.
+            normalizeLogDisplayValue(trim((string) $record['login'])).']'
+        ).', ';
         //col6
         $sOutput_item .= '"'.secureOutput($lang->get($record['action'])).'", ';
         //col7 (API / Extension)
@@ -764,6 +756,7 @@ if (isset($params['action']) && $params['action'] === 'connections') {
             if ($userDisplay === '') {
                 $userDisplay = $lang->get('authentication_lockout_unknown_user');
             }
+            $userDisplay = normalizeLogDisplayValue($userDisplay);
         }
 
         $firstFailureTimestamp = strtotime((string) ($lockoutRow['first_failure'] ?? ''));
@@ -879,8 +872,8 @@ if (isset($params['action']) && $params['action'] === 'connections') {
         $failedLoginUser = $isApiFailure === true
             ? trim(str_replace([' | tp_src=api', 'tp_src=api'], '', $failedLoginField), " |\t\n\r\0\x0B")
             : $failedLoginField;
-        $failedLoginUser = htmlspecialchars($failedLoginUser, ENT_QUOTES);
-        $failedLoginIp = htmlspecialchars(stripslashes((string) ($record['who'] ?? '')), ENT_QUOTES);
+        $failedLoginUser = normalizeLogDisplayValue($failedLoginUser);
+        $failedLoginIp = normalizeLogDisplayValue(stripslashes((string) ($record['who'] ?? '')));
         $failedLoginChannel = $isApiFailure === true
             ? $lang->get('authentication_channel_api')
             : $lang->get('authentication_channel_web_unknown');
@@ -898,7 +891,7 @@ if (isset($params['action']) && $params['action'] === 'connections') {
         // col1
         $sOutput .= json_encode(date($SETTINGS['date_format'].' '.$SETTINGS['time_format'], (int) $record['auth_date']), JSON_UNESCAPED_UNICODE) . ', ';
         // col2
-        $sOutput .= json_encode(htmlspecialchars((string) $lang->get($failedLoginLabel), ENT_QUOTES), JSON_UNESCAPED_UNICODE) . ', ';
+        $sOutput .= json_encode(normalizeLogDisplayValue($lang->get($failedLoginLabel)), JSON_UNESCAPED_UNICODE) . ', ';
         // col3
         $sOutput .= json_encode($failedLoginUser, JSON_UNESCAPED_UNICODE) . ', ';
         // col4
@@ -971,14 +964,17 @@ if (isset($params['action']) && $params['action'] === 'connections') {
         $sOutput .= '[';
     }
     foreach ($rows as $record) {
-        $record = secureOutput($record, ['name', 'lastname', 'login']);
         $sOutput .= '[';
         //col1
         $sOutput .= '"'.date($SETTINGS['date_format'].' '.$SETTINGS['time_format'], (int) $record['date']).'", ';
         //col2
         $sOutput .= '"'.addslashes(str_replace([chr(10), chr(13), '`', '<br />@', "'"], ['<br>', '<br>', "'", '', '&#39;'], $record['label'])).'", ';
         //col3
-        $sOutput .= tpDatatableJsonCell((string) $record['name'].' '.(string) $record['lastname'].' ['.(string) $record['login'].']');
+        $sOutput .= tpDatatableJsonCell(
+            normalizeLogDisplayValue($record['name'] ?? '').' '.
+            normalizeLogDisplayValue($record['lastname'] ?? '').' ['.
+            normalizeLogDisplayValue($record['login'] ?? '').']'
+        );
         //Finish the line
         $sOutput .= '],';
     }

--- a/app/sources/main.functions.php
+++ b/app/sources/main.functions.php
@@ -6952,6 +6952,24 @@ function secureOutput(mixed $data, array $fields = []): mixed
 }
 
 /**
+ * Normalize a database-backed log value for safe display.
+ *
+ * Older records may contain HTML entities, and some values have already been encoded more than
+ * once. Decode one storage layer here, then re-escape without double encoding. The DataTables
+ * renderers decode the remaining display layer and escape it again before inserting it into the
+ * DOM, so legacy accents remain readable without reintroducing stored XSS.
+ *
+ * @param mixed $value Value read from a log-related database column
+ * @return string Value with one storage entity layer removed and safely re-escaped
+ */
+function normalizeLogDisplayValue(mixed $value): string
+{
+    $decodedValue = html_entity_decode((string) $value, ENT_QUOTES | ENT_HTML5, 'UTF-8');
+
+    return htmlspecialchars($decodedValue, ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5, 'UTF-8', false);
+}
+
+/**
  * Permits to manage the cache tree for a user
  *
  * @param integer $user_id

--- a/tests/Unit/UtilitiesLogsEncodingTest.php
+++ b/tests/Unit/UtilitiesLogsEncodingTest.php
@@ -1,0 +1,155 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Regression guards for legacy HTML entities displayed on utilities.logs.
+ */
+class UtilitiesLogsEncodingTest extends TestCase
+{
+    private function source(string $relativePath): string
+    {
+        $path = __DIR__ . '/../../' . $relativePath;
+        self::assertFileExists($path);
+        $source = file_get_contents($path);
+        self::assertIsString($source);
+
+        return $source;
+    }
+
+    private function dataTableBranch(string $source, string $action, string $nextAction): string
+    {
+        $branchStart = strpos($source, "\$params['action'] === '{$action}'");
+        $nextBranch = strpos($source, "\$params['action'] === '{$nextAction}'", (int) $branchStart);
+
+        self::assertIsInt($branchStart);
+        self::assertIsInt($nextBranch);
+
+        return substr($source, $branchStart, $nextBranch - $branchStart);
+    }
+
+    /**
+     * Mirror the pure production transformation so the expected entity contract is explicit.
+     */
+    private function normalizeLogDisplayValue(mixed $value): string
+    {
+        $decodedValue = html_entity_decode((string) $value, ENT_QUOTES | ENT_HTML5, 'UTF-8');
+
+        return htmlspecialchars($decodedValue, ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5, 'UTF-8', false);
+    }
+
+    public function testLegacyAccentsAreReducedToAtMostOneEntityLayer(): void
+    {
+        self::assertSame('Clémence', $this->normalizeLogDisplayValue('Cl&eacute;mence'));
+        self::assertSame('Cl&eacute;mence', $this->normalizeLogDisplayValue('Cl&amp;eacute;mence'));
+        self::assertSame('Code accès', $this->normalizeLogDisplayValue('Code acc&egrave;s'));
+        self::assertSame('François', $this->normalizeLogDisplayValue('Fran&#231;ois'));
+        self::assertSame('R&amp;D', $this->normalizeLogDisplayValue('R&D'));
+    }
+
+    public function testNormalizationKeepsMarkupInertForTheClientRenderer(): void
+    {
+        $payload = '<img src=x onerror=alert(1)>';
+
+        self::assertSame(
+            '&lt;img src=x onerror=alert(1)&gt;',
+            $this->normalizeLogDisplayValue($payload)
+        );
+        self::assertSame(
+            '&lt;img src=x onerror=alert(1)&gt;',
+            $this->normalizeLogDisplayValue('&lt;img src=x onerror=alert(1)&gt;')
+        );
+        self::assertSame(
+            '&lt;img src=x onerror=alert(1)&gt;',
+            $this->normalizeLogDisplayValue('&amp;lt;img src=x onerror=alert(1)&amp;gt;')
+        );
+    }
+
+    public function testProductionHelperUsesTheAuditedDecodeThenEscapeContract(): void
+    {
+        $functions = $this->source('app/sources/main.functions.php');
+
+        self::assertStringContainsString('function normalizeLogDisplayValue(mixed $value): string', $functions);
+        self::assertStringContainsString(
+            "html_entity_decode((string) \$value, ENT_QUOTES | ENT_HTML5, 'UTF-8')",
+            $functions
+        );
+        self::assertStringContainsString(
+            "htmlspecialchars(\$decodedValue, ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5, 'UTF-8', false)",
+            $functions
+        );
+    }
+
+    public function testAllUtilitiesLogDataSourcesNormalizeDatabaseBackedText(): void
+    {
+        $dataTable = $this->source('app/sources/logs.datatables.php');
+        $knowledgeBase = $this->source('app/sources/kb.queries.php');
+
+        foreach (
+            [
+                ['connections', 'access'],
+                ['access', 'copy'],
+                ['copy', 'admin'],
+                ['admin', 'items'],
+                ['items', 'authentication_lockouts'],
+                ['authentication_lockouts', 'failed_auth'],
+                ['failed_auth', 'errors'],
+                ['errors', 'items_in_edition'],
+            ] as [$action, $nextAction]
+        ) {
+            self::assertStringContainsString(
+                'normalizeLogDisplayValue(',
+                $this->dataTableBranch($dataTable, $action, $nextAction),
+                "The {$action} log source must normalize its database-backed display text."
+            );
+        }
+
+        foreach (
+            [
+                "normalizeLogDisplayValue(\$record['name'] ?? '')",
+                "normalizeLogDisplayValue(\$record['lastname'] ?? '')",
+                "normalizeLogDisplayValue(\$record['login'] ?? '')",
+                "normalizeLogDisplayValue(trim((string) \$record['label']))",
+                "normalizeLogDisplayValue(trim((string) \$record['folder']))",
+                'normalizeLogDisplayValue($failedLoginUser)',
+                'normalizeLogDisplayValue($userDisplay)',
+            ] as $expectedCall
+        ) {
+            self::assertStringContainsString($expectedCall, $dataTable);
+        }
+
+        foreach (['label', 'user_login', 'action', 'reason'] as $field) {
+            self::assertStringContainsString(
+                "normalizeLogDisplayValue(\$row['{$field}'] ?? '')",
+                $knowledgeBase
+            );
+        }
+    }
+
+    public function testClientDecodesThenEscapesEveryTextRenderer(): void
+    {
+        $javascript = $this->source('app/pages/utilities.logs.js.php');
+        $safeRenderer = "return $('<div/>').text(decodeHtmlEntities(data)).html();";
+
+        self::assertGreaterThanOrEqual(7, substr_count($javascript, $safeRenderer));
+        self::assertStringContainsString('const normalizedValue = decodeHtmlEntities(', $javascript);
+        self::assertStringContainsString("return $('<div/>').text(normalizedValue).html();", $javascript);
+        self::assertStringNotContainsString('return decodeHtmlEntities(data);', $javascript);
+    }
+
+    public function testAuthenticationLockoutActionKeepsItsRawDatabaseIdentifier(): void
+    {
+        $dataTable = $this->source('app/sources/logs.datatables.php');
+        $branchStart = strpos($dataTable, "\$params['action'] === 'authentication_lockouts'");
+        $nextBranch = strpos($dataTable, '/* FAILED AUTHENTICATION */', (int) $branchStart);
+
+        self::assertIsInt($branchStart);
+        self::assertIsInt($nextBranch);
+        $branch = substr($dataTable, $branchStart, $nextBranch - $branchStart);
+
+        self::assertStringContainsString("'value' => (string) (\$lockoutRow['value'] ?? '')", $branch);
+        self::assertStringNotContainsString("normalizeLogDisplayValue(\$lockoutRow['value']", $branch);
+    }
+}


### PR DESCRIPTION
## Summary

This change fixes database-backed labels, folder names, logins, first names, and last names being displayed as literal HTML entities on `index.php?page=utilities.logs`.

Examples of the affected output included:

- `Cl&eacute;mence` instead of `Clémence`;
- `Code acc&egrave;s` instead of `Code accès`.

The issue was visible in the **Connections** and **Items** tabs and could affect the other log tabs using the same DataTables rendering pipeline.

## Root cause

Some current or legacy TeamPass records contain named or numeric HTML entities. The log endpoints escaped those values with `htmlspecialchars()` before JSON serialization. When an already encoded value was escaped again, for example `&eacute;` becoming `&amp;eacute;`, the client-side renderer removed only one encoding layer.

The remaining entity then had to stay escaped because the DataTables renderer deliberately treats database values as text to prevent stored XSS. Consequently, the entity source was displayed literally.

This behavior became visible after the log-table XSS hardening correctly stopped returning decoded database content as active HTML.

## Implementation

### Shared server-side normalization

`normalizeLogDisplayValue()` was added to `app/sources/main.functions.php`.

The helper:

1. decodes one stored HTML-entity layer with `ENT_QUOTES | ENT_HTML5` and UTF-8;
2. escapes the decoded value with `ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5`;
3. disables double encoding so a remaining legitimate entity layer is preserved for the client renderer.

This handles raw UTF-8 values, single-encoded legacy values, and values that have already been encoded twice.

### Utilities log data sources

`app/sources/logs.datatables.php` now applies the shared helper to database-backed text sent to the following views:

- Connections;
- item access/copy logs;
- Administration;
- Items;
- authentication lockout user display;
- Failed connections;
- Errors;
- background task user display values returned by the same endpoint.

The raw authentication-lockout key remains unchanged in the JSON response because it is an operational identifier used by the unlock action. Only its user-facing label is normalized.

### Knowledge base logs

`app/sources/kb.queries.php` uses the same helper for the Knowledge base log label, user login, action, and reason fields.

### Client-side rendering

The existing DataTables sequence remains in place:

1. decode the remaining display entity layer;
2. insert the result through jQuery's text API;
3. return escaped HTML to DataTables.

The authentication-lockout renderer was aligned with this sequence so user display names receive the same treatment as the other tabs.

## Security considerations

The stored-XSS protection is intentionally preserved:

- database values are JSON encoded;
- decoded values are never returned directly as active HTML;
- the final client-side insertion uses `text(...)` before DataTables receives the cell content;
- raw and entity-encoded markup therefore remains inert text;
- operational database identifiers are not modified.

The fix does not revert the previous XSS hardening and does not require a database migration.

## Tests added

`tests/Unit/UtilitiesLogsEncodingTest.php` adds regression coverage for:

- raw UTF-8 accents;
- named HTML entities;
- numeric HTML entities;
- double-encoded entities;
- ordinary ampersands;
- raw, encoded, and double-encoded HTML payloads;
- use of the normalizer by all Utilities log data sources;
- the client-side decode-then-escape contract;
- preservation of the raw authentication-lockout identifier.

## Suggested manual validation

1. Open **Utilities > Logs** with records containing accented user and item names.
2. Verify **Connections**, **Failed connections**, **Authentication lockouts**, **Errors**, **Copy**, **Administration**, **Items**, and **Knowledge base**.
3. Confirm that values stored as `é`, `&eacute;`, and `&amp;eacute;` all render as `é`.
4. Confirm that labels containing `<`, `>`, quotes, or entity-encoded markup are displayed as text and do not create DOM elements or execute scripts.
5. From **Authentication lockouts**, remove a lockout and confirm that the action still targets the exact stored login or IP value.

## Files changed

- `app/sources/main.functions.php`
- `app/sources/logs.datatables.php`
- `app/sources/kb.queries.php`
- `app/pages/utilities.logs.js.php`
- `tests/Unit/UtilitiesLogsEncodingTest.php`

No schema change or data migration is required.
