### PR TITLE
Update api item move from personnal to shared2

### DIFF
--- a/app/api/Model/ItemModel.php
+++ b/app/api/Model/ItemModel.php
@@ -1260,6 +1260,7 @@ class ItemModel
                 || array_key_exists('totp_algorithm', $params)
                 || array_key_exists('totp_digits', $params)
                 || array_key_exists('totp_period', $params);
+            $moveSideEffects = null;
 
             // Handle folder_id change
             if (isset($params['folder_id'])) {
@@ -1290,9 +1291,51 @@ class ItemModel
                     ];
                 }
 
+                $sourceItemInfos = $this->getFolderSettings((int) $currentItem['id_tree']);
                 $targetItemInfos = $this->getFolderSettings($newFolderId);
-                $updateData['id_tree'] = $newFolderId;
-                $updateData['perso'] = (int) $targetItemInfos['personal_folder'];
+
+                if (
+                    (int) $sourceItemInfos['personal_folder'] === 1
+                    && (int) $targetItemInfos['personal_folder'] === 0
+                ) {
+                    $additionalMoveFields = array_diff(
+                        array_keys($params),
+                        ['id', 'folder_id']
+                    );
+                    if (empty($additionalMoveFields) === false) {
+                        return [
+                            'error' => true,
+                            'error_message' => 'A personal-to-shared move must be requested separately from other item updates.',
+                            'error_header' => 'HTTP/1.1 422 Unprocessable Entity',
+                        ];
+                    }
+
+                    try {
+                        $moveSideEffects = movePersonalItemToSharedFolderSynchronously(
+                            $itemId,
+                            $newFolderId,
+                            (int) $userData['id'],
+                            $userPrivateKey
+                        );
+                    } catch (InvalidArgumentException | UnexpectedValueException $exception) {
+                        error_log(
+                            '[API] Personal-to-shared item move rejected for item ' . $itemId
+                            . ': ' . $exception->getMessage()
+                        );
+                        return [
+                            'error' => true,
+                            'error_message' => 'The item cannot be moved because one or more encryption keys are missing or invalid.',
+                            'error_header' => 'HTTP/1.1 422 Unprocessable Entity',
+                        ];
+                    }
+
+                    // Keep the in-memory row aligned for the standard response and cache refresh.
+                    $currentItem['id_tree'] = $newFolderId;
+                    $currentItem['perso'] = 0;
+                } else {
+                    $updateData['id_tree'] = $newFolderId;
+                    $updateData['perso'] = (int) $targetItemInfos['personal_folder'];
+                }
             }
 
             // Generate favicon URL if URL is provided and favicon_url is empty
@@ -1497,11 +1540,23 @@ class ItemModel
                 );
             }
 
-            // Log the update
             $label = isset($updateData['label']) ? $updateData['label'] : $currentItem['label'];
