### PR TITLE
Fix 5331 : notification center overflow

### DIFF
--- a/app/core/notification-center.js.php
+++ b/app/core/notification-center.js.php
@@ -37,6 +37,20 @@ $lang = new Language($session->get('user-language') ?? 'english');
 ?>
 <style>
     #tp-notification-menu { width: 360px; max-width: 92vw; }
+    /* Keep the header and footer visible while long notification lists scroll. */
+    #tp-notification-menu #tp-notification-list {
+        max-height: min(60vh, 30rem);
+        overflow-x: hidden;
+        overflow-y: auto;
+        overscroll-behavior: contain;
+        scrollbar-width: thin;
+    }
+    #tp-notification-menu #tp-notification-list::-webkit-scrollbar { width: 6px; }
+    #tp-notification-menu #tp-notification-list::-webkit-scrollbar-thumb {
+        background-color: rgba(108, 117, 125, 0.55);
+        border-radius: 3px;
+    }
+    #tp-notification-menu #tp-notification-list::-webkit-scrollbar-track { background: transparent; }
     #tp-notification-menu .tp-notification-row { white-space: normal; }
     #tp-notification-menu .tp-notification-when { white-space: nowrap; flex: 0 0 auto; }
     #tp-notification-menu .tp-notification-detail { word-break: break-word; }


### PR DESCRIPTION
## Related issue

Fixes #5331.

## Summary

The in-app notification dropdown could grow beyond the browser viewport when a user accumulated many notifications. Because the **Mark all as read** action is rendered after the notification rows, the action could be pushed below the visible area and become inaccessible at normal zoom levels.

This change constrains the notification list to a viewport-aware maximum height and makes only that list vertically scrollable. The notification center header and the **Mark all as read** footer remain outside the scrollable area and therefore stay visible.

## Root cause

The notification dropdown defined a fixed width but did not constrain its height. The backend can return up to 30 notification rows, and each row was rendered directly before the footer. With enough rows, the dropdown exceeded the viewport instead of creating an internal scrolling area.

The mark-as-read endpoint and unread counter were already functioning correctly; the issue was limited to the dropdown layout.

## Changes

- Limit the notification list height to the smaller of `60vh` and `30rem`.
- Enable vertical scrolling only when the list exceeds that height.
- Prevent horizontal overflow inside the notification list.
- Use a thin scrollbar, with a narrow WebKit scrollbar for Chromium- and Safari-based browsers.
- Contain scroll chaining so that reaching the end of the notification list does not immediately scroll the page behind the dropdown.
- Keep the notification header and **Mark all as read** action permanently outside the scrollable list.

## User-visible behavior

- Short notification lists are unchanged and do not display a scrollbar.
- Long notification lists display a small vertical scrollbar.
- Users can scroll through every loaded notification.
- **Mark all as read** remains visible and accessible regardless of the number of loaded notifications.
- No notification data, read state, or backend limit is changed.

## Scope and compatibility

- Frontend-only change in `app/core/notification-center.js.php`.
- No database migration.
- No API or server-side behavior change.
- No new dependency.
- No new or modified language string.
- Compatible with the existing AdminLTE 3 / Bootstrap notification dropdown.

## Validation

- Confirmed that the header and footer remain outside `#tp-notification-list`.
- Confirmed that overflow is applied only to `#tp-notification-list`.
- Confirmed that the existing **Mark all as read** handler and backend endpoint are unchanged.
- Confirmed that the change does not affect the server-side 30-row display limit or 50-row retention limit.

## Manual test plan

1. Enable the in-app notification center.
2. Open the notification dropdown with no notifications and confirm that no scrollbar is shown.
3. Create one notification and confirm that the dropdown remains unchanged.
4. Create enough item encryption completion notifications to exceed the maximum list height.
5. Open the dropdown at 100% browser zoom.
6. Confirm that a thin vertical scrollbar appears inside the notification list.
7. Scroll to the oldest loaded notification and confirm that all rows can be read.
8. Confirm that the notification header and **Mark all as read** remain visible while scrolling.
9. Select **Mark all as read** and confirm that the unread badge is cleared and unread rows lose their emphasized style.
10. Repeat on a small viewport and with keyboard navigation.

## Risk assessment

Low. The change is limited to CSS rules scoped by the existing notification center IDs. It does not modify notification persistence, rendering data, event handling, authentication, or mark-as-read behavior.
