### PR TITLE
Display user avatar in the topbar account menu

### DIFF
--- a/app/pages/profile.js.php
+++ b/app/pages/profile.js.php
@@ -103,6 +103,27 @@ if ($checkUserAccess->checkSession() === false || $checkUserAccess->userAccessPa
 
 
     // AVATAR IMPORT
+    const updateAccountAvatar = (avatarUrl) => {
+        $('.tp-account-avatar').each(function() {
+            const accountAvatar = $(this)
+            accountAvatar.find('.tp-account-avatar-img').remove()
+
+            if (typeof avatarUrl !== 'string' || avatarUrl === '') {
+                return
+            }
+
+            $('<img>', {
+                class: 'tp-account-avatar-img',
+                src: avatarUrl,
+                alt: ''
+            })
+                .on('error', function() {
+                    $(this).remove()
+                })
+                .appendTo(accountAvatar)
+        })
+    }
+
     // Both the button in the settings tab and the profile picture itself open the file dialog.
     // Plupload resolves browse_button through Dom.getAll(), so a list of ids is supported and
     // missing elements are simply ignored (profile edition disabled).
@@ -176,6 +197,7 @@ if ($checkUserAccess->checkSession() === false || $checkUserAccess->userAccessPa
                 toastr.remove();
                 if (myData.error === false) {
                     $('#profile-user-avatar').attr('src', 'assets/avatars/' + myData.filename);
+                    updateAccountAvatar('assets/avatars/' + encodeURIComponent(myData.filename_thumb || myData.filename))
                     $('#profile-avatar-delete').removeClass('hidden');
                     $('#profile-avatar-file-list').html('').addClass('hidden');
                 } else {
@@ -256,6 +278,7 @@ if ($checkUserAccess->checkSession() === false || $checkUserAccess->userAccessPa
                         }
 
                         $('#profile-user-avatar').attr('src', data.avatar_url || './assets/images/photo.jpg');
+                        updateAccountAvatar('')
                         $('#profile-avatar-delete').addClass('hidden');
                         toastr.success(
                             data.message || '<?php echo addslashes($lang->get('avatar_deleted')); ?>',

--- a/public/assets/css/teampass.css
+++ b/public/assets/css/teampass.css
@@ -975,6 +975,7 @@ body.dark-mode .form-control:focus-visible {
 }
 
 .tp-account-avatar {
+    position: relative;
     display: inline-flex;
     align-items: center;
     justify-content: center;
@@ -988,6 +989,16 @@ body.dark-mode .form-control:focus-visible {
     font-weight: 700;
     letter-spacing: .02em;
     text-transform: uppercase;
+    overflow: hidden;
+}
+.tp-account-avatar-img {
+    position: absolute;
+    inset: 0;
+    display: block;
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    background-color: #007bff;
 }
 .tp-account-avatar-lg {
     width: 42px;

--- a/public/index.php
+++ b/public/index.php
@@ -381,8 +381,21 @@ if ((null === $session->get('user-validite_pw') || empty($session->get('user-val
                 // Favorites page gate: feature enabled and caller not an administrator.
                 $tpShowQuickAccess = (int) ($SETTINGS['show_last_items'] ?? 1) === 1;
                 $tpQuickAccessStarred = (int) ($SETTINGS['enable_favourites'] ?? 0) === 1 && (int) $session_user_admin !== 1;
-                // Account chip initials + role label.
+                // Account chip avatar (with initials fallback) + role label.
                 $tpInitials = strtoupper(mb_substr((string) $session_name, 0, 1, 'UTF-8') . mb_substr((string) $session_lastname, 0, 1, 'UTF-8'));
+                $tpAvatarUrl = '';
+                foreach (['user-avatar_thumb', 'user-avatar'] as $tpAvatarSessionKey) {
+                    $tpAvatarFile = basename(trim((string) $session->get($tpAvatarSessionKey)));
+                    if ($tpAvatarFile === '') {
+                        continue;
+                    }
+
+                    $tpAvatarPath = __DIR__ . '/assets/avatars/' . $tpAvatarFile;
+                    if (is_file($tpAvatarPath) === true) {
+                        $tpAvatarUrl = './assets/avatars/' . rawurlencode($tpAvatarFile);
+                        break;
+                    }
+                }
                 $tpRoleLabel = (int) $session_user_admin === 1
                     ? $lang->get('god')
                     : ($session_user_manager === 1 ? $lang->get('gestionnaire') : $lang->get('user'));
@@ -438,7 +451,7 @@ if ((null === $session->get('user-validite_pw') || empty($session->get('user-val
                         <a class="nav-link tp-account-chip" href="#" data-toggle="dropdown" role="button"
                             aria-haspopup="true" aria-expanded="false"
                             aria-label="<?php echo $lang->get('my_profile'); ?>">
-                            <span class="tp-account-avatar"><?php echo htmlspecialchars($tpInitials, ENT_QUOTES, 'UTF-8'); ?></span>
+                            <span class="tp-account-avatar"><?php echo htmlspecialchars($tpInitials, ENT_QUOTES, 'UTF-8'); ?><?php if ($tpAvatarUrl !== '') { ?><img class="tp-account-avatar-img" src="<?php echo htmlspecialchars($tpAvatarUrl, ENT_QUOTES, 'UTF-8'); ?>" alt="" onerror="this.remove();"><?php } ?></span>
                             <span class="tp-account-identity">
                                 <span class="tp-account-name"><?php echo $session_name . ' ' . $session_lastname; ?></span>
                                 <span class="tp-account-exp infotip" id="countdown" title="<?php echo $lang->get('index_expiration_in'); ?>"></span>
@@ -448,7 +461,7 @@ if ((null === $session->get('user-validite_pw') || empty($session->get('user-val
 
                         <div class="dropdown-menu dropdown-menu-right tp-account-menu">
                             <div class="tp-account-menu-head">
-                                <span class="tp-account-avatar tp-account-avatar-lg"><?php echo htmlspecialchars($tpInitials, ENT_QUOTES, 'UTF-8'); ?></span>
+                                <span class="tp-account-avatar tp-account-avatar-lg"><?php echo htmlspecialchars($tpInitials, ENT_QUOTES, 'UTF-8'); ?><?php if ($tpAvatarUrl !== '') { ?><img class="tp-account-avatar-img" src="<?php echo htmlspecialchars($tpAvatarUrl, ENT_QUOTES, 'UTF-8'); ?>" alt="" onerror="this.remove();"><?php } ?></span>
                                 <span class="tp-account-menu-identity">
                                     <span class="tp-account-menu-name"><?php echo $session_name . ' ' . $session_lastname; ?></span>
                                     <span class="tp-account-menu-role"><?php echo $tpRoleLabel; ?></span>

--- a/tests/Unit/AccountAvatarDisplayTest.php
+++ b/tests/Unit/AccountAvatarDisplayTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Regression coverage for the account avatar displayed in the topbar.
+ */
+class AccountAvatarDisplayTest extends TestCase
+{
+    private static function source(string $relativePath): string
+    {
+        $content = file_get_contents(__DIR__ . '/../../' . $relativePath);
+        self::assertNotFalse($content, $relativePath . ' must be readable');
+
+        return (string) $content;
+    }
+
+    public function testAccountAvatarUsesSessionThumbnailWithSafeFallbacks(): void
+    {
+        $index = self::source('public/index.php');
+
+        self::assertStringContainsString("foreach (['user-avatar_thumb', 'user-avatar']", $index);
+        self::assertStringContainsString('basename(trim((string) $session->get($tpAvatarSessionKey)))', $index);
+        self::assertStringContainsString('is_file($tpAvatarPath) === true', $index);
+        self::assertStringContainsString("'./assets/avatars/' . rawurlencode(\$tpAvatarFile)", $index);
+        self::assertSame(2, substr_count($index, 'class="tp-account-avatar-img"'));
+        self::assertSame(
+            2,
+            substr_count($index, "htmlspecialchars(\$tpInitials, ENT_QUOTES, 'UTF-8')"),
+            'Both account avatar locations must retain the initials fallback'
+        );
+    }
+
+    public function testAccountAvatarImageIsCircularAndCropped(): void
+    {
+        $stylesheet = self::source('public/assets/css/teampass.css');
+
+        self::assertStringContainsString('.tp-account-avatar-img {', $stylesheet);
+        self::assertStringContainsString('object-fit: cover;', $stylesheet);
+        self::assertStringContainsString('overflow: hidden;', $stylesheet);
+    }
+
+    public function testProfileUpdatesAndRemovesTheTopbarAvatarWithoutReloading(): void
+    {
+        $javascript = self::source('app/pages/profile.js.php');
+
+        self::assertStringContainsString('const updateAccountAvatar = (avatarUrl) => {', $javascript);
+        self::assertStringContainsString("accountAvatar.find('.tp-account-avatar-img').remove()", $javascript);
+        self::assertStringContainsString(
+            "updateAccountAvatar('assets/avatars/' + encodeURIComponent(myData.filename_thumb || myData.filename))",
+            $javascript
+        );
+        self::assertStringContainsString("updateAccountAvatar('')", $javascript);
+    }
+}


### PR DESCRIPTION
## Summary

This change displays the authenticated user's avatar in the account area at the top right of the TeamPass interface.

When no usable avatar is available, TeamPass keeps displaying the user's initials exactly as before.

The avatar is shown consistently in:

- the compact account chip in the topbar;
- the account header inside the dropdown menu.

## Current behavior

TeamPass 3.2.1.4 introduced an account chip containing the user's initials. Although the user's avatar and avatar thumbnail are already stored in the session, neither value was used by this new component.

As a result, users with an existing profile image still saw their initials in the topbar.

## Implementation

### Safe avatar resolution

`public/index.php` now resolves the account image from the existing session data:

1. use `user-avatar_thumb` when its file exists;
2. fall back to the full `user-avatar` file when needed;
3. keep the initials when neither file is usable.

The stored filename is reduced to its basename, checked with `is_file()`, and URL-encoded before being inserted into the generated URL.

No additional database query is performed.

### Account avatar rendering

Both account avatar locations retain the initials in their markup as the fallback content. When a valid image is available, it is placed over those initials.

The image:

- fills the existing circular account badge;
- uses `object-fit: cover` to preserve the badge proportions;
- works with both the regular and enlarged account badge sizes;
- is removed if loading fails, revealing the initials again.

### Live profile updates

The profile page now updates the topbar account avatar immediately after a successful avatar upload.

When the current avatar is deleted, the topbar image is removed immediately and the original initials become visible again. No page reload is required for either action.

## Security considerations

- The avatar filename is never used directly as a filesystem path.
- `basename()` prevents path components from being honored.
- `is_file()` prevents rendering stale database or session references.
- `rawurlencode()` and `htmlspecialchars()` protect the generated image URL.
- The image is decorative (`alt=""`) because the surrounding account control already has an accessible profile label and user identity.
- No user-supplied HTML is generated by the live profile update; the image element is built through jQuery's element API.

## Compatibility and impact

- Compatible with the existing TeamPass 3.2.1.4 session and avatar upload mechanisms.
- No database schema change.
- No install or upgrade script.
- No API change.
- No new language string.
- No new dependency.
- Existing initials behavior remains the fallback for all account types.

## Tests added

`tests/Unit/AccountAvatarDisplayTest.php` provides regression coverage for:

- thumbnail-first resolution with full-avatar fallback;
- safe filename and file-existence checks;
- presence of the avatar in both account locations;
- preservation of initials in both locations;
- circular cropped-image styling;
- immediate topbar updates after avatar upload and deletion.

## Suggested manual validation

1. Sign in with a user who has no avatar and confirm that initials are displayed in both account locations.
2. Sign in with a user who already has an avatar and confirm that the image is displayed in both locations.
3. Upload a new avatar from the profile page and confirm that the topbar changes without reloading the page.
4. Delete the avatar and confirm that the topbar immediately returns to the initials.
5. Confirm the result in light mode, dark mode, and the compact mobile layout.
6. Temporarily test a missing avatar file reference and confirm that initials are used instead of a broken image.

## Files changed

- `public/index.php`
- `public/assets/css/teampass.css`
- `app/pages/profile.js.php`
- `tests/Unit/AccountAvatarDisplayTest.php`

No data migration is required.