-            logItems($SETTINGS, $itemId, $label, $userData['id'], 'at_modification', $userData['username']);
-
-            updateCacheTable('update_value', $itemId, (int) $userData['id']);
+            if (is_array($moveSideEffects)) {
+                finalizeItemMoveSideEffects(
+                    $SETTINGS,
+                    $itemId,
+                    (string) $label,
+                    (int) $userData['id'],
+                    (string) $userData['username'],
+                    (int) $moveSideEffects['source_folder_id'],
+                    (string) $moveSideEffects['source_folder_title'],
+                    (int) $moveSideEffects['target_folder_id'],
+                    (string) $moveSideEffects['target_folder_title']
+                );
+            } else {
+                logItems($SETTINGS, $itemId, $label, $userData['id'], 'at_modification', $userData['username']);
+                updateCacheTable('update_value', $itemId, (int) $userData['id']);
+            }
 
             // Success response
             return [

--- a/app/sources/items.queries.php
+++ b/app/sources/items.queries.php
@@ -5939,202 +5939,53 @@ switch ($inputData['type']) {
             // ---
             // ---
         } elseif (intval($dataSource['personal_folder']) === 1 && intval($dataDestination['personal_folder']) === 0) {
-            // If previous is personal folder and new is not personal folder => no key exist on item => add new
-            // Create keys for all users
-
-            // Get the ITEM object key for the user
-            $userKey = DB::queryFirstRow(
-                'SELECT share_key, increment_id
-                FROM ' . prefixTable('sharekeys_items') . '
-                WHERE user_id = %i AND object_id = %i',
-                $session->get('user-id'),
-                $inputData['itemId']
-            );
-            if (DB::count() > 0) {
-                $objectKey = decryptUserObjectKeyWithMigration(
-                    $userKey['share_key'],
-                    $session->get('user-private_key'),
-                    $session->get('user-public_key'),
-                    intval($userKey['increment_id']),
-                    'sharekeys_items'
+            try {
+                movePersonalItemToSharedFolderSynchronously(
+                    (int) $inputData['itemId'],
+                    (int) $inputData['folderId'],
+                    (int) $session->get('user-id'),
+                    (string) $session->get('user-private_key')
                 );
-
-                // This is a public object
-                $users = DB::query(
-                    'SELECT id, public_key
-                    FROM ' . prefixTable('users') . '
-                    WHERE id NOT IN %li
-                    AND public_key != ""',
-                    $tpUsersIDs
+            } catch (InvalidArgumentException | UnexpectedValueException $exception) {
+                error_log(
+                    'TEAMPASS Error - move_item personal-to-shared validation failed for item '
+                    . (int) $inputData['itemId'] . ': ' . $exception->getMessage()
                 );
-
-                foreach ($users as $user) {
-                    // Insert in DB the new object key for this item by user
-                    insertOrUpdateSharekey(
-                        prefixTable('sharekeys_items'),
-                        (int) $inputData['itemId'],
-                        intval($user['id']),
-                        encryptUserObjectKey($objectKey, $user['public_key'])
-                    );
-                }
+                echo (string) prepareExchangedData(
+                    [
+                        'error' => true,
+                        'message' => $lang->get('error_missing_sharekey'),
+                    ],
+                    'encode'
+                );
+                break;
+            } catch (Throwable $exception) {
+                error_log(
+                    'TEAMPASS Error - move_item personal-to-shared failed for item '
+                    . (int) $inputData['itemId'] . ': ' . $exception->getMessage()
+                );
+                echo (string) prepareExchangedData(
+                    [
+                        'error' => true,
+                        'message' => $lang->get('error_unknown'),
+                    ],
+                    'encode'
+                );
+                break;
             }
-
-            // Get fields for this Item
-            // Fetch encryption_type to skip non-encrypted fields and detect orphans
-            $rows = DB::query(
-                'SELECT id, encryption_type
-                FROM ' . prefixTable('categories_items') . '
-                WHERE item_id = %i',
-                $inputData['itemId']
-            );
-            foreach ($rows as $field) {
-                // Non-encrypted fields have no sharekey — nothing to distribute
-                if ($field['encryption_type'] === 'not_set') {
-                    continue;
-                }
-
-                $userKey = DB::queryFirstRow(
-                    'SELECT share_key, increment_id
-                    FROM ' . prefixTable('sharekeys_fields') . '
-                    WHERE user_id = %i AND object_id = %i',
-                    $session->get('user-id'),
-                    $field['id']
-                );
-                if (DB::count() === 0) {
-                    // Encrypted field with no sharekey: the object key is unrecoverable.
-                    // Keeping this row would cause a permanent decryption_failed for all users.
-                    // Delete the orphaned field value and log the incident.
-                    logEvents(
-                        $SETTINGS,
-                        'error',
-                        'move_item: encrypted field id=' . $field['id'] .
-                            ' (item=' . $inputData['itemId'] . ') has no sharekey' .
-                            ' for user=' . $session->get('user-id') .
-                            ' — orphaned row deleted during personal→public move',
-                        (string) $session->get('user-id'),
-                        (string) $session->get('user-login'),
-                        (string) $inputData['itemId']
-                    );
-                    DB::delete(prefixTable('categories_items'), 'id = %i', $field['id']);
-                    continue;
-                }
-
-                $objectKey = decryptUserObjectKeyWithMigration(
-                    $userKey['share_key'],
-                    $session->get('user-private_key'),
-                    $session->get('user-public_key'),
-                    intval($userKey['increment_id']),
-                    'sharekeys_fields'
-                );
-
-                // This is a public object
-                $users = DB::query(
-                    'SELECT id, public_key
-                    FROM ' . prefixTable('users') . '
-                    WHERE id NOT IN %li
-                    AND public_key != ""',
-                    $tpUsersIDs
-                );
-                foreach ($users as $user) {
-                    // Insert in DB the new object key for this item by user
-                    insertOrUpdateSharekey(
-                        prefixTable('sharekeys_fields'),
-                        intval($field['id']),
-                        intval($user['id']),
-                        encryptUserObjectKey($objectKey, $user['public_key'])
-                    );
-                }
-            }
-
-            // Get the FILE object key for the user
-            // Get FILES for this Item
-            $rows = DB::query(
-                'SELECT id
-                FROM ' . prefixTable('files') . '
-                WHERE id_item = %i',
-                $inputData['itemId']
-            );
-            foreach ($rows as $attachment) {
-                $userKey = DB::queryFirstRow(
-                    'SELECT share_key, increment_id
-                    FROM ' . prefixTable('sharekeys_files') . '
-                    WHERE user_id = %i AND object_id = %i',
-                    $session->get('user-id'),
-                    $attachment['id']
-                );
-                if (DB::count() > 0) {
-                    $objectKey = decryptUserObjectKeyWithMigration(
-                        $userKey['share_key'],
-                        $session->get('user-private_key'),
-                        $session->get('user-public_key'),
-                        intval($userKey['increment_id']),
-                        'sharekeys_files'
-                    );
-
-                    // This is a public object
-                    $users = DB::query(
-                        'SELECT id, public_key
-                        FROM ' . prefixTable('users') . '
-                        WHERE id NOT IN %li
-                        AND public_key != ""',
-                        $tpUsersIDs
-                    );
-
-                    foreach ($users as $user) {
-                        // Insert in DB the new object key for this item by user
-                        insertOrUpdateSharekey(
-                            prefixTable('sharekeys_files'),
-                            intval($attachment['id']),
-                            intval($user['id']),
-                            encryptUserObjectKey($objectKey, $user['public_key'])
-                        );
-                    }
-                }
-            }
-
-            // update item
-            DB::update(
-                prefixTable('items'),
-                array(
-                    'id_tree' => $inputData['folderId'],
-                    'perso' => 0,
-                    'updated_at' => time(),
-                ),
-                'id=%i',
-                $inputData['itemId']
-            );
         }
 
-        // Log item moved
-        logItems(
+        finalizeItemMoveSideEffects(
             $SETTINGS,
             (int) $inputData['itemId'],
-            $dataSource['label'],
-            $session->get('user-id'),
-            'at_modification',
-            $session->get('user-login'),
-            'at_moved : ' . strval($dataSource['title']) . ' -> ' . strval($dataDestination['title'])
+            (string) $dataSource['label'],
+            (int) $session->get('user-id'),
+            (string) ($session->get('user-login') ?? ''),
+            (int) $dataSource['id_tree'],
+            (string) $dataSource['title'],
+            (int) $inputData['folderId'],
+            (string) $dataDestination['title']
         );
-
-        // Update cache table
-        updateCacheTable('update_value', (int) $inputData['itemId']);
-
-        // Refresh tree counters for both source and destination folders (#5221)
-        adjustFolderItemsCounter((int) $dataSource['id_tree'], -1);
-        adjustFolderItemsCounter((int) $inputData['folderId'], 1);
-
-        // Notify via WebSocket: item moved from source folder and arrived in destination folder.
-        // Both folders' subscribers receive the event (excluding the user who performed the move).
-        $movePayload = [
-            'item_id'        => (int) $inputData['itemId'],
-            'from_folder_id' => (int) $dataSource['id_tree'],
-            'to_folder_id'   => (int) $inputData['folderId'],
-            'label'          => $dataSource['label'],
-            'moved_by'       => $session->get('user-login') ?? '',
-        ];
-        $moveExclude = (int) $session->get('user-id');
-        emitWebSocketEvent('item_moved', 'folder', (int) $dataSource['id_tree'], $movePayload, $moveExclude);
-        emitWebSocketEvent('item_moved', 'folder', (int) $inputData['folderId'], $movePayload, $moveExclude);
 
         $returnValues = array(
             'error' => '',

--- a/app/sources/main.functions.php
+++ b/app/sources/main.functions.php
@@ -6293,6 +6293,325 @@ function storeUsersShareKey(
 }
 
 /**
+ * Move a personal item to a shared folder and synchronously distribute its object keys.
+ *
+ * The item remains personal until every source key owned by the caller has been loaded and
+ * decrypted. Item, encrypted custom-field and file sharekeys are then distributed inside the
+ * same transaction as the folder change. Historical log sharekeys intentionally keep the
+ * existing Web move behaviour and are not redistributed by this first implementation.
+ *
+ * @param int    $itemId        Item to move
+ * @param int    $targetFolderId Shared destination folder
+ * @param int    $userId        User performing the move
+ * @param string $userPrivateKey Decrypted private key of the user performing the move
+ *
+ * @return array{
+ *     item_id: int,
+ *     label: string,
+ *     source_folder_id: int,
+ *     source_folder_title: string,
+ *     target_folder_id: int,
+ *     target_folder_title: string,
+ *     fields_count: int,
+ *     files_count: int
+ * }
+ *
+ * @throws InvalidArgumentException When the requested transition is not personal to shared
+ * @throws UnexpectedValueException When a required source encryption key is unavailable
+ * @throws Throwable When the database operation cannot be completed
+ */
+function movePersonalItemToSharedFolderSynchronously(
+    int $itemId,
+    int $targetFolderId,
+    int $userId,
+    string $userPrivateKey
+): array {
+    if ($itemId <= 0 || $targetFolderId <= 0 || $userId <= 0 || $userPrivateKey === '') {
+        throw new InvalidArgumentException('Invalid personal item move parameters.');
+    }
+
+    $transactionStarted = false;
+    try {
+        DB::startTransaction();
+        $transactionStarted = true;
+
+        // Lock the item so no concurrent request can change its folder while keys are prepared.
+        $item = DB::queryFirstRow(
+            'SELECT i.id, i.id_tree, i.label,
+                source_folder.personal_folder AS source_personal_folder,
+                source_folder.title AS source_folder_title
+            FROM ' . prefixTable('items') . ' AS i
+            INNER JOIN ' . prefixTable('nested_tree') . ' AS source_folder ON source_folder.id = i.id_tree
+            WHERE i.id = %i
+            FOR UPDATE',
+            $itemId
+        );
+        if (is_array($item) === false) {
+            throw new InvalidArgumentException('Item not found.');
+        }
+
+        $targetFolder = DB::queryFirstRow(
+            'SELECT id, title, personal_folder
+            FROM ' . prefixTable('nested_tree') . '
+            WHERE id = %i',
+            $targetFolderId
+        );
+        if (is_array($targetFolder) === false) {
+            throw new InvalidArgumentException('Target folder not found.');
+        }
+
+        if (
+            (int) $item['source_personal_folder'] !== 1
+            || (int) $targetFolder['personal_folder'] !== 0
+        ) {
+            throw new InvalidArgumentException('Only personal-to-shared item moves are supported by this operation.');
+        }
+
+        $user = DB::queryFirstRow(
+            'SELECT public_key
+            FROM ' . prefixTable('users') . '
+            WHERE id = %i',
+            $userId
+        );
+        if (is_array($user) === false || empty($user['public_key'])) {
+            throw new UnexpectedValueException(
+                'The item cannot be moved because the user encryption keys are unavailable.'
+            );
+        }
+        $userPublicKey = (string) $user['public_key'];
+
+        /**
+         * Decrypt one caller sharekey while preserving the migration-on-read contract.
+         *
+         * @param array<string, mixed> $sharekeyRow
+         */
+        $decryptSourceKey = static function (
+            array $sharekeyRow,
+            string $sharekeysTable,
+            string $objectType,
+            int $objectId
+        ) use ($userPrivateKey, $userPublicKey): string {
+            if (
+                empty($sharekeyRow['share_key'])
+                || empty($sharekeyRow['increment_id'])
+            ) {
+                error_log(
+                    'TEAMPASS Error - personal-to-shared move: missing ' . $objectType
+                    . ' sharekey for object ' . $objectId
+                );
+                throw new UnexpectedValueException(
+                    'The item cannot be moved because one or more encryption keys are missing or invalid.'
+                );
+            }
+
+            try {
+                $objectKey = decryptUserObjectKeyWithMigration(
+                    (string) $sharekeyRow['share_key'],
+                    $userPrivateKey,
+                    $userPublicKey,
+                    (int) $sharekeyRow['increment_id'],
+                    $sharekeysTable
+                );
+            } catch (Throwable $exception) {
+                error_log(
+                    'TEAMPASS Error - personal-to-shared move: unable to decrypt ' . $objectType
+                    . ' key for object ' . $objectId . ' - ' . $exception->getMessage()
+                );
+                throw new UnexpectedValueException(
+                    'The item cannot be moved because one or more encryption keys are missing or invalid.',
+                    0,
+                    $exception
+                );
+            }
+
+            if ($objectKey === '') {
+                throw new UnexpectedValueException(
+                    'The item cannot be moved because one or more encryption keys are missing or invalid.'
+                );
+            }
+
+            return $objectKey;
+        };
+
+        $itemSharekey = DB::queryFirstRow(
+            'SELECT share_key, increment_id
+            FROM ' . prefixTable('sharekeys_items') . '
+            WHERE user_id = %i AND object_id = %i',
+            $userId,
+            $itemId
+        );
+        $itemObjectKey = $decryptSourceKey(
+            is_array($itemSharekey) ? $itemSharekey : [],
+            'sharekeys_items',
+            'item',
+            $itemId
+        );
+
+        $fieldObjectKeys = [];
+        $fields = DB::query(
+            'SELECT custom_field.id, custom_field.encryption_type, sharekey.share_key, sharekey.increment_id
+            FROM ' . prefixTable('categories_items') . ' AS custom_field
+            LEFT JOIN ' . prefixTable('sharekeys_fields') . ' AS sharekey
+                ON sharekey.object_id = custom_field.id AND sharekey.user_id = %i
+            WHERE custom_field.item_id = %i',
+            $userId,
+            $itemId
+        );
+        foreach ($fields as $field) {
+            // Plain custom fields have no object key to distribute.
+            if ((string) $field['encryption_type'] === 'not_set') {
+                continue;
+            }
+
+            $fieldId = (int) $field['id'];
+            $fieldObjectKeys[] = [
+                'object_id' => $fieldId,
+                'object_key' => $decryptSourceKey(
+                    $field,
+                    'sharekeys_fields',
+                    'custom field',
+                    $fieldId
+                ),
+            ];
+        }
+
+        $fileObjectKeys = [];
+        $files = DB::query(
+            'SELECT attachment.id, sharekey.share_key, sharekey.increment_id
+            FROM ' . prefixTable('files') . ' AS attachment
+            LEFT JOIN ' . prefixTable('sharekeys_files') . ' AS sharekey
+                ON sharekey.object_id = attachment.id AND sharekey.user_id = %i
+            WHERE attachment.id_item = %i',
+            $userId,
+            $itemId
+        );
+        foreach ($files as $file) {
+            $fileId = (int) $file['id'];
+            $fileObjectKeys[] = [
+                'object_id' => $fileId,
+                'object_key' => $decryptSourceKey(
+                    $file,
+                    'sharekeys_files',
+                    'file',
+                    $fileId
+                ),
+            ];
+        }
+
+        // Reuse the canonical recipient selection and sharekey-upsert implementation.
+        storeUsersShareKey(
+            'sharekeys_items',
+            0,
+            $itemId,
+            $itemObjectKey,
+            false,
+            true,
+            [],
+            -1,
+            $userId
+        );
+        foreach ($fieldObjectKeys as $fieldObjectKey) {
+            storeUsersShareKey(
+                'sharekeys_fields',
+                0,
+                (int) $fieldObjectKey['object_id'],
+                (string) $fieldObjectKey['object_key'],
+                false,
+                true,
+                [],
+                -1,
+                $userId
+            );
+        }
+        foreach ($fileObjectKeys as $fileObjectKey) {
+            storeUsersShareKey(
+                'sharekeys_files',
+                0,
+                (int) $fileObjectKey['object_id'],
+                (string) $fileObjectKey['object_key'],
+                false,
+                true,
+                [],
+                -1,
+                $userId
+            );
+        }
+
+        // Publish the item in the shared folder only after every source object key was recovered.
+        DB::update(
+            prefixTable('items'),
+            [
+                'id_tree' => $targetFolderId,
+                'perso' => 0,
+                'updated_at' => time(),
+            ],
+            'id = %i',
+            $itemId
+        );
+
+        DB::commit();
+        $transactionStarted = false;
+
+        return [
+            'item_id' => $itemId,
+            'label' => (string) $item['label'],
+            'source_folder_id' => (int) $item['id_tree'],
+            'source_folder_title' => (string) $item['source_folder_title'],
+            'target_folder_id' => $targetFolderId,
+            'target_folder_title' => (string) $targetFolder['title'],
+            'fields_count' => count($fieldObjectKeys),
+            'files_count' => count($fileObjectKeys),
+        ];
+    } catch (Throwable $exception) {
+        if ($transactionStarted === true) {
+            DB::rollback();
+        }
+        throw $exception;
+    }
+}
+
+/**
+ * Apply the shared post-commit effects of an item move.
+ *
+ * @param array<string, mixed> $settings TeamPass settings
+ */
+function finalizeItemMoveSideEffects(
+    array $settings,
+    int $itemId,
+    string $itemLabel,
+    int $userId,
+    string $userLogin,
+    int $sourceFolderId,
+    string $sourceFolderTitle,
+    int $targetFolderId,
+    string $targetFolderTitle
+): void {
+    logItems(
+        $settings,
+        $itemId,
+        $itemLabel,
+        $userId,
+        'at_modification',
+        $userLogin,
+        'at_moved : ' . $sourceFolderTitle . ' -> ' . $targetFolderTitle
+    );
+
+    updateCacheTable('update_value', $itemId, $userId);
+    adjustFolderItemsCounter($sourceFolderId, -1);
+    adjustFolderItemsCounter($targetFolderId, 1);
+
+    $movePayload = [
+        'item_id' => $itemId,
+        'from_folder_id' => $sourceFolderId,
+        'to_folder_id' => $targetFolderId,
+        'label' => $itemLabel,
+        'moved_by' => $userLogin,
+    ];
+    emitWebSocketEvent('item_moved', 'folder', $sourceFolderId, $movePayload, $userId);
+    emitWebSocketEvent('item_moved', 'folder', $targetFolderId, $movePayload, $userId);
+}
+
+/**
  * Insert or update sharekey for a user
  * Handles duplicate key errors gracefully
  * 

--- a/tests/Unit/Api/PersonalToSharedItemMoveTest.php
+++ b/tests/Unit/Api/PersonalToSharedItemMoveTest.php
@@ -1,0 +1,144 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Regression guards for the shared synchronous personal-to-shared item move path.
+ */
+class PersonalToSharedItemMoveTest extends TestCase
+{
+    private function source(string $relativePath): string
+    {
+        $path = __DIR__ . '/../../..' . $relativePath;
+        self::assertFileExists($path, $relativePath . ' must exist');
+        $source = file_get_contents($path);
+        self::assertIsString($source);
+
+        return $source;
+    }
+
+    private function section(string $source, string $startMarker, string $endMarker): string
+    {
+        $start = strpos($source, $startMarker);
+        self::assertIsInt($start, 'Start marker must exist: ' . $startMarker);
+        $end = strpos($source, $endMarker, $start + strlen($startMarker));
+        self::assertIsInt($end, 'End marker must exist after: ' . $startMarker);
+
+        return substr($source, $start, $end - $start);
+    }
+
+    public function testApiAndWebUseTheSameSynchronousMoveFunction(): void
+    {
+        $apiModel = $this->source('/app/api/Model/ItemModel.php');
+        $webQueries = $this->source('/app/sources/items.queries.php');
+
+        self::assertStringContainsString(
+            'movePersonalItemToSharedFolderSynchronously(',
+            $apiModel
+        );
+        self::assertStringContainsString(
+            'movePersonalItemToSharedFolderSynchronously(',
+            $webQueries
+        );
+        self::assertStringNotContainsString(
+            'orphaned row deleted during personal→public move',
+            $webQueries,
+            'A missing field sharekey must abort the move, never delete the field.'
+        );
+    }
+
+    public function testMoveRecoversAllExistingWebObjectKeyFamiliesBeforePublishing(): void
+    {
+        $functions = $this->source('/app/sources/main.functions.php');
+        $move = $this->section(
+            $functions,
+            'function movePersonalItemToSharedFolderSynchronously(',
+            'function finalizeItemMoveSideEffects('
+        );
+
+        self::assertStringContainsString("'sharekeys_items'", $move);
+        self::assertStringContainsString("'sharekeys_fields'", $move);
+        self::assertStringContainsString("'sharekeys_files'", $move);
+        self::assertStringContainsString('decryptUserObjectKeyWithMigration(', $move);
+        self::assertSame(3, substr_count($move, 'storeUsersShareKey('));
+        self::assertStringNotContainsString("'sharekeys_logs'", $move);
+        self::assertStringNotContainsString("DB::delete(prefixTable('categories_items')", $move);
+    }
+
+    public function testMoveIsLockedTransactionalAndPublishesTheFolderChangeLast(): void
+    {
+        $functions = $this->source('/app/sources/main.functions.php');
+        $move = $this->section(
+            $functions,
+            'function movePersonalItemToSharedFolderSynchronously(',
+            'function finalizeItemMoveSideEffects('
+        );
+
+        $begin = strpos($move, 'DB::startTransaction();');
+        $lock = strpos($move, 'FOR UPDATE');
+        $sharekeys = strpos($move, 'storeUsersShareKey(');
+        $publish = strpos($move, "'id_tree' => \$targetFolderId");
+        $commit = strpos($move, 'DB::commit();');
+        $rollback = strpos($move, 'DB::rollback();');
+
+        self::assertIsInt($begin);
+        self::assertIsInt($lock);
+        self::assertIsInt($sharekeys);
+        self::assertIsInt($publish);
+        self::assertIsInt($commit);
+        self::assertIsInt($rollback);
+        self::assertLessThan($lock, $begin);
+        self::assertLessThan($sharekeys, $lock);
+        self::assertLessThan($publish, $sharekeys);
+        self::assertLessThan($commit, $publish);
+        self::assertGreaterThan($commit, $rollback);
+        self::assertStringNotContainsString('storeTask(', $move);
+    }
+
+    public function testApiAndWebShareTheSamePostCommitMoveEffects(): void
+    {
+        $functions = $this->source('/app/sources/main.functions.php');
+        $apiModel = $this->source('/app/api/Model/ItemModel.php');
+        $webQueries = $this->source('/app/sources/items.queries.php');
+        $effects = $this->section(
+            $functions,
+            'function finalizeItemMoveSideEffects(',
+            'function insertOrUpdateSharekey('
+        );
+
+        self::assertStringContainsString('finalizeItemMoveSideEffects(', $apiModel);
+        self::assertStringContainsString('finalizeItemMoveSideEffects(', $webQueries);
+        self::assertStringContainsString('logItems(', $effects);
+        self::assertStringContainsString("updateCacheTable('update_value'", $effects);
+        self::assertSame(2, substr_count($effects, 'adjustFolderItemsCounter('));
+        self::assertSame(2, substr_count($effects, "emitWebSocketEvent('item_moved'"));
+    }
+
+    public function testApiReturnsAValidationErrorWhenSourceKeysCannotBeRecovered(): void
+    {
+        $apiModel = $this->source('/app/api/Model/ItemModel.php');
+
+        self::assertStringContainsString(
+            'catch (InvalidArgumentException | UnexpectedValueException $exception)',
+            $apiModel
+        );
+        self::assertStringContainsString(
+            "'error_header' => 'HTTP/1.1 422 Unprocessable Entity'",
+            $apiModel
+        );
+    }
+
+    public function testApiRequiresTheMoveToBeSeparateFromOtherUpdates(): void
+    {
+        $apiModel = $this->source('/app/api/Model/ItemModel.php');
+
+        self::assertStringContainsString('$additionalMoveFields = array_diff(', $apiModel);
+        self::assertStringContainsString("['id', 'folder_id']", $apiModel);
+        self::assertStringContainsString(
+            'A personal-to-shared move must be requested separately from other item updates.',
+            $apiModel
+        );
+    }
+}


### PR DESCRIPTION
## Summary

This change adds a shared synchronous implementation for moving an item from a personal folder, including a personal subfolder, to a shared folder.

Both the REST API and the existing Web `move_item` action now use the same cryptographic transition. The item remains personal until its item, encrypted custom-field, and attachment object keys have been recovered and redistributed. The sharekey changes and the final `items.id_tree` / `items.perso` update are committed in one database transaction.

This pull request is intentionally a first building block for item-move consistency. It addresses only the personal-to-shared transition and establishes a common API/Web path that can be reviewed and extended in later pull requests. It has not yet been validated on a real TeamPass instance and must not be considered production-validated at this stage.

## Problem

The Web and API paths previously implemented different behaviours:

- the Web path synchronously redistributed item, field, and file sharekeys before moving the item;
- the API path only changed `items.id_tree` and `items.perso` when the request contained `{id, folder_id}`;
- API consumers with access to the destination folder could therefore receive no item because they had no usable `sharekeys_items` entry;
- encrypted custom fields and attachments were not redistributed by the API move;
- the Web path deleted an encrypted custom-field row when the moving user had no field sharekey.

## Scope

Included:

- one personal item to one shared folder;
- personal root folders and personal subfolders;
- item password object key;
- encrypted custom-field object keys;
- attachment object keys;
- migration-aware source-key decryption;
- transactional sharekey redistribution and item publication;
- common post-commit log, cache, folder-counter, and WebSocket effects;
- API `422 Unprocessable Entity` response when required source keys cannot be recovered;
- API `422 Unprocessable Entity` response when a personal-to-shared move is mixed with other item updates;
- Web failure without deleting encrypted data.

Not included:

- shared-to-personal moves;
- shared-to-shared or personal-to-personal behaviour changes;
- mass moves;
- personal/shared folder moves;
- historical `sharekeys_logs` redistribution;
- Secure Send or OTV policy changes;
- an asynchronous move workflow;
- a change to the existing move authorisation policy.

Historical log sharekeys are intentionally unchanged in this first implementation to preserve the existing Web move scope. Their expected visibility after a personal-to-shared move remains a maintainer decision.

## Implementation

### Shared synchronous transition

`movePersonalItemToSharedFolderSynchronously()` performs the common transition:

1. starts a database transaction;
2. locks the item row with `FOR UPDATE`;
3. verifies that the source folder is personal and the destination is shared;
4. loads the moving user's public key;
5. loads and decrypts the item sharekey with `decryptUserObjectKeyWithMigration()`;
6. loads and decrypts every encrypted custom-field sharekey;
7. loads and decrypts every attachment sharekey;
8. aborts without deleting data if any required source key is missing or invalid;
9. redistributes each object key through the canonical `storeUsersShareKey()` recipient logic;
10. updates `items.id_tree`, sets `items.perso = 0`, and updates the timestamp;
11. commits the transaction.

The item folder update occurs after sharekey preparation and redistribution. Other requests cannot observe the item as shared before the transaction commits.

### API path

`ItemModel::updateItem()` detects a personal-to-shared `folder_id` transition and delegates it to the common function.

The move must be requested separately from password, metadata, TOTP, tag, or custom-field updates. This prevents a validation failure in another update from occurring after the cryptographic move has committed. Missing or invalid source keys also produce a `422 Unprocessable Entity` response instead of publishing an unreadable shared item.

Other folder-transition types keep their existing API behaviour.

### Web path

The personal-to-shared branch of the Web `move_item` action delegates to the same common function.

The previous inline RSA fan-out loops were removed. In particular, the Web path no longer deletes an encrypted custom-field row when its source sharekey is unavailable. The complete move now fails and leaves the item personal.

### Shared post-commit effects

`finalizeItemMoveSideEffects()` is used by both paths to:

- write the `at_moved` item log;
- update the item cache;
- decrement the source-folder item counter;
- increment the destination-folder item counter;
- emit `item_moved` events to source- and destination-folder subscribers.

These effects run after the cryptographic transaction has committed.

## Integrity and failure behaviour

- No item folder change is committed if its item key cannot be recovered.
- No item folder change is committed if an encrypted custom field has no recoverable source key.
- No item folder change is committed if an attachment has no recoverable source key.
- Missing field keys no longer cause field deletion.
- Migration-aware decryption is used for item, field, and file sharekeys.
- A row lock prevents concurrent folder changes while the transition is prepared.
- The operation does not enqueue raw object keys in `background_tasks`.
- Recipient-specific public-key failures retain the existing `storeUsersShareKey()` behaviour: they are logged and isolated rather than aborting every recipient.

## API behaviour

Request example:

```json
{
  "id": 123,
  "folder_id": 456
}
```

Successful response remains compatible with the existing update endpoint:

```json
{
  "error": false,
  "message": "Item updated successfully",
  "item_id": 123
}
```

When a required source key cannot be recovered, the endpoint returns `422 Unprocessable Entity` and the item remains personal.

The endpoint also returns `422 Unprocessable Entity` when `folder_id` is combined with another item update during this specific personal-to-shared transition. Clients must submit the move as a dedicated request.

## Files changed

| File | Purpose |
|---|---|
| `app/sources/main.functions.php` | Shared transactional move and shared post-commit effects |
| `app/sources/items.queries.php` | Web delegation to the common move path |
| `app/api/Model/ItemModel.php` | API transition detection and delegation |
| `tests/Unit/Api/PersonalToSharedItemMoveTest.php` | Static regression coverage for both callers and the transaction contract |
| `PR_PERSONAL_TO_SHARED_ITEM_MOVE.md` | Pull request description and review notes |

No database migration is required.

## Automated regression coverage

`PersonalToSharedItemMoveTest` verifies that:

- the API and Web paths call the same move function;
- the common function covers item, field, and file sharekeys;
- source-key decryption remains migration-aware;
- the transaction begins before sharekey generation;
- the item is published only after sharekey generation;
- commit and rollback guards remain present;
- the move does not enqueue a background task;
- missing field keys cannot reintroduce the previous destructive deletion;
- API and Web use the same log/cache/counter/WebSocket helper;
- the API retains a `422` validation response for unrecoverable source keys;
- the API requires this move to be submitted separately from unrelated item updates.

The repository currently exposes source-level unit tests rather than a database-backed API integration harness for this path.

### Local validation status

- Static move-path checks: passed.
- PHPUnit test file and `phpunit.xml`: present.
- PHPUnit execution: not run in the analysed workspace because no PHP interpreter is available in `PATH`.
- Real-life API/Web validation: **not performed yet**.
- Database-backed validation: not run; the manual plan below requires an isolated TeamPass test instance.
- Production readiness: not established by this pull request alone.

This implementation should therefore be reviewed as a first foundation for this area. Its transaction boundaries, recipient policy, error handling, and behaviour with real user keys still require validation on an isolated but representative TeamPass installation before production use.

## Manual validation plan

This plan has not yet been executed. Use an isolated TeamPass test instance with two normal users, one personal folder, one personal subfolder, and one shared destination folder before considering the change validated.

### Basic item

1. Create a personal item as user A.
2. Move it through the API with only `id` and `folder_id`.
3. Confirm `items.id_tree` points to the shared folder and `items.perso = 0`.
4. Confirm user B can list and decrypt the item.

### Encrypted custom fields and attachments

1. Add encrypted custom fields and attachments to a personal item.
2. Move the item from the personal root to a shared folder.
3. Repeat from a personal subfolder.
4. Confirm user B can decrypt the password, encrypted fields, and attachments.
5. Confirm non-encrypted custom fields remain unchanged.

### Failure behaviour

1. In an isolated database, remove the moving user's field or file sharekey.
2. Attempt the move.
3. Confirm the API returns `422`, or the Web action reports an error.
4. Confirm the item remains in its personal folder with `perso = 1`.
5. Confirm the custom-field and file rows still exist.
6. Confirm no partial public sharekeys were committed.

### Side effects

1. Confirm the move log contains the source and destination titles.
2. Confirm source and destination counters are updated once.
3. Confirm source and destination folder subscribers receive `item_moved`.
4. Confirm the cache row points to the shared destination.

## Review points

The maintainer should explicitly confirm:

1. whether historical log sharekeys must remain private or be redistributed;
2. whether the existing recipient selection in `storeUsersShareKey()` is the intended shared-item policy;
3. whether API source/destination move rights should remain unchanged in this PR;
4. whether large-installation benchmarks require a future staged asynchronous workflow;
5. whether the real-life validation plan above must be completed before merge or during a dedicated maintainer test phase;
6. which follow-up transitions should reuse this first common building block.
