### PR TITLE
Use the TeamPass confirmation modal when resetting email templates

### DIFF
--- a/app/pages/emails_templates.js.php
+++ b/app/pages/emails_templates.js.php
@@ -525,23 +525,27 @@ $groupLabels = [
                 return;
             }
 
-            if (window.confirm('<?php echo $lang->get('emails_templates_reset_confirm'); ?>') === false) {
-                return;
-            }
-
-            emailsTemplatesPost(
-                'reset_template', {
-                    template: emailsTemplatesCurrent,
-                    language: $('#emails-templates-language').val()
-                },
+            launchConfirmDialog(
+                <?php echo json_encode($lang->get('emails_templates_reset'), JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP); ?>,
+                <?php echo json_encode($lang->get('emails_templates_reset_confirm'), JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP); ?>,
                 function() {
-                    toastr.remove();
-                    toastr.success('<?php echo $lang->get('done'); ?>', '', {
-                        timeOut: 1000
-                    });
-                    emailsTemplatesLoadList($('#emails-templates-language').val());
-                    emailsTemplatesLoad(emailsTemplatesCurrent);
-                }
+                    emailsTemplatesPost(
+                        'reset_template', {
+                            template: emailsTemplatesCurrent,
+                            language: $('#emails-templates-language').val()
+                        },
+                        function() {
+                            toastr.remove();
+                            toastr.success('<?php echo $lang->get('done'); ?>', '', {
+                                timeOut: 1000
+                            });
+                            emailsTemplatesLoadList($('#emails-templates-language').val());
+                            emailsTemplatesLoad(emailsTemplatesCurrent);
+                        }
+                    );
+                },
+                <?php echo json_encode($lang->get('emails_templates_reset'), JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP); ?>,
+                <?php echo json_encode($lang->get('cancel'), JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP); ?>
             );
         });
     });

--- a/tests/Unit/EmailsTemplatesCatalogTest.php
+++ b/tests/Unit/EmailsTemplatesCatalogTest.php
@@ -279,6 +279,26 @@ class EmailsTemplatesCatalogTest extends TestCase
     }
 
     /**
+     * Destructive actions must use the shared TeamPass confirmation modal rather than
+     * the browser-native dialog, which does not follow the application theme.
+     */
+    public function testResetUsesTheTeamPassConfirmationDialog(): void
+    {
+        $source = (string) file_get_contents(dirname(__DIR__, 2) . '/app/pages/emails_templates.js.php');
+
+        $this->assertStringContainsString(
+            'launchConfirmDialog(',
+            $source,
+            'Reset must use the shared TeamPass confirmation modal'
+        );
+        $this->assertStringNotContainsString(
+            'window.confirm(',
+            $source,
+            'The browser-native reset confirmation dialog must not be restored'
+        );
+    }
+
+    /**
      * The editor must not offer formatting the email will never carry.
      *
      * sendMailToUser() runs xss_clean() on the body at send time, which drops every style


### PR DESCRIPTION
## Summary

This change replaces the browser-native confirmation dialog used by the email template reset action with TeamPass's shared confirmation modal.

The reset behavior and backend request remain unchanged. The customization is removed only after the administrator confirms the action through the themed TeamPass dialog.

## Motivation

The email template management page used `window.confirm()` before restoring a template to its shipped value. That browser-owned dialog did not follow the visual language or interaction pattern used by TeamPass.

TeamPass already provides `launchConfirmDialog()` for this purpose. Reusing it gives the reset action:

- the standard TeamPass modal layout;
- the shared TeamPass confirmation presentation;
- explicit, localized action and cancellation buttons;
- consistent modal behavior with other destructive actions in the application.

## Implementation

The reset click handler in `app/pages/emails_templates.js.php` now calls `launchConfirmDialog()` with:

- `emails_templates_reset` as the modal title;
- `emails_templates_reset_confirm` as the confirmation message;
- `emails_templates_reset` as the action-button label;
- the existing `cancel` translation as the cancellation label.

The existing `reset_template` request is executed inside the confirmation callback. Its payload, success notification, template-list refresh, and editor reload are unchanged.

The localized strings are emitted with `json_encode()` and the `JSON_HEX_*` flags so they remain valid and safe JavaScript strings regardless of translated punctuation or HTML-significant characters.

## Regression coverage

`EmailsTemplatesCatalogTest` now verifies that:

- the email templates page calls `launchConfirmDialog()`;
- `window.confirm()` is absent from the page script.

This prevents the browser-native reset dialog from being reintroduced accidentally.

## Files changed

- `app/pages/emails_templates.js.php`
- `tests/Unit/EmailsTemplatesCatalogTest.php`

## Validation

| Check | Result |
|---|---|
| PHP syntax, `app/pages/emails_templates.js.php` | Passed |
| PHP syntax, `tests/Unit/EmailsTemplatesCatalogTest.php` | Passed |
| `EmailsTemplatesCatalogTest` | `18 tests, 289 assertions` passed |
| PHPStan level 4 on `app/pages/emails_templates.js.php` | Passed with no errors |
| Native `window.confirm()` absence check | Passed |
| Trailing-whitespace and conflict-marker check | Passed |

The validation used PHP 8.2.33. The targeted PHPStan run used the repository configuration at level 4 while omitting only the instance-specific `app/config/settings.php` bootstrap file, which is not present in this source checkout.

## Backward compatibility

- No backend endpoint or request payload changed.
- No email template content or rendering behavior changed.
- No translation key was added or modified.
- No database migration or setting is required.
- The preview and Summernote dialogs are intentionally unchanged.

## Manual verification

1. Open **Administration > Email templates**.
2. Select a customized template and language.
3. Click **Reset to default**.
4. Confirm that the TeamPass warning modal appears instead of the browser-native dialog.
5. Cancel and verify that the customization remains unchanged.
6. Open the dialog again, confirm the reset, and verify that the shipped template is restored.
