### PR TITLE
Preserve API password history and expose item revision timestamps

### DIFF
--- a/.claude/docs/api-reference.md
+++ b/.claude/docs/api-reference.md
@@ -151,9 +151,14 @@ Get item(s) by ID or label.
 
 **Pagination:** label/description searches return `X-Total-Count` (total matches in accessible folders, before per-item sharekey filtering).
 
-**Response:** array of item objects `{ id, revision, label, description, login, email, url, password, path, folder_id, folder_label, has_otp, favicon_url, tags, fields }`.
+**Response:** array of item objects `{ id, revision, revision_changed_at, label, description, login, email, url, password, path, folder_id, folder_label, has_otp, favicon_url, tags, fields }`.
 
 **`revision`** — monotonic item revision, allocated from the `teampass_items_revisions` journal on every content change (item row, custom fields, tags, attachments, OTP, move, delete, restore). `0` = never changed since the column was introduced. Also returned by `item/inFolders`, `item/findByUrl`, `item/create` and `item/update`. See `architecture-item-revisions.md`.
+
+**`revision_changed_at`** — Unix UTC timestamp in seconds paired with `revision`. It changes only
+when a functional content revision is allocated, never on a read or ciphertext-only rewrite.
+`null` means the exact date is not known, notably for revision 0 or when an upgrade could not find
+the current revision in the prunable journal. Returned everywhere `revision` is returned.
 
 **Custom fields:** `fields` is an array of `{ id, title, type, masked, value }` for the item's folder-associated categories. Encrypted values are decrypted via `decryptUserObjectKeyWithMigration()` on `sharekeys_fields` (+ `base64_decode`); empty when no sharekey is available yet. Only present when `item_extra_fields` is enabled. Also returned by `item/inFolders`.
 
@@ -181,7 +186,7 @@ Find items by URL match.
 
 **Params:** `url` (string). The `%` and `_` characters are escaped before the LIKE query.
 
-**Response:** array of `{ id, label, login, url, folder_id, has_otp, favicon_url }`. Empty result → `200` + `[]`.
+**Response:** array of `{ id, revision, revision_changed_at, label, login, url, folder_id, has_otp, favicon_url }`. Empty result → `200` + `[]`.
 
 **Permissions:** `allowed_to_read`.
 
@@ -210,7 +215,7 @@ Delta feed for offline clients (mobile vault). Answers "what must I apply since 
 
 **Params:** `since` (int, **required**, exclusive; `0` on a first sync), `limit` (default 200, max 1000).
 
-**Response:** `{ cursor, has_more, full_sync_required, changed[], removed[] }`. `changed` carries full item payloads (same shape and same code path as `item/get`); `removed` is `{ id, revision, reason }` with `reason` in `deleted` | `purged` | `out_of_scope`.
+**Response:** `{ cursor, has_more, full_sync_required, changed[], removed[] }`. `changed` carries full item payloads (same shape and same code path as `item/get`); `removed` is `{ id, revision, revision_changed_at, reason }` with `reason` in `deleted` | `purged` | `out_of_scope`. The revision/date pair comes from the winning journal row after deduplication.
 
 **Cursor-based, not offset-based** — a change feed has no stable total, so no `X-Total-Count`. Store `cursor`, resend it as `since`, repeat while `has_more`.
 
@@ -244,7 +249,7 @@ Create a new item.
 
 **Custom fields:** `fields` = array of `{ id, value }` (field id + value). Encrypt-before-INSERT for encrypted categories; creator sharekey created synchronously, other users via the `new_item` background task. Only fields tied to the folder are stored; empty values ignored. Requires `item_extra_fields`.
 
-**Response 201:** `{ error: false, message, newId }` + `Location: /api/v1/item/get?id=<newId>` (path-absolute reference). Validation failures → `422`; missing fields → `400`; folder not allowed / read-only → `403`.
+**Response 201:** `{ error: false, message, newId, revision, revision_changed_at }` + `Location: /api/v1/item/get?id=<newId>` (path-absolute reference). Validation failures → `422`; missing fields → `400`; folder not allowed / read-only → `403`.
 
 **Permissions:** `allowed_to_create`. Blocked with 403 if folder is read-only for user.
 
@@ -257,6 +262,12 @@ Update an existing item. **Only PUT is accepted** — POST returns 405.
 **Body:** `id` (required), at least one of: `label`, `password`, `description`, `login`, `email`, `url`, `tags`, `anyone_can_modify`, `icon`, `folder_id`, `totp`, `fields`.
 
 **Optimistic concurrency — `revision` (optional).** The revision the client's edit was based on. When it differs from `items.revision`, the update is rejected with `409` and **nothing is written**; omitting it keeps last-writer-wins, so existing clients are unaffected. It is a **precondition, not an updatable field**: it is absent from the `$updateableFields` list in `ItemController::updateAction()`, so `{id, revision}` alone still answers `400 'At least one supported field to update must be provided.'`, and it never triggers the personal→shared move conflict guard.
+
+**Password history.** When a non-empty `password` is supplied, the server decrypts the current
+value before any mutation and compares it with `hash_equals()`. An unchanged password is a password
+no-op: by itself it causes no ciphertext rewrite, sharekey fan-out, password-history row or revision. A real change stores the
+previous value in `log_items.old_value`, encrypted with the application master key and tagged
+`at_pw`, exactly like the web UI. Failure to recover or prepare the old value aborts before mutation.
 
 **Custom fields:** `fields` = array of `{ id, value }`. Created if absent, updated only when the value changed (current value decrypted for comparison); encrypted fields re-encrypted and sharekeys refreshed synchronously for all eligible users (consistent with the password path). Empty values ignored. Requires `item_extra_fields`.
 

--- a/.claude/docs/api-reference.md
+++ b/.claude/docs/api-reference.md
@@ -247,9 +247,18 @@ Create a new item.
 
 **Body:** `label`, `password`, `folder_id`, optional `description`, `login`, `email`, `url`, `tags`, `totp`, `fields`.
 
+**Optional idempotency:** `Idempotency-Key: <opaque-key>` (1–128 visible ASCII characters,
+without spaces). Its identity is scoped to the authenticated user and `item.create`. The first
+accepted request returns the normal `201`; an identical replay within 90 days returns the exact
+stored result and `Idempotency-Replayed: true` without repeating any write or side effect. Reusing
+the key with a different functional payload returns `409`. A concurrent request still holding the
+key's processing lease also returns `409` with `Retry-After`. The fingerprint covers every
+functional create field, including credential, TOTP and custom-field values, but is a
+server-secret HMAC: neither those values, the request body nor the raw key is persisted.
+
 **Custom fields:** `fields` = array of `{ id, value }` (field id + value). Encrypt-before-INSERT for encrypted categories; creator sharekey created synchronously, other users via the `new_item` background task. Only fields tied to the folder are stored; empty values ignored. Requires `item_extra_fields`.
 
-**Response 201:** `{ error: false, message, newId, revision, revision_changed_at }` + `Location: /api/v1/item/get?id=<newId>` (path-absolute reference). Validation failures → `422`; missing fields → `400`; folder not allowed / read-only → `403`.
+**Response 201:** `{ error: false, message, newId, revision, revision_changed_at }` + `Location: /api/v1/item/get?id=<newId>` (path-absolute reference). An idempotent replay preserves both. Validation failures → `422`; missing fields or invalid idempotency key → `400`; folder not allowed / read-only → `403`.
 
 **Permissions:** `allowed_to_create`. Blocked with 403 if folder is read-only for user.
 
@@ -302,7 +311,20 @@ The password guard compares against the **decrypted** current value, so resendin
 
 Soft-delete an item.
 
-**Params:** `id` (int).
+**Params:** `id` (int), optional `revision` (unsigned 32-bit integer). When supplied, `revision`
+is an optimistic-concurrency precondition checked against the locked item row immediately before
+the mutation. A mismatch returns `409` with no delete, audit, revision, cache change or WebSocket
+event. Omitting it preserves the historical last-writer-wins behavior.
+
+**Optional idempotency:** `Idempotency-Key` follows the same syntax and 90-day replay window as
+create, scoped to the authenticated user and `item.delete`. Its fingerprint contains the item id
+and the expected revision (including omission). A replay returns the original successful result
+with `Idempotency-Replayed: true`; it never deletes again, so a later restoration is not undone.
+The same key with another item or revision returns `409`; an in-progress request returns `409` and
+`Retry-After`.
+
+**Response 200:** `{ error: false, message, item_id, revision, revision_changed_at }`. The
+revision/date pair is the deletion revision later exposed by `GET /item/changes`.
 
 **LAPR:** `409` while the item is still referenced by a non-deleted managed account or enrolled endpoint — remove the managed account or reconfigure the endpoint first. The relationship has no FK, so deleting the item would orphan it and break rotation or endpoint authentication. Inactive when the LAPR module is disabled.
 
@@ -448,7 +470,7 @@ The key is `extension_url` (value = `cpassman_url`) — the doc previously named
 | 403 | Permission denied (folder read-only, admin required, CRUD rights missing) |
 | 404 | Resource not found / unknown route |
 | 405 | HTTP method not supported for this endpoint (`Allow:` header lists supported methods) |
-| 409 | The supplied `revision` no longer matches the item (optimistic concurrency on `item/update`), the resource changed while the request was being processed (concurrent personal→shared item move), or the operation conflicts with a LAPR relationship (managed login/password update, move to a personal folder, delete of a linked item) |
+| 409 | The supplied `revision` no longer matches the item (`item/update` or `item/delete`), an idempotency key was reused with another request or is still processing, the resource changed during a concurrent personal→shared move, or the operation conflicts with a LAPR relationship |
 | 422 | Validation failed (password rules, invalid complexity/access_rights, personal→shared move combined with another update or with unrecoverable keys) |
 | 429 | Rate limit exceeded (`api_rate_limit_per_minute`) — `Retry-After` header gives the wait in seconds |
 | 500 | Internal server error (details logged server-side, not returned to client) |

--- a/.claude/docs/architecture-api-idempotency.md
+++ b/.claude/docs/architecture-api-idempotency.md
@@ -1,0 +1,143 @@
+# API Item Mutation Idempotency
+
+> Target release: 3.2.2
+
+TeamPass accepts an optional `Idempotency-Key` on `POST /item/create` and
+`DELETE /item/delete`. It is intended for offline clients that may lose an HTTP response and must
+retry without creating a second item or deleting a restored item again.
+
+## Public contract
+
+The header is an opaque value containing 1–128 visible ASCII characters (`0x21`–`0x7e`), without
+spaces. A UUID is recommended but not required. Empty, non-ASCII, control-character and oversized
+values return `400`.
+
+An identity is the tuple `(authenticated user, operation, HMAC(key))`. Create and delete are
+separate scopes, and the same raw key used by two users never collides.
+
+For a valid key:
+
+| State | Result |
+|---|---|
+| First request | Normal mutation: `201` for create, `200` for delete |
+| Completed, same fingerprint | Stored status/body, plus `Idempotency-Replayed: true` |
+| Same identity, different fingerprint | `409 Conflict`, no write |
+| Another request owns the active processing lease | `409 Conflict` plus `Retry-After` |
+| Expired processing lease | One request atomically takes ownership and resumes |
+
+Without the header, no idempotency record is created and the legacy API behavior is retained.
+
+Create fingerprints include the folder, label, login, password, email, URL, description, tags,
+TOTP secret and parameters, custom fields, icon and `anyone_can_modify`. Delete fingerprints
+include the item id and the optional expected revision. Associative keys are sorted recursively;
+list order remains significant.
+
+The fingerprint and key hash are HMAC-SHA-256 values derived from the TeamPass instance secret
+with a domain-separated subkey. The table never stores or logs the raw key, JSON body, password,
+TOTP secret or custom-field values. Stored response bodies contain only replay-safe identifiers,
+revision metadata and public success messages.
+
+## Persistence
+
+`teampass_api_idempotency` contains:
+
+- identity: `user_id`, `operation`, `key_hash` with a composite unique key;
+- intent: `request_fingerprint`;
+- ownership: `status`, `owner_token_hash`, `locked_until`;
+- replay metadata: `resource_id`, `http_status`, `response_body`;
+- lifecycle: `created_at`, `updated_at`, `expires_at`.
+
+`teampass_items.api_idempotency_id` is a nullable unique link used only by keyed creates. It makes
+a committed item discoverable from a stale reservation even if the PHP process died before it
+could return the response. Historical and non-keyed items keep `NULL`.
+
+## Transaction and crash behavior
+
+Reservation uses a short, persistent five-minute processing lease. Syntax, global rights, basic
+payload and folder rights are checked before create reservation. Delete rights are checked before
+its reservation in the current controller flow. Model-level validation may still fail after
+reservation; a failed or rolled-back request removes only the reservation owned by that request,
+so a corrected retry is not blocked.
+
+External favicon/DNS resolution is completed before the create transaction. The functional SQL
+writes then share one transaction with idempotency completion:
+
+- item row and the durable create link;
+- item/sharekey/custom-field/tag/TOTP writes;
+- audit and revision writes;
+- cache, health and background-task rows;
+- the queued WebSocket event;
+- replay status and response.
+
+Delete similarly locks the item row, evaluates the optional revision and LAPR guard, applies the
+soft delete and its SQL side effects, then completes the replay record before commit.
+
+This ordering covers the important failure windows:
+
+- crash before mutation: the transaction has no functional write; the lease can later be taken;
+- crash during mutation: InnoDB rolls back both functional writes and completion;
+- commit followed by a lost HTTP response: the completed response is replayed;
+- stale create row with a committed linked item: recovery reconstructs and finalizes the safe
+  create response without running side effects;
+- concurrent duplicate: the unique identity gives one owner; contenders receive processing or
+  replay state.
+
+The queued WebSocket event is a database row and therefore follows the transaction. Actual
+delivery occurs later and is naturally outside it. External UDP syslog emission is deliberately
+deferred until after commit; a replay never emits it again. There is therefore a narrow at-most-once
+window where a process crash immediately after commit can omit that external datagram. The durable
+TeamPass audit row remains in the SQL transaction.
+
+TeamPass's audit/revision helpers remain best-effort for historical callers. These two
+transactional API paths enable their strict mode and additionally verify that a new revision/date
+pair was persisted; a failure therefore rolls back create/delete instead of completing an
+idempotency record with a missing audit or tombstone.
+
+A completed delete is replayed, never executed again. If the item is restored later, retrying the
+old key cannot delete the restored state. If the item is eventually hard-purged or the caller no
+longer passes the controller's current access checks, the endpoint may return `404`/`403` before
+reaching its completed record; it still never repeats the mutation. Normal replay is guaranteed
+while the item remains addressable and the record remains in its replay window.
+
+## Cleanup
+
+Completed records are kept for 90 days, matching the default offline synchronization window. The
+existing orphan-maintenance task clears expired `items.api_idempotency_id` links and deletes the
+corresponding records. A processing record is removed only when both its replay window and lease
+have expired, so maintenance never deletes an active request.
+
+After cleanup, reusing an old key is a new operation. Clients must therefore keep retryable
+offline intents within the documented 90-day window, just as they must perform a full sync after
+falling outside the revision window.
+
+## Examples
+
+First creation:
+
+```bash
+curl -i -X POST "https://teampass.example/api/index.php/item/create" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -H "Idempotency-Key: 550e8400-e29b-41d4-a716-446655440000" \
+  -d '{"folder_id":3,"label":"Router","password":"secret","login":"admin","email":"","url":"","tags":"","anyone_can_modify":0}'
+```
+
+Repeating the same command returns the original `201`, `Location` and body, with:
+
+```text
+Idempotency-Replayed: true
+```
+
+Changing `label`, `password` or any other functional field while keeping the key returns `409`.
+
+Conditional, idempotent deletion:
+
+```bash
+curl -i -X DELETE \
+  "https://teampass.example/api/index.php/item/delete?id=123&revision=456" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Idempotency-Key: 8fe52f47-6f72-4a1a-b0d8-68a01c884d41"
+```
+
+A stale `revision` returns `409` before the delete or any of its side effects. Omitting `revision`
+keeps the historical last-writer-wins behavior.

--- a/.claude/docs/architecture-item-revisions.md
+++ b/.claude/docs/architecture-item-revisions.md
@@ -1,6 +1,6 @@
 # Item Revisions & Offline Synchronization
 
-> Last updated: 2026-08-19 — branch `feat/item-revision-id`, target release 3.2.2
+> Last updated: 2026-08-24 — target release 3.2.2
 > Design study: `workReadmeFiles/item-revision-id-study.md`
 
 Gives every item a **monotonic revision ID** so an offline client (the mobile vault) can tell
@@ -22,7 +22,8 @@ too coarse. That workaround can now be replaced by a revision check.
 ## Data model
 
 ```sql
-teampass_items.revision  INT UNSIGNED NOT NULL DEFAULT 0   -- latest journal revision
+teampass_items.revision             INT UNSIGNED NOT NULL DEFAULT 0
+teampass_items.revision_changed_at  BIGINT UNSIGNED NULL  -- timestamp paired with revision
 
 teampass_items_revisions:
   revision           INT UNSIGNED AUTO_INCREMENT PRIMARY KEY  -- THE global sequence
@@ -38,9 +39,10 @@ teampass_items_revisions:
 (`revA != revB`) and "what changed since X?" (`revision > cursor`). A per-item counter cannot do
 the second.
 
-**No backfill.** `revision = 0` means "never changed since tracking was installed", which is
-consistent for every client — they only ever compare an item against *their own* cached copy. Same
-precedent as the `hibp_*` columns, where the default *is* the migration.
+**Revision 0 is not backfilled.** It means "never changed since tracking was installed" and its
+`revision_changed_at` is `NULL`. During upgrade, a positive revision timestamp is backfilled only
+when the exact `(item_id, revision)` row is still present in the journal. If pruning already removed
+that row, the date remains `NULL` rather than being guessed from the unreliable `items.updated_at`.
 
 **The journal is not a history.** It records *that* a change happened and in which folder, never
 *what* the value was. Item history stays `teampass_log_items` (+ `old_value` for passwords).
@@ -68,10 +70,12 @@ would make every offline client re-download an item nobody touched.
 (`main.queries.php:3375`) and the custom-field re-encryption (`fields.queries.php`, `edit_field` /
 `dataIsEncryptedInDB`) change the stored bytes but not the plaintext the client caches.
 
-**Per-request memo.** `update_item` calls `logItems()` once per changed attribute (~15× per save);
+`bumpItemRevision()` computes one `changedAt = time()` value and stores it in both the journal row
+and `items.revision_changed_at` alongside `items.revision`. **Per-request memo.** `update_item` calls
+`logItems()` once per changed attribute (~15× per save);
 the memo collapses them into one revision. A later call in the same request **rewrites the stored
 row in place** when it knows more — a deletion, or the source folder of a move
-(`itemRevisionShouldUpgradeEntry()`). `resetItemRevisionMemo()` is called per subtask by
+(`itemRevisionShouldUpgradeEntry()`) — it never changes the timestamp. `resetItemRevisionMemo()` is called per subtask by
 `background_tasks___worker.php`, which is long-lived.
 
 **Rule: a new item write path that does not go through `logItems()` must bump explicitly.** The
@@ -87,9 +91,14 @@ five that exist today:
 
 ## API surface
 
-- `revision` returned by `item/get`, `item/inFolders`, `item/findByUrl`, `item/create`, `item/update`
+- `revision` and `revision_changed_at` returned by `item/get`, `item/inFolders`,
+  `item/findByUrl`, `item/create`, `item/update`
 - `GET /api/v1/item/changes?since=&limit=` — the delta feed (see `api-reference.md`)
 - `PUT /api/v1/item/update` accepts an optional `revision` precondition → `409` on mismatch
+
+`revision_changed_at` is a Unix UTC timestamp in seconds, or `NULL` when no reliable date exists.
+The delta feed takes the pair from the winning journal row after deduplication; tombstones cannot
+read from `items` because a purged item no longer has a row.
 
 ## The sync window setting
 

--- a/.claude/docs/architecture-item-revisions.md
+++ b/.claude/docs/architecture-item-revisions.md
@@ -1,6 +1,6 @@
 # Item Revisions & Offline Synchronization
 
-> Last updated: 2026-08-24 — target release 3.2.2
+> Last updated: 2026-08-25 — target release 3.2.2
 > Design study: `workReadmeFiles/item-revision-id-study.md`
 
 Gives every item a **monotonic revision ID** so an offline client (the mobile vault) can tell
@@ -92,9 +92,17 @@ five that exist today:
 ## API surface
 
 - `revision` and `revision_changed_at` returned by `item/get`, `item/inFolders`,
-  `item/findByUrl`, `item/create`, `item/update`
+  `item/findByUrl`, `item/create`, `item/update`, `item/delete`
 - `GET /api/v1/item/changes?since=&limit=` — the delta feed (see `api-reference.md`)
 - `PUT /api/v1/item/update` accepts an optional `revision` precondition → `409` on mismatch
+- `DELETE /api/v1/item/delete` accepts the same optional precondition. The row is locked and the
+  comparison runs immediately before soft deletion; a mismatch produces no audit, revision,
+  cache update or WebSocket event. A successful response carries the exact deletion
+  `revision`/`revision_changed_at` pair that the next delta scan uses for its tombstone.
+
+`POST /item/create` and `DELETE /item/delete` also accept an optional persistent idempotency key.
+The completion record is committed in the functional SQL transaction, so replay never allocates
+another journal row. See `architecture-api-idempotency.md`.
 
 `revision_changed_at` is a Unix UTC timestamp in seconds, or `NULL` when no reliable date exists.
 The delta feed takes the pair from the winning journal row after deduplication; tombstones cannot

--- a/app/api/Controller/Api/ItemController.php
+++ b/app/api/Controller/Api/ItemController.php
@@ -644,7 +644,8 @@ class ItemController extends BaseController
                 } else {
                     // Query items with the specific URL
                     $rows = DB::query(
-                        "SELECT i.id, i.label, i.login, i.url, i.id_tree, i.favicon_url, i.revision,
+                        "SELECT i.id, i.label, i.login, i.url, i.id_tree, i.favicon_url,
+                                i.revision, i.revision_changed_at,
                                 CASE WHEN o.enabled = 1 THEN 1 ELSE 0 END AS has_otp
                         FROM " . prefixTable('items') . " AS i
                         LEFT JOIN " . prefixTable('items_otp') . " AS o ON (o.item_id = i.id)
@@ -679,6 +680,9 @@ class ItemController extends BaseController
                         $ret[] = [
                             'id' => (int) $row['id'],
                             'revision' => (int) $row['revision'],
+                            'revision_changed_at' => $row['revision_changed_at'] === null
+                                ? null
+                                : (int) $row['revision_changed_at'],
                             'label' => $row['label'],
                             'login' => $row['login'],
                             'url' => $row['url'],

--- a/app/api/Controller/Api/ItemController.php
+++ b/app/api/Controller/Api/ItemController.php
@@ -94,6 +94,82 @@ class ItemController extends BaseController
 
 
     /**
+     * Read and validate the optional Idempotency-Key request header.
+     *
+     * @param symfonyRequest $request Current request
+     * @return string|null Validated key, null when the header is absent
+     */
+    private function getIdempotencyKey(symfonyRequest $request): ?string
+    {
+        if ($request->headers->has('Idempotency-Key') === false) {
+            return null;
+        }
+
+        return ApiIdempotencyModel::validateKey((string) $request->headers->get('Idempotency-Key', ''));
+    }
+
+
+    /**
+     * Build the complete functional create intent used for request fingerprinting.
+     *
+     * @param array<string, mixed> $params Normalized item parameters
+     * @return array<string, mixed>
+     */
+    private function createIdempotencyIntent(array $params): array
+    {
+        return [
+            'folder_id' => (int) $params['folder_id'],
+            'label' => (string) $params['label'],
+            'login' => (string) $params['login'],
+            'password' => (string) $params['password'],
+            'email' => (string) $params['email'],
+            'url' => (string) $params['url'],
+            'description' => (string) $params['description'],
+            'tags' => (string) $params['tags'],
+            'totp' => (string) $params['totp'],
+            'totp_algorithm' => (string) $params['totp_algorithm'],
+            'totp_digits' => (int) $params['totp_digits'],
+            'totp_period' => (int) $params['totp_period'],
+            'fields' => $params['fields'],
+            'icon' => (string) $params['icon'],
+            'anyone_can_modify' => (int) $params['anyone_can_modify'],
+        ];
+    }
+
+
+    /**
+     * Parse the optional unsigned 32-bit item revision query parameter.
+     *
+     * @param array<string, mixed> $params Request parameters
+     * @return int|null Parsed revision, null when omitted
+     */
+    private function parseOptionalRevision(array $params): ?int
+    {
+        if (array_key_exists('revision', $params) === false) {
+            return null;
+        }
+
+        $rawRevision = $params['revision'];
+        if (is_int($rawRevision)) {
+            $revision = $rawRevision;
+        } elseif (is_string($rawRevision) && preg_match('/^(0|[1-9][0-9]*)$/D', $rawRevision) === 1) {
+            if (strlen($rawRevision) > 10) {
+                throw new InvalidArgumentException('Revision must be an unsigned 32-bit integer.');
+            }
+            $revision = (int) $rawRevision;
+        } else {
+            throw new InvalidArgumentException('Revision must be an unsigned 32-bit integer.');
+        }
+
+        if ($revision < 0 || $revision > 4294967295) {
+            throw new InvalidArgumentException('Revision must be an unsigned 32-bit integer.');
+        }
+
+        return $revision;
+    }
+
+
+    /**
      * Manage case inFolder - get items inside an array of folders
      *
      * @param array $userData
@@ -254,6 +330,8 @@ class ItemController extends BaseController
         $arrErrorHeaders = [];
         $arrSuccessHeaders = [];
         $intSuccessStatus = 200;
+        $idempotencyModel = null;
+        $idempotencyReservation = null;
 
         if (strtoupper($requestMethod) === 'POST') {
             // Is user allowed to create a folder
@@ -274,8 +352,16 @@ class ItemController extends BaseController
                 // get parameters
                 $arrQueryStringParams = $this->getQueryStringParams();
 
+                try {
+                    $idempotencyKey = $this->getIdempotencyKey($request);
+                } catch (InvalidArgumentException $exception) {
+                    $idempotencyKey = null;
+                    $strErrorDesc = $exception->getMessage();
+                    $strErrorHeader = 'HTTP/1.1 400 Bad Request';
+                }
+
                 // Check that the parameters are indeed an array before using them
-                if (is_array($arrQueryStringParams)) {
+                if (empty($strErrorDesc) === true && is_array($arrQueryStringParams)) {
                     // check parameters
                     $arrCheck = $this->checkNewItemData($arrQueryStringParams, $userData);
 
@@ -304,26 +390,72 @@ class ItemController extends BaseController
                             'fields' => $this->normalizeFields($arrQueryStringParams['fields'] ?? []),
                         ];
 
-                        // launch
-                        $itemModel = new ItemModel();
-                        $ret = $itemModel->addItem(
-                            $arrItemParams
-                        );
-                        if (($ret['error'] ?? false) === true) {
-                            $strErrorDesc = (string) ($ret['error_message'] ?? 'Item creation failed');
-                            $strErrorHeader = (string) ($ret['error_header'] ?? 'HTTP/1.1 422 Unprocessable Entity');
-                        } else {
-                            // 201 Created + Location of the new resource (path-absolute reference)
-                            $responseData = json_encode($ret);
-                            $intSuccessStatus = 201;
-                            $requestPath = (string) parse_url($request->getRequestUri(), PHP_URL_PATH);
-                            $arrSuccessHeaders[] = 'Location: '
-                                . preg_replace('/create$/', 'get', $requestPath)
-                                . '?id=' . (int) $ret['newId'];
+                        if ($idempotencyKey !== null) {
+                            try {
+                                $idempotencyModel = new ApiIdempotencyModel();
+                                $decision = $idempotencyModel->reserve(
+                                    (int) $userData['id'],
+                                    ApiIdempotencyModel::OPERATION_ITEM_CREATE,
+                                    $idempotencyKey,
+                                    $this->createIdempotencyIntent($arrItemParams)
+                                );
+
+                                if ($decision['state'] === 'replay') {
+                                    $responseData = json_encode($decision['response']);
+                                    $intSuccessStatus = (int) $decision['http_status'];
+                                    $arrSuccessHeaders[] = 'Idempotency-Replayed: true';
+                                    $requestPath = (string) parse_url($request->getRequestUri(), PHP_URL_PATH);
+                                    $arrSuccessHeaders[] = 'Location: '
+                                        . preg_replace('/create$/', 'get', $requestPath)
+                                        . '?id=' . (int) $decision['resource_id'];
+                                } elseif ($decision['state'] === 'conflict') {
+                                    $strErrorDesc = 'Idempotency-Key was already used with a different request.';
+                                    $strErrorHeader = 'HTTP/1.1 409 Conflict';
+                                } elseif ($decision['state'] === 'processing') {
+                                    $strErrorDesc = 'A request with this Idempotency-Key is still processing.';
+                                    $strErrorHeader = 'HTTP/1.1 409 Conflict';
+                                    $arrErrorHeaders[] = 'Retry-After: ' . (int) ($decision['retry_after'] ?? 1);
+                                } else {
+                                    $idempotencyReservation = $decision;
+                                }
+                            } catch (Throwable $exception) {
+                                error_log('[API] Unable to reserve item.create idempotency: ' . $exception->getMessage());
+                                $strErrorDesc = 'An internal error occurred while preparing the item creation.';
+                                $strErrorHeader = 'HTTP/1.1 500 Internal Server Error';
+                            }
+                        }
+
+                        if (empty($strErrorDesc) === true && $responseData === '') {
+                            // launch
+                            $itemModel = new ItemModel();
+                            $ret = $itemModel->addItem(
+                                $arrItemParams,
+                                $idempotencyModel,
+                                $idempotencyReservation
+                            );
+                            if (($ret['error'] ?? false) === true) {
+                                if ($idempotencyModel !== null && $idempotencyReservation !== null) {
+                                    try {
+                                        $idempotencyModel->releaseReservation($idempotencyReservation);
+                                    } catch (Throwable $exception) {
+                                        error_log('[API] Unable to release failed item.create idempotency: ' . $exception->getMessage());
+                                    }
+                                }
+                                $strErrorDesc = (string) ($ret['error_message'] ?? 'Item creation failed');
+                                $strErrorHeader = (string) ($ret['error_header'] ?? 'HTTP/1.1 422 Unprocessable Entity');
+                            } else {
+                                // 201 Created + Location of the new resource (path-absolute reference)
+                                $responseData = json_encode($ret);
+                                $intSuccessStatus = 201;
+                                $requestPath = (string) parse_url($request->getRequestUri(), PHP_URL_PATH);
+                                $arrSuccessHeaders[] = 'Location: '
+                                    . preg_replace('/create$/', 'get', $requestPath)
+                                    . '?id=' . (int) $ret['newId'];
+                            }
                         }
                     }
 
-                } else {
+                } elseif (empty($strErrorDesc) === true) {
                     $strErrorDesc = 'Data not consistent';
                     $strErrorHeader = 'HTTP/1.1 400 Bad Request';
                 }
@@ -1065,6 +1197,10 @@ class ItemController extends BaseController
         $request = symfonyRequest::createFromGlobals();
         $requestMethod = $request->getMethod();
         $strErrorDesc = $strErrorHeader = $responseData = '';
+        $arrErrorHeaders = [];
+        $arrSuccessHeaders = [];
+        $idempotencyModel = null;
+        $idempotencyReservation = null;
 
         if (strtoupper($requestMethod) === 'DELETE') {
             // Check if user is allowed to delete items
@@ -1074,16 +1210,28 @@ class ItemController extends BaseController
             } else {
                 // Get parameters
                 $arrQueryStringParams = $this->getQueryStringParams();
-                
+
                 // Check that the parameters are indeed an array before using them
                 if (is_array($arrQueryStringParams)) {
+                    try {
+                        $idempotencyKey = $this->getIdempotencyKey($request);
+                        $expectedRevision = $this->parseOptionalRevision($arrQueryStringParams);
+                    } catch (InvalidArgumentException $exception) {
+                        $idempotencyKey = null;
+                        $expectedRevision = null;
+                        $strErrorDesc = $exception->getMessage();
+                        $strErrorHeader = 'HTTP/1.1 400 Bad Request';
+                    }
+
                     // Check if item ID is provided
-                    if (!isset($arrQueryStringParams['id']) || empty($arrQueryStringParams['id'])) {
+                    if (empty($strErrorDesc) === true
+                        && (!isset($arrQueryStringParams['id']) || empty($arrQueryStringParams['id']))
+                    ) {
                         $strErrorDesc = 'Item ID is mandatory';
                         $strErrorHeader = 'HTTP/1.1 400 Bad Request';
-                    } else {
+                    } elseif (empty($strErrorDesc) === true) {
                         $itemId = (int) $arrQueryStringParams['id'];
-                        
+
                         try {
                             // Load item info to check access rights
                             $itemInfo = DB::queryFirstRow(
@@ -1110,22 +1258,67 @@ class ItemController extends BaseController
                                     $strErrorDesc = 'Access denied: you are not allowed to delete items in this folder';
                                     $strErrorHeader = 'HTTP/1.1 403 Forbidden';
                                 } else {
-                                    // delete the item
-                                    $itemModel = new ItemModel();
-                                    $ret = $itemModel->deleteItem(
-                                        $itemId,
-                                        $userData
-                                    );
+                                    if ($idempotencyKey !== null) {
+                                        try {
+                                            $idempotencyModel = new ApiIdempotencyModel();
+                                            $decision = $idempotencyModel->reserve(
+                                                (int) $userData['id'],
+                                                ApiIdempotencyModel::OPERATION_ITEM_DELETE,
+                                                $idempotencyKey,
+                                                [
+                                                    'item_id' => $itemId,
+                                                    'revision' => $expectedRevision,
+                                                ]
+                                            );
 
-                                    if ($ret['error'] === true) {
-                                        $strErrorDesc = $ret['error_message'];
-                                        $strErrorHeader = $ret['error_header'];
-                                    } else {
-                                        $responseData = json_encode($ret);
+                                            if ($decision['state'] === 'replay') {
+                                                $responseData = json_encode($decision['response']);
+                                                $arrSuccessHeaders[] = 'Idempotency-Replayed: true';
+                                            } elseif ($decision['state'] === 'conflict') {
+                                                $strErrorDesc = 'Idempotency-Key was already used with a different request.';
+                                                $strErrorHeader = 'HTTP/1.1 409 Conflict';
+                                            } elseif ($decision['state'] === 'processing') {
+                                                $strErrorDesc = 'A request with this Idempotency-Key is still processing.';
+                                                $strErrorHeader = 'HTTP/1.1 409 Conflict';
+                                                $arrErrorHeaders[] = 'Retry-After: ' . (int) ($decision['retry_after'] ?? 1);
+                                            } else {
+                                                $idempotencyReservation = $decision;
+                                            }
+                                        } catch (Throwable $exception) {
+                                            error_log('[API] Unable to reserve item.delete idempotency: ' . $exception->getMessage());
+                                            $strErrorDesc = 'An internal error occurred while preparing the item deletion.';
+                                            $strErrorHeader = 'HTTP/1.1 500 Internal Server Error';
+                                        }
+                                    }
+
+                                    if (empty($strErrorDesc) === true && $responseData === '') {
+                                        // delete the item
+                                        $itemModel = new ItemModel();
+                                        $ret = $itemModel->deleteItem(
+                                            $itemId,
+                                            $userData,
+                                            $expectedRevision,
+                                            $idempotencyModel,
+                                            $idempotencyReservation
+                                        );
+
+                                        if ($ret['error'] === true) {
+                                            if ($idempotencyModel !== null && $idempotencyReservation !== null) {
+                                                try {
+                                                    $idempotencyModel->releaseReservation($idempotencyReservation);
+                                                } catch (Throwable $exception) {
+                                                    error_log('[API] Unable to release failed item.delete idempotency: ' . $exception->getMessage());
+                                                }
+                                            }
+                                            $strErrorDesc = $ret['error_message'];
+                                            $strErrorHeader = $ret['error_header'];
+                                        } else {
+                                            $responseData = json_encode($ret);
+                                        }
                                     }
                                 }
                             }
-                        } catch (Error $e) {
+                        } catch (Throwable $e) {
                             error_log('[API] ItemController error: ' . $e->getMessage());
                             $strErrorDesc = 'An internal error occurred. Please contact support.';
                             $strErrorHeader = 'HTTP/1.1 500 Internal Server Error';
@@ -1146,10 +1339,10 @@ class ItemController extends BaseController
         if (empty($strErrorDesc) === true) {
             $this->sendOutput(
                 $responseData,
-                ['Content-Type: application/json', 'HTTP/1.1 200 OK']
+                array_merge(['Content-Type: application/json', 'HTTP/1.1 200 OK'], $arrSuccessHeaders)
             );
         } else {
-            $this->sendProblemFromHeader($strErrorHeader, $strErrorDesc, $arrErrorHeaders ?? []);
+            $this->sendProblemFromHeader($strErrorHeader, $strErrorDesc, $arrErrorHeaders);
         }
     }
     //end deleteAction()

--- a/app/api/Model/ApiIdempotencyModel.php
+++ b/app/api/Model/ApiIdempotencyModel.php
@@ -1,0 +1,443 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Teampass - a collaborative passwords manager.
+ * ---
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * ---
+ * @project   Teampass
+ * @version   API
+ * @file      ApiIdempotencyModel.php
+ * @copyright 2009-2026 Teampass.net
+ * @license   https://spdx.org/licenses/GPL-3.0-only.html#licenseText GPL-3.0
+ * @see       https://www.teampass.net
+ */
+
+/**
+ * Persistent idempotency records for mutating API operations.
+ *
+ * Only HMACs and replay-safe response metadata are stored. Request bodies,
+ * passwords, TOTP secrets, custom-field values and raw idempotency keys never
+ * reach the database through this model.
+ */
+class ApiIdempotencyModel
+{
+    public const OPERATION_ITEM_CREATE = 'item.create';
+    public const OPERATION_ITEM_DELETE = 'item.delete';
+    public const MAX_KEY_LENGTH = 128;
+    public const PROCESSING_LEASE_SECONDS = 300;
+    public const REPLAY_WINDOW_SECONDS = 7776000; // 90 days, aligned with the default offline sync window.
+
+    private string $hmacSecret;
+
+    /**
+     * @param string|null $hmacSecret Test-only secret override; production derives it from SECUREFILE
+     */
+    public function __construct(?string $hmacSecret = null)
+    {
+        if ($hmacSecret !== null) {
+            $this->hmacSecret = $hmacSecret;
+            return;
+        }
+
+        if (defined('TEAMPASS_SECRETS') === false || defined('SECUREFILE') === false) {
+            throw new RuntimeException('The server idempotency secret is unavailable.');
+        }
+
+        $masterSecret = @file_get_contents(TEAMPASS_SECRETS . '/' . SECUREFILE);
+        if (is_string($masterSecret) === false || $masterSecret === '') {
+            throw new RuntimeException('The server idempotency secret is unavailable.');
+        }
+
+        $this->hmacSecret = hash_hmac('sha256', 'teampass-api-idempotency-v1', $masterSecret, true);
+    }
+
+    /**
+     * Validate and return an opaque Idempotency-Key header value.
+     *
+     * @param string $key Raw header value
+     * @return string Validated key
+     */
+    public static function validateKey(string $key): string
+    {
+        if ($key === '' || strlen($key) > self::MAX_KEY_LENGTH) {
+            throw new InvalidArgumentException('Idempotency-Key must contain between 1 and 128 characters.');
+        }
+
+        if (preg_match('/^[\x21-\x7E]+$/D', $key) !== 1) {
+            throw new InvalidArgumentException('Idempotency-Key must contain visible ASCII characters without spaces.');
+        }
+
+        return $key;
+    }
+
+    /**
+     * Build a deterministic HMAC fingerprint for a functional request intent.
+     *
+     * Associative keys are sorted recursively, so JSON property order does not
+     * influence the result. List order is preserved because it may be functional.
+     *
+     * @param array<string, mixed> $intent Functional request fields
+     * @return string Lowercase hexadecimal HMAC
+     */
+    public function fingerprint(array $intent): string
+    {
+        $canonical = $this->canonicalize($intent);
+        $encoded = json_encode(
+            $canonical,
+            JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_PRESERVE_ZERO_FRACTION | JSON_THROW_ON_ERROR
+        );
+
+        return hash_hmac('sha256', $encoded, $this->hmacSecret);
+    }
+
+    /**
+     * Classify an existing record before attempting a replay or stale takeover.
+     *
+     * @param array<string, mixed> $record Existing database row
+     * @param string $requestFingerprint HMAC of the current request intent
+     * @param int $now Current Unix timestamp
+     * @return array{state: string, retry_after?: int}
+     */
+    public function evaluateRecord(array $record, string $requestFingerprint, int $now): array
+    {
+        if (hash_equals((string) ($record['request_fingerprint'] ?? ''), $requestFingerprint) === false) {
+            return ['state' => 'conflict'];
+        }
+
+        if ((string) ($record['status'] ?? '') === 'completed') {
+            return ['state' => 'replay'];
+        }
+
+        $lockedUntil = (int) ($record['locked_until'] ?? 0);
+        if ($lockedUntil >= $now) {
+            return [
+                'state' => 'processing',
+                'retry_after' => max(1, $lockedUntil - $now),
+            ];
+        }
+
+        return ['state' => 'stale'];
+    }
+
+    /**
+     * Reserve an idempotency identity or return the existing request outcome.
+     *
+     * @param int $userId Authenticated TeamPass user
+     * @param string $operation Operation scope
+     * @param string $key Validated raw Idempotency-Key
+     * @param array<string, mixed> $intent Functional request intent
+     * @return array<string, mixed> acquired, replay, conflict or processing decision
+     */
+    public function reserve(int $userId, string $operation, string $key, array $intent): array
+    {
+        if ($userId <= 0 || in_array($operation, [self::OPERATION_ITEM_CREATE, self::OPERATION_ITEM_DELETE], true) === false) {
+            throw new InvalidArgumentException('Invalid idempotency scope.');
+        }
+
+        $key = self::validateKey($key);
+        $keyHash = hash_hmac('sha256', $key, $this->hmacSecret);
+        $requestFingerprint = $this->fingerprint($intent);
+
+        for ($attempt = 0; $attempt < 3; $attempt++) {
+            $now = time();
+            $ownerToken = bin2hex(random_bytes(32));
+            $ownerTokenHash = hash('sha256', $ownerToken);
+
+            try {
+                DB::insert(
+                    prefixTable('api_idempotency'),
+                    [
+                        'user_id' => $userId,
+                        'operation' => $operation,
+                        'key_hash' => $keyHash,
+                        'request_fingerprint' => $requestFingerprint,
+                        'status' => 'processing',
+                        'owner_token_hash' => $ownerTokenHash,
+                        'resource_id' => null,
+                        'http_status' => null,
+                        'response_body' => null,
+                        'created_at' => $now,
+                        'updated_at' => $now,
+                        'locked_until' => $now + self::PROCESSING_LEASE_SECONDS,
+                        'expires_at' => $now + self::REPLAY_WINDOW_SECONDS,
+                    ]
+                );
+
+                return [
+                    'state' => 'acquired',
+                    'id' => (int) DB::insertId(),
+                    'owner_token' => $ownerToken,
+                    'request_fingerprint' => $requestFingerprint,
+                ];
+            } catch (Throwable $exception) {
+                $record = $this->findRecord($userId, $operation, $keyHash);
+                if ($record === null) {
+                    throw $exception;
+                }
+            }
+
+            $decision = $this->evaluateRecord($record, $requestFingerprint, $now);
+            if ($decision['state'] === 'conflict') {
+                return $decision;
+            }
+
+            if ($decision['state'] === 'replay') {
+                return $this->buildReplayDecision($record);
+            }
+
+            if ($decision['state'] === 'processing') {
+                return $decision;
+            }
+
+            // A committed create is linked back to its reservation. This defensive recovery
+            // path repairs an old/stale processing row without re-running any side effect.
+            if ($operation === self::OPERATION_ITEM_CREATE) {
+                $recovered = $this->recoverCommittedCreate($record, $requestFingerprint, $now);
+                if ($recovered !== null) {
+                    return $recovered;
+                }
+            }
+
+            DB::update(
+                prefixTable('api_idempotency'),
+                [
+                    'owner_token_hash' => $ownerTokenHash,
+                    'updated_at' => $now,
+                    'locked_until' => $now + self::PROCESSING_LEASE_SECONDS,
+                    'expires_at' => $now + self::REPLAY_WINDOW_SECONDS,
+                ],
+                'id = %i AND status = %s AND locked_until < %i AND request_fingerprint = %s',
+                (int) $record['id'],
+                'processing',
+                $now,
+                $requestFingerprint
+            );
+
+            if (DB::affectedRows() === 1) {
+                return [
+                    'state' => 'acquired',
+                    'id' => (int) $record['id'],
+                    'owner_token' => $ownerToken,
+                    'request_fingerprint' => $requestFingerprint,
+                ];
+            }
+        }
+
+        return ['state' => 'processing', 'retry_after' => 1];
+    }
+
+    /**
+     * Lock and verify a reservation inside the mutation transaction.
+     *
+     * @param array<string, mixed> $reservation Acquired reservation
+     * @return void
+     */
+    public function lockReservation(array $reservation): void
+    {
+        $record = DB::queryFirstRow(
+            'SELECT id, status, owner_token_hash
+             FROM ' . prefixTable('api_idempotency') . '
+             WHERE id = %i
+             FOR UPDATE',
+            (int) ($reservation['id'] ?? 0)
+        );
+
+        $expectedTokenHash = hash('sha256', (string) ($reservation['owner_token'] ?? ''));
+        if ($record === null
+            || (string) $record['status'] !== 'processing'
+            || hash_equals((string) $record['owner_token_hash'], $expectedTokenHash) === false
+        ) {
+            throw new RuntimeException('The idempotency reservation is no longer owned by this request.');
+        }
+    }
+
+    /**
+     * Complete a reservation in the same transaction as the functional mutation.
+     *
+     * @param array<string, mixed> $reservation Acquired reservation
+     * @param int $resourceId Created or deleted item id
+     * @param int $httpStatus Replay HTTP status
+     * @param array<string, mixed> $response Replay-safe response body
+     * @return void
+     */
+    public function completeReservation(
+        array $reservation,
+        int $resourceId,
+        int $httpStatus,
+        array $response
+    ): void {
+        $responseBody = json_encode(
+            $response,
+            JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR
+        );
+        $now = time();
+
+        DB::update(
+            prefixTable('api_idempotency'),
+            [
+                'status' => 'completed',
+                'resource_id' => $resourceId,
+                'http_status' => $httpStatus,
+                'response_body' => $responseBody,
+                'updated_at' => $now,
+                'locked_until' => 0,
+                'expires_at' => $now + self::REPLAY_WINDOW_SECONDS,
+            ],
+            'id = %i AND status = %s AND owner_token_hash = %s',
+            (int) ($reservation['id'] ?? 0),
+            'processing',
+            hash('sha256', (string) ($reservation['owner_token'] ?? ''))
+        );
+
+        if (DB::affectedRows() !== 1) {
+            throw new RuntimeException('Unable to finalize the idempotency reservation.');
+        }
+    }
+
+    /**
+     * Release an acquired reservation after validation or a rolled-back mutation failed.
+     *
+     * @param array<string, mixed> $reservation Acquired reservation
+     * @return void
+     */
+    public function releaseReservation(array $reservation): void
+    {
+        DB::delete(
+            prefixTable('api_idempotency'),
+            'id = %i AND status = %s AND owner_token_hash = %s',
+            (int) ($reservation['id'] ?? 0),
+            'processing',
+            hash('sha256', (string) ($reservation['owner_token'] ?? ''))
+        );
+    }
+
+    /**
+     * Canonicalize associative arrays recursively while preserving list order.
+     *
+     * @param mixed $value Value to canonicalize
+     * @return mixed Canonicalized value
+     */
+    private function canonicalize($value)
+    {
+        if (is_array($value) === false) {
+            return $value;
+        }
+
+        if (array_is_list($value)) {
+            return array_map(fn ($entry) => $this->canonicalize($entry), $value);
+        }
+
+        ksort($value, SORT_STRING);
+        foreach ($value as $key => $entry) {
+            $value[$key] = $this->canonicalize($entry);
+        }
+
+        return $value;
+    }
+
+    /**
+     * Find one idempotency record by its scoped identity.
+     *
+     * @return array<string, mixed>|null
+     */
+    private function findRecord(int $userId, string $operation, string $keyHash): ?array
+    {
+        $record = DB::queryFirstRow(
+            'SELECT id, user_id, operation, request_fingerprint, status, owner_token_hash,
+                    resource_id, http_status, response_body, locked_until, expires_at
+             FROM ' . prefixTable('api_idempotency') . '
+             WHERE user_id = %i AND operation = %s AND key_hash = %s',
+            $userId,
+            $operation,
+            $keyHash
+        );
+
+        return is_array($record) ? $record : null;
+    }
+
+    /**
+     * Convert a completed database row to a replay decision.
+     *
+     * @param array<string, mixed> $record Completed row
+     * @return array<string, mixed>
+     */
+    private function buildReplayDecision(array $record): array
+    {
+        $response = json_decode((string) ($record['response_body'] ?? ''), true);
+        if (is_array($response) === false) {
+            throw new RuntimeException('The stored idempotency response is invalid.');
+        }
+
+        return [
+            'state' => 'replay',
+            'resource_id' => (int) ($record['resource_id'] ?? 0),
+            'http_status' => (int) ($record['http_status'] ?? 200),
+            'response' => $response,
+        ];
+    }
+
+    /**
+     * Recover a committed create from the durable item-to-reservation link.
+     *
+     * @param array<string, mixed> $record Stale processing row
+     * @param string $requestFingerprint Current request fingerprint
+     * @param int $now Current Unix timestamp
+     * @return array<string, mixed>|null Replay decision when recovery succeeded
+     */
+    private function recoverCommittedCreate(array $record, string $requestFingerprint, int $now): ?array
+    {
+        $item = DB::queryFirstRow(
+            'SELECT id, revision, revision_changed_at
+             FROM ' . prefixTable('items') . '
+             WHERE api_idempotency_id = %i',
+            (int) $record['id']
+        );
+        if ($item === null) {
+            return null;
+        }
+
+        $response = [
+            'error' => false,
+            'message' => 'Item added successfully',
+            'newId' => (int) $item['id'],
+            'revision' => (int) ($item['revision'] ?? 0),
+            'revision_changed_at' => $item['revision_changed_at'] === null
+                ? null
+                : (int) $item['revision_changed_at'],
+        ];
+        $responseBody = json_encode($response, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR);
+
+        DB::update(
+            prefixTable('api_idempotency'),
+            [
+                'status' => 'completed',
+                'resource_id' => (int) $item['id'],
+                'http_status' => 201,
+                'response_body' => $responseBody,
+                'updated_at' => $now,
+                'locked_until' => 0,
+                'expires_at' => $now + self::REPLAY_WINDOW_SECONDS,
+            ],
+            'id = %i AND status = %s AND locked_until < %i AND request_fingerprint = %s',
+            (int) $record['id'],
+            'processing',
+            $now,
+            $requestFingerprint
+        );
+
+        if (DB::affectedRows() !== 1) {
+            return null;
+        }
+
+        return [
+            'state' => 'replay',
+            'resource_id' => (int) $item['id'],
+            'http_status' => 201,
+            'response' => $response,
+        ];
+    }
+}

--- a/app/api/Model/ItemModel.php
+++ b/app/api/Model/ItemModel.php
@@ -80,7 +80,7 @@ class ItemModel
         $rows = DB::query(
             "SELECT i.id, i.label, i.description, i.pw, i.pw_iv, i.url, i.id_tree, i.login, i.email,
                 i.viewed_no, i.fa_icon, i.inactif, i.perso, i.favicon_url, i.anyone_can_modify,
-                i.revision,
+                i.revision, i.revision_changed_at,
                 t.title as folder_label,
                 io.secret as otp_secret,
                 io.algorithm as otp_algorithm,
@@ -168,6 +168,9 @@ class ItemModel
                 [
                     'id' => (int) $row['id'],
                     'revision' => (int) $row['revision'],
+                    'revision_changed_at' => $row['revision_changed_at'] === null
+                        ? null
+                        : (int) $row['revision_changed_at'],
                     'label' => $row['label'],
                     'description' => $row['description'],
                     'pwd' => $pwd,
@@ -289,7 +292,7 @@ class ItemModel
     ): array {
         // 1. Scan the journal window.
         $journalRows = DB::query(
-            'SELECT r.revision, r.item_id, r.action
+            'SELECT r.revision, r.item_id, r.action, r.changed_at
             FROM ' . prefixTable('items_revisions') . ' AS r
             WHERE r.revision > %i' . $journalScopeSql . '
             ORDER BY r.revision ASC
@@ -355,6 +358,7 @@ class ItemModel
                 $removed[] = [
                     'id' => (int) $itemId,
                     'revision' => (int) $row['revision'],
+                    'revision_changed_at' => (int) $row['changed_at'],
                     'reason' => $verdict['reason'],
                 ];
                 continue;
@@ -376,6 +380,18 @@ class ItemModel
                 0,
                 [array_keys($toDeliver)]
             );
+
+            // The journal winner defines the cursor contract. A concurrent later update may
+            // already be visible in items, so explicitly keep the revision/timestamp pair from
+            // the winning journal row scanned by this page.
+            foreach ($changed as &$item) {
+                $changedItemId = (int) $item['id'];
+                if (isset($winners[$changedItemId]) === true) {
+                    $item['revision'] = (int) $winners[$changedItemId]['revision'];
+                    $item['revision_changed_at'] = (int) $winners[$changedItemId]['changed_at'];
+                }
+            }
+            unset($item);
         }
 
         // 6. An item whose sharekeys are still being distributed cannot be handed over yet.
@@ -503,12 +519,15 @@ class ItemModel
             // waiting for a manual dashboard scan (no-op when the dashboard is disabled).
             refreshItemHealthAfterSave((int) $newID, $userId, (string) $plaintextPasswordForHealth, $SETTINGS);
 
+            $revisionMetadata = getItemRevisionMetadata((int) $newID);
+
             // Success response
             return [
                 'error' => false,
                 'message' => 'Item added successfully',
                 'newId' => $newID,
-                'revision' => getItemRevision((int) $newID),
+                'revision' => $revisionMetadata['revision'],
+                'revision_changed_at' => $revisionMetadata['revision_changed_at'],
             ];
 
         } catch (Exception $e) {
@@ -687,6 +706,41 @@ class ItemModel
         string $userPrivateKey,
         array $currentItem
     ): string {
+        try {
+            return $this->getItemPasswordForUpdate(
+                $itemId,
+                $userId,
+                $userPrivateKey,
+                $currentItem
+            );
+        } catch (UnexpectedValueException $e) {
+            error_log('[API] ItemModel password comparison failed for item ' . $itemId);
+
+            return "\0lapr-undecryptable";
+        }
+    }
+
+    /**
+     * Recover the current cleartext password before an API password update.
+     *
+     * The migration-aware sharekey path is mandatory. Any missing or unusable key fails
+     * before the caller mutates the item, so a successful password update never knowingly
+     * creates a gap in the encrypted password history.
+     *
+     * @param int    $itemId         Item id
+     * @param int    $userId         Caller id
+     * @param string $userPrivateKey Caller RSA private key (cleartext)
+     * @param array  $currentItem    Current items row
+     *
+     * @return string Current cleartext password
+     * @throws UnexpectedValueException When the password cannot be recovered safely
+     */
+    private function getItemPasswordForUpdate(
+        int $itemId,
+        int $userId,
+        string $userPrivateKey,
+        array $currentItem
+    ): string {
         if (empty($currentItem['pw']) === true) {
             return '';
         }
@@ -698,33 +752,40 @@ class ItemModel
             $userId,
             $itemId
         );
-        if (DB::count() === 0) {
-            return "\0lapr-undecryptable";
+        if ($userKey === null) {
+            throw new UnexpectedValueException('The current item password cannot be decrypted.');
         }
 
         $userPublicKey = (string) DB::queryFirstField(
             'SELECT public_key FROM ' . prefixTable('users') . ' WHERE id = %i',
             $userId
         );
-
-        try {
-            return teampassDecryptPasswordValue(
-                (string) $currentItem['pw'],
-                decryptUserObjectKeyWithMigration(
-                    $userKey['share_key'],
-                    $userPrivateKey,
-                    $userPublicKey,
-                    (int) $userKey['increment_id'],
-                    'sharekeys_items'
-                ),
-                (int) ($currentItem['pw_len'] ?? 0),
-                (string) ($currentItem['pw_iv'] ?? '')
-            );
-        } catch (Exception $e) {
-            error_log('[API] ItemModel LAPR password comparison failed for item ' . $itemId . ': ' . $e->getMessage());
-
-            return "\0lapr-undecryptable";
+        if ($userPublicKey === '') {
+            throw new UnexpectedValueException('The current item password cannot be decrypted.');
         }
+
+        $objectKey = decryptUserObjectKeyWithMigration(
+            (string) $userKey['share_key'],
+            $userPrivateKey,
+            $userPublicKey,
+            (int) $userKey['increment_id'],
+            'sharekeys_items'
+        );
+        if ($objectKey === '') {
+            throw new UnexpectedValueException('The current item password cannot be decrypted.');
+        }
+
+        $password = teampassDecryptPasswordValue(
+            (string) $currentItem['pw'],
+            $objectKey,
+            (int) ($currentItem['pw_len'] ?? 0),
+            (string) ($currentItem['pw_iv'] ?? '')
+        );
+        if ($password === '' && (int) ($currentItem['pw_len'] ?? 0) > 0) {
+            throw new UnexpectedValueException('The current item password cannot be decrypted.');
+        }
+
+        return $password;
     }
 
     /**
@@ -1475,6 +1536,7 @@ class ItemModel
         try {
             include_once API_ROOT_PATH . '/../sources/main.functions.php';
             include_once API_ROOT_PATH . '/../sources/lapr.functions.php';
+            include_once API_ROOT_PATH . '/../sources/item_update_logic.php';
 
             // Load config
             $configManager = new ConfigManager();
@@ -1526,11 +1588,14 @@ class ItemModel
                 // rejected. A password that cannot be decrypted fails closed.
                 $laprPasswordChanged = isset($params['password'])
                     && (string) $params['password'] !== ''
-                    && (string) $params['password'] !== $this->getItemPasswordForComparison(
-                        $itemId,
-                        (int) $userData['id'],
-                        $userPrivateKey,
-                        $currentItem
+                    && itemPasswordHasChanged(
+                        $this->getItemPasswordForComparison(
+                            $itemId,
+                            (int) $userData['id'],
+                            $userPrivateKey,
+                            $currentItem
+                        ),
+                        (string) $params['password']
                     );
                 if ($laprLoginChanged === true || $laprPasswordChanged === true) {
                     return [
@@ -1560,6 +1625,8 @@ class ItemModel
             $updateData = [];
             $passwordKey = null;
             $newPassword = null;
+            $encryptedPreviousPassword = null;
+            $passwordChanged = false;
             $hasTotpUpdate = array_key_exists('totp', $params)
                 || array_key_exists('totp_algorithm', $params)
                 || array_key_exists('totp_digits', $params)
@@ -1696,11 +1763,6 @@ class ItemModel
                 }
             }
 
-            // Generate favicon URL if URL is provided and favicon_url is empty
-            if (empty($currentItem['url']) === false) {
-                $updateData['favicon_url'] = $this->getFaviconUrl($currentItem['url']);
-            }
-
             // Each field is stored the way the web form stores it, so an update cannot
             // reintroduce the markup that validateData() strips on creation
             // (GHSA-r298-6mxv-j9hc).
@@ -1730,9 +1792,16 @@ class ItemModel
                 }
             }
 
+            // Regenerate the favicon only when this request actually changes the URL.
+            if (isset($params['url']) && isset($params['favicon_url']) === false) {
+                $updateData['favicon_url'] = empty($updateData['url']) === true
+                    ? ''
+                    : $this->getFaviconUrl((string) $updateData['url']);
+            }
+
             // Handle password update
             if (isset($params['password']) && !empty($params['password'])) {
-                $newPassword = $params['password'];
+                $newPassword = (string) $params['password'];
 
                 // Validate password length
                 if (strlen($newPassword) > $SETTINGS['pwd_maximum_length']) {
@@ -1743,22 +1812,42 @@ class ItemModel
                     ];
                 }
 
-                // Get folder ID for complexity check
-                $folderId = isset($updateData['id_tree']) ? $updateData['id_tree'] : $currentItem['id_tree'];
+                $currentPassword = $this->getItemPasswordForUpdate(
+                    $itemId,
+                    (int) $userData['id'],
+                    $userPrivateKey,
+                    $currentItem
+                );
 
-                // Get folder settings
-                $itemInfos = $this->getFolderSettings((int) $folderId);
+                if (itemPasswordHasChanged($currentPassword, $newPassword) === true) {
+                    // Prepare the history ciphertext before mutating the item. A master-key
+                    // failure therefore cannot produce a successful update with no old_value.
+                    $previousValue = cryption($currentPassword, '', 'encrypt');
+                    if (($previousValue['error'] ?? true) !== false
+                        || empty($previousValue['string']) === true
+                    ) {
+                        throw new RuntimeException('Failed to prepare encrypted password history.');
+                    }
+                    $encryptedPreviousPassword = (string) $previousValue['string'];
 
-                // Check password complexity — capture score to avoid re-running zxcvbn on the ciphertext
-                $complexityLevel = $this->checkPasswordComplexity($newPassword, array_merge($itemInfos, ['folderId' => $folderId]));
+                    // Get folder ID for complexity check
+                    $folderId = isset($updateData['id_tree']) ? $updateData['id_tree'] : $currentItem['id_tree'];
 
-                // Encrypt password
-                $cryptedData = $this->encryptPassword($newPassword);
-                $passwordKey = $cryptedData['passwordKey'];
-                $updateData['pw'] = $cryptedData['encrypted'];
-                $updateData['pw_iv'] = $cryptedData['meta'] ?? '';
-                $updateData['pw_len'] = strlen($newPassword);
-                $updateData['complexity_level'] = $complexityLevel;
+                    // Get folder settings
+                    $itemInfos = $this->getFolderSettings((int) $folderId);
+
+                    // Check password complexity — capture score to avoid re-running zxcvbn on the ciphertext
+                    $complexityLevel = $this->checkPasswordComplexity($newPassword, array_merge($itemInfos, ['folderId' => $folderId]));
+
+                    // Encrypt password
+                    $cryptedData = $this->encryptPassword($newPassword);
+                    $passwordKey = $cryptedData['passwordKey'];
+                    $updateData['pw'] = $cryptedData['encrypted'];
+                    $updateData['pw_iv'] = $cryptedData['meta'] ?? '';
+                    $updateData['pw_len'] = strlen($newPassword);
+                    $updateData['complexity_level'] = $complexityLevel;
+                    $passwordChanged = true;
+                }
             }
 
             $otpConfiguration = null;
@@ -1799,8 +1888,13 @@ class ItemModel
                 );
             }
             
+            $hasGeneralUpdate = empty($updateData) === false
+                || $hasTotpUpdate === true
+                || isset($params['tags'])
+                || (isset($params['fields']) && is_array($params['fields']));
+
             // Update the item
-            if (!empty($updateData) || $hasTotpUpdate === true) {
+            if (empty($updateData) === false || $hasTotpUpdate === true) {
                 $updateData['updated_at'] = time();
 
                 DB::update(
@@ -1911,17 +2005,38 @@ class ItemModel
                     $moveContext['target_folder_id'],
                     $moveContext['target_folder_title']
                 );
-            } else {
+            }
+
+            if ($passwordChanged === true && $encryptedPreviousPassword !== null) {
+                logItems(
+                    $SETTINGS,
+                    $itemId,
+                    (string) $label,
+                    (int) $userData['id'],
+                    'at_modification',
+                    (string) $userData['username'],
+                    'at_pw',
+                    TP_ENCRYPTION_NAME,
+                    null,
+                    $encryptedPreviousPassword
+                );
+            } elseif (is_array($moveContext) === false && $hasGeneralUpdate === true) {
                 logItems($SETTINGS, $itemId, $label, $userData['id'], 'at_modification', $userData['username']);
+            }
+
+            if (is_array($moveContext) === false && $hasGeneralUpdate === true) {
                 updateCacheTable('update_value', $itemId, (int) $userData['id']);
             }
+
+            $revisionMetadata = getItemRevisionMetadata($itemId);
 
             // Success response
             return [
                 'error' => false,
                 'message' => 'Item updated successfully',
                 'item_id' => $itemId,
-                'revision' => getItemRevision($itemId),
+                'revision' => $revisionMetadata['revision'],
+                'revision_changed_at' => $revisionMetadata['revision_changed_at'],
             ];
 
         } catch (InvalidArgumentException | UnexpectedValueException $e) {

--- a/app/api/Model/ItemModel.php
+++ b/app/api/Model/ItemModel.php
@@ -435,11 +435,19 @@ class ItemModel
      * Main function to add a new item to the database.
      * It handles data preparation, validation, password checks, folder settings,
      * item creation, and post-insertion tasks (like logging, sharing, and tagging).
+     *
+     * @param array<string, mixed> $arrItemParams Item fields and authenticated user context
+     * @param ApiIdempotencyModel|null $idempotencyModel Persistent idempotency coordinator
+     * @param array<string, mixed>|null $idempotencyReservation Acquired reservation
+     * @return array<string, mixed> Success or error response
      */
     public function addItem(
-        array $arrItemParams
+        array $arrItemParams,
+        ?ApiIdempotencyModel $idempotencyModel = null,
+        ?array $idempotencyReservation = null
     ) : array
     {
+        $transactionStarted = false;
         try {
             include_once API_ROOT_PATH . '/../sources/main.functions.php';
 
@@ -504,11 +512,38 @@ class ItemModel
                 $data['favicon_url'] = $this->getFaviconUrl($data['url']);
             }
 
+            // Keep the complete persistent mutation atomic, including the replay result. External
+            // favicon resolution and all validation deliberately happened before this transaction.
+            DB::startTransaction();
+            $transactionStarted = true;
+            if ($idempotencyModel !== null && $idempotencyReservation !== null) {
+                $idempotencyModel->lockReservation($idempotencyReservation);
+            }
+
             // Step 8: Insert the new item into the database
-            $newID = $this->insertNewItem($data, $password, $itemInfos, $complexityLevel, $passwordIv);
+            $newID = $this->insertNewItem(
+                $data,
+                $password,
+                $itemInfos,
+                $complexityLevel,
+                $passwordIv,
+                $idempotencyReservation === null ? null : (int) $idempotencyReservation['id']
+            );
 
             // Step 9: Handle post-insert tasks (logging, sharing, tagging, custom fields)
-            $this->handlePostInsertTasks($newID, $itemInfos, $folderId, $passwordKey, $userId, $username, $tags, $fields, $data, $SETTINGS);
+            $this->handlePostInsertTasks(
+                $newID,
+                $itemInfos,
+                $folderId,
+                $passwordKey,
+                $userId,
+                $username,
+                $tags,
+                $fields,
+                $data,
+                $SETTINGS,
+                false
+            );
 
             updateCacheTable('add_value', $newID, $userId);
 
@@ -520,9 +555,12 @@ class ItemModel
             refreshItemHealthAfterSave((int) $newID, $userId, (string) $plaintextPasswordForHealth, $SETTINGS);
 
             $revisionMetadata = getItemRevisionMetadata((int) $newID);
+            if ($revisionMetadata['revision'] <= 0 || $revisionMetadata['revision_changed_at'] === null) {
+                throw new RuntimeException('The item creation revision could not be persisted.');
+            }
 
             // Success response
-            return [
+            $response = [
                 'error' => false,
                 'message' => 'Item added successfully',
                 'newId' => $newID,
@@ -530,12 +568,45 @@ class ItemModel
                 'revision_changed_at' => $revisionMetadata['revision_changed_at'],
             ];
 
-        } catch (Exception $e) {
-            // Error response
+            if ($idempotencyModel !== null && $idempotencyReservation !== null) {
+                $idempotencyModel->completeReservation($idempotencyReservation, $newID, 201, $response);
+            }
+
+            DB::commit();
+            $transactionStarted = false;
+
+            // Syslog is an external UDP side effect. Emit it only after the SQL outcome and
+            // replay result are durable; an idempotent replay never reaches this point.
+            emitItemSyslog($SETTINGS, $newID, $label, 'at_creation', $username);
+
+            return $response;
+        } catch (InvalidArgumentException | UnexpectedValueException $e) {
+            if ($transactionStarted === true) {
+                DB::rollback();
+                resetItemRevisionMemo();
+            }
+
             return [
                 'error' => true,
                 'error_header' => 'HTTP/1.1 422 Unprocessable Entity',
                 'error_message' => $e->getMessage(),
+            ];
+        } catch (Throwable $e) {
+            if ($transactionStarted === true) {
+                DB::rollback();
+                resetItemRevisionMemo();
+            }
+
+            error_log(
+                '[API] ItemModel::addItem failed for user '
+                . (int) ($arrItemParams['id'] ?? 0)
+                . ' [' . get_class($e) . ':' . (int) $e->getCode() . ']'
+            );
+
+            return [
+                'error' => true,
+                'error_header' => 'HTTP/1.1 500 Internal Server Error',
+                'error_message' => 'An internal error occurred while creating the item.',
             ];
         }
     }
@@ -678,11 +749,11 @@ class ItemModel
     private function validatePassword(string $password, array $SETTINGS) : void
     {
         if ($this->isPasswordEmptyAllowed($password, $SETTINGS['create_item_without_password'])) {
-            throw new Exception('Empty password is not allowed');
+            throw new InvalidArgumentException('Empty password is not allowed');
         }
 
         if (strlen($password) > $SETTINGS['pwd_maximum_length']) {
-            throw new Exception('Password is too long (max allowed is ' . $SETTINGS['pwd_maximum_length'] . ' characters)');
+            throw new InvalidArgumentException('Password is too long (max allowed is ' . $SETTINGS['pwd_maximum_length'] . ' characters)');
         }
     }
 
@@ -832,7 +903,7 @@ class ItemModel
     {
         // Check existence first
         if (isset($itemInfos['folderId']) === false) {
-            throw new Exception('Folder ID is missing');
+            throw new InvalidArgumentException('Folder ID is missing');
         }
 
         // Cast to integer for strict validation
@@ -840,7 +911,7 @@ class ItemModel
 
         // Validate value
         if ($folderId <= 0) {
-            throw new Exception('Invalid folder ID for complexity check');
+            throw new InvalidArgumentException('Invalid folder ID for complexity check');
         }
 
         $folderComplexity = DB::queryFirstRow(
@@ -862,7 +933,7 @@ class ItemModel
         $passwordStrengthScore = convertPasswordStrength((int) $passwordStrength['score']);
 
         if ($passwordStrengthScore < $requested_folder_complexity && (int) $itemInfos['no_complex_check_on_creation'] === 0) {
-            throw new Exception('Password strength is too low');
+            throw new InvalidArgumentException('Password strength is too low');
         }
 
         return $passwordStrengthScore;
@@ -889,7 +960,7 @@ class ItemModel
 	     (isset($SETTINGS['duplicate_item']) && (int) $SETTINGS['duplicate_item'] === 0)
 	     && (int) $itemInfos['personal_folder'] === 0)
         ) {
-            throw new Exception('Similar item already exists. Duplicates are not allowed.');
+            throw new InvalidArgumentException('Similar item already exists. Duplicates are not allowed.');
         }
     }
 
@@ -916,35 +987,48 @@ class ItemModel
      * @param array $itemInfos - Folder-specific settings
      * @param int $complexityLevel - Complexity level computed from the plaintext password by checkPasswordComplexity()
      * @param string $passwordIv - v2 metadata (pw_iv) returned by encryptPassword(); empty for legacy data
+     * @param int|null $idempotencyId Durable create reservation identifier
      * @return int - Returns the ID of the newly created item
      */
-    private function insertNewItem(array $data, string $password, array $itemInfos, int $complexityLevel, string $passwordIv = '') : int
+    private function insertNewItem(
+        array $data,
+        string $password,
+        array $itemInfos,
+        int $complexityLevel,
+        string $passwordIv = '',
+        ?int $idempotencyId = null
+    ) : int
     {
         include_once API_ROOT_PATH . '/../sources/main.functions.php';
 
+        $itemData = [
+            'label' => $data['label'],
+            'description' => $data['description'],
+            'pw' => $password,
+            'pw_iv' => $passwordIv,
+            'pw_len' => strlen($data['password']),
+            'email' => $data['email'],
+            'url' => $data['url'],
+            'id_tree' => $data['folderId'],
+            'login' => $data['login'],
+            'inactif' => 0,
+            'restricted_to' => '',
+            'perso' => $itemInfos['personal_folder'],
+            'anyone_can_modify' => $data['anyoneCanModify'],
+            'complexity_level' => $complexityLevel,
+            'encryption_type' => 'teampass_aes',
+            'fa_icon' => $data['icon'],
+            'item_key' => uniqidReal(50),
+            'created_at' => time(),
+            'favicon_url' => $data['favicon_url'],
+        ];
+        if ($idempotencyId !== null) {
+            $itemData['api_idempotency_id'] = $idempotencyId;
+        }
+
         DB::insert(
             prefixTable('items'),
-            [
-                'label' => $data['label'],
-                'description' => $data['description'],
-                'pw' => $password,
-                'pw_iv' => $passwordIv,
-                'pw_len' => strlen($data['password']),
-                'email' => $data['email'],
-                'url' => $data['url'],
-                'id_tree' => $data['folderId'],
-                'login' => $data['login'],
-                'inactif' => 0,
-                'restricted_to' => '',
-                'perso' => $itemInfos['personal_folder'],
-                'anyone_can_modify' => $data['anyoneCanModify'],
-                'complexity_level' => $complexityLevel,
-                'encryption_type' => 'teampass_aes',
-                'fa_icon' => $data['icon'],
-                'item_key' => uniqidReal(50),
-                'created_at' => time(),
-                'favicon_url' => $data['favicon_url'],
-            ]
+            $itemData
         );
 
         $newItemId = DB::insertId();
@@ -990,6 +1074,7 @@ class ItemModel
      * @param string $tags - Tags to be associated with the item
      * @param array $data - The original data used to create the item (including the label)
      * @param array $SETTINGS - System settings for logging and task creation
+     * @param bool $emitSyslog - Whether logItems() may emit the external syslog datagram
      */
     private function handlePostInsertTasks(
         int $newID,
@@ -1001,7 +1086,8 @@ class ItemModel
         string $tags,
         array $fields,
         array $data,
-        array $SETTINGS
+        array $SETTINGS,
+        bool $emitSyslog = true
     ) : void {
         // Create share keys for the creator
         storeUsersShareKey(
@@ -1017,7 +1103,20 @@ class ItemModel
         );
 
         // Log the item creation
-        logItems($SETTINGS, $newID, $data['label'], $userId, 'at_creation', $username);
+        logItems(
+            $SETTINGS,
+            $newID,
+            $data['label'],
+            $userId,
+            'at_creation',
+            $username,
+            null,
+            null,
+            null,
+            null,
+            $emitSyslog,
+            true
+        );
 
         // Add tags to the item
         $this->addTags($newID, $tags);
@@ -2079,13 +2178,20 @@ class ItemModel
      *
      * @param int $itemId The ID of the item to delete
      * @param array $userData User data from JWT token
+     * @param int|null $expectedRevision Optional optimistic-concurrency precondition
+     * @param ApiIdempotencyModel|null $idempotencyModel Persistent idempotency coordinator
+     * @param array<string, mixed>|null $idempotencyReservation Acquired reservation
      * @return array Returns success or error response
      */
     public function deleteItem(
         int $itemId,
-        array $userData
+        array $userData,
+        ?int $expectedRevision = null,
+        ?ApiIdempotencyModel $idempotencyModel = null,
+        ?array $idempotencyReservation = null
     ): array
     {
+        $transactionStarted = false;
         try {
             include_once API_ROOT_PATH . '/../sources/main.functions.php';
             include_once API_ROOT_PATH . '/../sources/lapr.functions.php';
@@ -2094,17 +2200,53 @@ class ItemModel
             $configManager = new ConfigManager();
             $SETTINGS = $configManager->getAllSettings();
 
-            // Load current item data
+            DB::startTransaction();
+            $transactionStarted = true;
+            if ($idempotencyModel !== null && $idempotencyReservation !== null) {
+                $idempotencyModel->lockReservation($idempotencyReservation);
+            }
+
+            // Lock the item row and perform the revision check immediately before mutation.
             $currentItem = DB::queryFirstRow(
-                'SELECT * FROM ' . prefixTable('items') . ' WHERE id = %i',
+                'SELECT * FROM ' . prefixTable('items') . ' WHERE id = %i FOR UPDATE',
                 $itemId
             );
 
             if (DB::count() === 0) {
+                DB::rollback();
+                $transactionStarted = false;
                 return [
                     'error' => true,
                     'error_message' => 'Item not found',
                     'error_header' => 'HTTP/1.1 404 Not Found',
+                ];
+            }
+
+            $folderAccessModel = new FolderAccessModel();
+            if ($folderAccessModel->canAccessItemInFolder(
+                $userData,
+                (int) $currentItem['id_tree'],
+                $itemId
+            ) === false || $folderAccessModel->canDeleteInFolder(
+                (int) $currentItem['id_tree'],
+                (int) $userData['id']
+            ) === false) {
+                DB::rollback();
+                $transactionStarted = false;
+                return [
+                    'error' => true,
+                    'error_message' => 'Access denied: you are not allowed to delete this item',
+                    'error_header' => 'HTTP/1.1 403 Forbidden',
+                ];
+            }
+
+            if ($expectedRevision !== null && $expectedRevision !== (int) ($currentItem['revision'] ?? 0)) {
+                DB::rollback();
+                $transactionStarted = false;
+                return [
+                    'error' => true,
+                    'error_message' => 'The item was modified since revision ' . $expectedRevision . '.',
+                    'error_header' => 'HTTP/1.1 409 Conflict',
                 ];
             }
 
@@ -2113,6 +2255,8 @@ class ItemModel
             if ((bool) ($laprRelation['is_managed'] ?? false) === true
                 || (bool) ($laprRelation['is_credential'] ?? false) === true
             ) {
+                DB::rollback();
+                $transactionStarted = false;
                 return [
                     'error' => true,
                     'error_message' => 'This item is linked to LAPR. Remove the managed account or linked endpoint first.',
@@ -2131,23 +2275,80 @@ class ItemModel
                 $itemId
             );
 
-            logItems($SETTINGS, $itemId, $currentItem['label'], $userData['id'], 'at_delete', $userData['username']);
+            logItems(
+                $SETTINGS,
+                $itemId,
+                $currentItem['label'],
+                $userData['id'],
+                'at_delete',
+                $userData['username'],
+                null,
+                null,
+                null,
+                null,
+                false,
+                true
+            );
 
             updateCacheTable('delete_value', $itemId);
 
-            // Success response
-            return [
+            emitItemEvent(
+                'deleted',
+                $itemId,
+                (int) $currentItem['id_tree'],
+                (string) $currentItem['label'],
+                (string) $userData['username'],
+                (int) $userData['id']
+            );
+
+            $revisionMetadata = getItemRevisionMetadata($itemId);
+            if ($revisionMetadata['revision'] <= (int) ($currentItem['revision'] ?? 0)
+                || $revisionMetadata['revision_changed_at'] === null
+            ) {
+                throw new RuntimeException('The item deletion revision could not be persisted.');
+            }
+            $response = [
                 'error' => false,
                 'message' => 'Item deleted successfully',
                 'item_id' => $itemId,
+                'revision' => $revisionMetadata['revision'],
+                'revision_changed_at' => $revisionMetadata['revision_changed_at'],
             ];
 
-        } catch (Exception $e) {
-            // Error response
+            if ($idempotencyModel !== null && $idempotencyReservation !== null) {
+                $idempotencyModel->completeReservation($idempotencyReservation, $itemId, 200, $response);
+            }
+
+            DB::commit();
+            $transactionStarted = false;
+
+            // Keep the external syslog datagram outside the SQL transaction. Replays return
+            // the stored response above the model and therefore never emit it again.
+            emitItemSyslog(
+                $SETTINGS,
+                $itemId,
+                (string) $currentItem['label'],
+                'at_delete',
+                (string) $userData['username']
+            );
+
+            return $response;
+        } catch (Throwable $e) {
+            if ($transactionStarted === true) {
+                DB::rollback();
+                resetItemRevisionMemo();
+            }
+
+            error_log(
+                '[API] ItemModel::deleteItem failed for item '
+                . $itemId
+                . ' [' . get_class($e) . ':' . (int) $e->getCode() . ']'
+            );
+
             return [
                 'error' => true,
                 'error_header' => 'HTTP/1.1 500 Internal Server Error',
-                'error_message' => $e->getMessage(),
+                'error_message' => 'An internal error occurred while deleting the item.',
             ];
         }
     }

--- a/app/api/Model/ItemModel.php
+++ b/app/api/Model/ItemModel.php
@@ -2007,7 +2007,7 @@ class ItemModel
                 );
             }
 
-            if ($passwordChanged === true && $encryptedPreviousPassword !== null) {
+            if ($passwordChanged === true) {
                 logItems(
                     $SETTINGS,
                     $itemId,
@@ -2018,7 +2018,7 @@ class ItemModel
                     'at_pw',
                     TP_ENCRYPTION_NAME,
                     null,
-                    $encryptedPreviousPassword
+                    (string) $encryptedPreviousPassword
                 );
             } elseif (is_array($moveContext) === false && $hasGeneralUpdate === true) {
                 logItems($SETTINGS, $itemId, $label, $userData['id'], 'at_modification', $userData['username']);

--- a/app/api/Model/ItemModel.php
+++ b/app/api/Model/ItemModel.php
@@ -580,21 +580,18 @@ class ItemModel
             emitItemSyslog($SETTINGS, $newID, $label, 'at_creation', $username);
 
             return $response;
-        } catch (InvalidArgumentException | UnexpectedValueException $e) {
+        } catch (Throwable $e) {
             if ($transactionStarted === true) {
                 DB::rollback();
                 resetItemRevisionMemo();
             }
 
-            return [
-                'error' => true,
-                'error_header' => 'HTTP/1.1 422 Unprocessable Entity',
-                'error_message' => $e->getMessage(),
-            ];
-        } catch (Throwable $e) {
-            if ($transactionStarted === true) {
-                DB::rollback();
-                resetItemRevisionMemo();
+            if ($e instanceof InvalidArgumentException || $e instanceof UnexpectedValueException) {
+                return [
+                    'error' => true,
+                    'error_header' => 'HTTP/1.1 422 Unprocessable Entity',
+                    'error_message' => $e->getMessage(),
+                ];
             }
 
             error_log(

--- a/app/api/inc/bootstrap.php
+++ b/app/api/inc/bootstrap.php
@@ -46,6 +46,7 @@ require API_ROOT_PATH . "/Controller/Api/BaseController.php";
 
 // include the use model file
 require API_ROOT_PATH . "/Model/UserModel.php";
+require API_ROOT_PATH . "/Model/ApiIdempotencyModel.php";
 require API_ROOT_PATH . "/Model/ItemModel.php";
 require API_ROOT_PATH . "/Model/FolderModel.php";
 require API_ROOT_PATH . "/Model/FolderAccessModel.php";

--- a/app/api/index.php
+++ b/app/api/index.php
@@ -63,8 +63,8 @@ if ($corsOriginsRaw === '') {
 header('Content-Type: application/json; charset=UTF-8');
 header('Access-Control-Allow-Methods: POST, GET, PUT, DELETE');
 header('Access-Control-Max-Age: 3600');
-header('Access-Control-Allow-Headers: Content-Type, Access-Control-Allow-Headers, Authorization, X-Requested-With');
-header('Access-Control-Expose-Headers: X-Api-Version, X-Total-Count, Location, Allow');
+header('Access-Control-Allow-Headers: Content-Type, Access-Control-Allow-Headers, Authorization, X-Requested-With, Idempotency-Key');
+header('Access-Control-Expose-Headers: X-Api-Version, X-Total-Count, Location, Allow, Idempotency-Replayed, Retry-After');
 header('X-Content-Type-Options: nosniff');
 header('X-Frame-Options: DENY');
 header('Referrer-Policy: no-referrer');

--- a/app/api/openapi.json
+++ b/app/api/openapi.json
@@ -552,6 +552,10 @@
                                                     "revision": {
                                                         "type": "integer"
                                                     },
+                                                    "revision_changed_at": {
+                                                        "type": "integer",
+                                                        "description": "Unix UTC timestamp in seconds of the winning journal revision."
+                                                    },
                                                     "reason": {
                                                         "type": "string",
                                                         "enum": [
@@ -713,6 +717,13 @@
                                         "revision": {
                                             "type": "integer",
                                             "description": "Revision of the item after the update"
+                                        },
+                                        "revision_changed_at": {
+                                            "type": [
+                                                "integer",
+                                                "null"
+                                            ],
+                                            "description": "Unix UTC timestamp in seconds paired with the returned revision; null when the date is unknown."
                                         }
                                     }
                                 }
@@ -1189,6 +1200,13 @@
                         "type": "integer",
                         "description": "Monotonic revision of the item, bumped on every content change. Compare it against a cached copy to detect staleness; the larger value is the newer one."
                     },
+                    "revision_changed_at": {
+                        "type": [
+                            "integer",
+                            "null"
+                        ],
+                        "description": "Unix UTC timestamp in seconds paired with revision. It changes on functional content revisions, never on reads or ciphertext-only rewrites; null means the date is unknown."
+                    },
                     "label": {
                         "type": "string"
                     },
@@ -1296,6 +1314,13 @@
                     "revision": {
                         "type": "integer",
                         "description": "Monotonic revision of the item, bumped on every content change. Compare it against a cached copy to detect staleness; the larger value is the newer one."
+                    },
+                    "revision_changed_at": {
+                        "type": [
+                            "integer",
+                            "null"
+                        ],
+                        "description": "Unix UTC timestamp in seconds paired with revision; null when the date is unknown."
                     },
                     "label": {
                         "type": "string"
@@ -1637,6 +1662,13 @@
                     "revision": {
                         "type": "integer",
                         "description": "Revision allocated to the new item"
+                    },
+                    "revision_changed_at": {
+                        "type": [
+                            "integer",
+                            "null"
+                        ],
+                        "description": "Unix UTC timestamp in seconds paired with the allocated revision; null when the date is unknown."
                     }
                 }
             },

--- a/app/api/openapi.json
+++ b/app/api/openapi.json
@@ -628,7 +628,12 @@
             "post": {
                 "operationId": "itemCreate",
                 "summary": "Create a new item",
-                "description": "All listed fields must be present, even if empty.",
+                "description": "All listed fields must be present, even if empty. Idempotency-Key is optional; within its 90-day replay window the same user, key and canonical creation intent return the original 201 response without repeating side effects.",
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/IdempotencyKey"
+                    }
+                ],
                 "requestBody": {
                     "required": true,
                     "content": {
@@ -648,6 +653,9 @@
                                 "schema": {
                                     "type": "string"
                                 }
+                            },
+                            "Idempotency-Replayed": {
+                                "$ref": "#/components/headers/Idempotency-Replayed"
                             }
                         },
                         "content": {
@@ -669,6 +677,9 @@
                     },
                     "405": {
                         "$ref": "#/components/responses/MethodNotAllowed"
+                    },
+                    "409": {
+                        "$ref": "#/components/responses/Conflict"
                     },
                     "422": {
                         "$ref": "#/components/responses/UnprocessableEntity"
@@ -764,23 +775,66 @@
             "delete": {
                 "operationId": "itemDelete",
                 "summary": "Soft-delete an item",
+                "description": "The optional revision is an optimistic-concurrency precondition. Idempotency-Key makes a successful deletion replayable for 90 days without allocating another revision or repeating side effects.",
                 "parameters": [
+                    {
+                        "$ref": "#/components/parameters/IdempotencyKey"
+                    },
                     {
                         "name": "id",
                         "in": "query",
                         "required": true,
                         "schema": {
-                            "type": "integer"
+                            "type": "integer",
+                            "minimum": 1
+                        }
+                    },
+                    {
+                        "name": "revision",
+                        "in": "query",
+                        "required": false,
+                        "description": "Current item revision expected by the caller. A mismatch returns 409 before any mutation.",
+                        "schema": {
+                            "type": "integer",
+                            "minimum": 0,
+                            "maximum": 4294967295
                         }
                     }
                 ],
                 "responses": {
                     "200": {
                         "description": "Item deleted",
+                        "headers": {
+                            "Idempotency-Replayed": {
+                                "$ref": "#/components/headers/Idempotency-Replayed"
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "type": "object"
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "type": "boolean"
+                                        },
+                                        "message": {
+                                            "type": "string"
+                                        },
+                                        "item_id": {
+                                            "type": "integer"
+                                        },
+                                        "revision": {
+                                            "type": "integer",
+                                            "description": "Deletion revision exposed by item/changes"
+                                        },
+                                        "revision_changed_at": {
+                                            "type": [
+                                                "integer",
+                                                "null"
+                                            ],
+                                            "description": "Unix UTC timestamp paired with the deletion revision"
+                                        }
+                                    }
                                 }
                             }
                         }
@@ -796,6 +850,9 @@
                     },
                     "405": {
                         "$ref": "#/components/responses/MethodNotAllowed"
+                    },
+                    "409": {
+                        "$ref": "#/components/responses/Conflict"
                     },
                     "500": {
                         "$ref": "#/components/responses/InternalError"
@@ -1157,6 +1214,18 @@
                     "type": "integer",
                     "minimum": 0
                 }
+            },
+            "IdempotencyKey": {
+                "name": "Idempotency-Key",
+                "in": "header",
+                "required": false,
+                "description": "Opaque 1-128 character visible-ASCII key, scoped to the authenticated user and API operation. Raw keys are never persisted.",
+                "schema": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 128,
+                    "pattern": "^[!-~]+$"
+                }
             }
         },
         "headers": {
@@ -1164,6 +1233,15 @@
                 "description": "Total number of matching entries before pagination",
                 "schema": {
                     "type": "integer"
+                }
+            },
+            "Idempotency-Replayed": {
+                "description": "Present with value true when the stored response was replayed without executing the mutation.",
+                "schema": {
+                    "type": "string",
+                    "enum": [
+                        "true"
+                    ]
                 }
             }
         },

--- a/app/scripts/task_maintenance_clean_orphan_objects.php
+++ b/app/scripts/task_maintenance_clean_orphan_objects.php
@@ -64,14 +64,16 @@ $integritySummary = cleanOrphanObjectsAndScanIntegrity();
 $prunedRevisions = pruneItemRevisionsJournal(
     offlineSyncResolveWindowDays($SETTINGS['offline_sync_window_days'] ?? null)
 );
+$prunedIdempotencyRecords = pruneApiIdempotencyRecords();
 
 // log end
 doLog('completed', '', 1, $logID);
 
 echo sprintf(
-    'Items integrity scan completed: %d active corrupted item(s). %d journal entry(ies) pruned.',
+    'Items integrity scan completed: %d active corrupted item(s). %d journal entry(ies) pruned. %d API idempotency record(s) pruned.',
     (int) ($integritySummary['count'] ?? 0),
-    $prunedRevisions
+    $prunedRevisions,
+    $prunedIdempotencyRecords
 );
 
 /**

--- a/app/sources/item_revisions_logic.php
+++ b/app/sources/item_revisions_logic.php
@@ -241,6 +241,35 @@ function itemRevisionDedupeScan(array $rows): array
 }
 
 /**
+ * Normalize the revision metadata read from an item row.
+ *
+ * Revision 0 predates revision tracking and therefore never has a reliable timestamp.
+ *
+ * @param array<string, mixed>|null $row Item row containing revision metadata
+ *
+ * @return array{revision: int, revision_changed_at: int|null}
+ */
+function itemRevisionMetadataFromRow(?array $row): array
+{
+    if ($row === null) {
+        return [
+            'revision' => 0,
+            'revision_changed_at' => null,
+        ];
+    }
+
+    $revision = (int) ($row['revision'] ?? 0);
+    $changedAt = $row['revision_changed_at'] ?? null;
+
+    return [
+        'revision' => $revision,
+        'revision_changed_at' => $revision > 0 && $changedAt !== null
+            ? (int) $changedAt
+            : null,
+    ];
+}
+
+/**
  * Decide what a client must do with an item that changed.
  *
  * @param int                 $itemId          Item id

--- a/app/sources/item_update_logic.php
+++ b/app/sources/item_update_logic.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Teampass - a collaborative passwords manager.
+ * ---
+ * This file is part of the TeamPass project.
+ *
+ * TeamPass is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * TeamPass is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Certain components of this file may be under different licenses. For
+ * details, see the `licenses` directory or individual file headers.
+ * ---
+ * DB-free decisions used by the API item update path.
+ *
+ * @file      item_update_logic.php
+ * @author    Nils Laumaillé (nils@teampass.net)
+ * @copyright 2009-2026 Teampass.net
+ * @license   GPL-3.0
+ * @see       https://www.teampass.net
+ */
+
+/**
+ * Tell whether a submitted password differs from the current cleartext value.
+ *
+ * @param string $currentPassword   Current server-side cleartext password
+ * @param string $submittedPassword New password received by the API
+ *
+ * @return bool True only for an actual password change
+ */
+function itemPasswordHasChanged(string $currentPassword, string $submittedPassword): bool
+{
+    return hash_equals($currentPassword, $submittedPassword) === false;
+}

--- a/app/sources/main.functions.php
+++ b/app/sources/main.functions.php
@@ -2892,8 +2892,11 @@ function logEvents(
  * @param string $encryption_type Encryption on
  * @param string $time Encryption Time
  * @param string $old_value       Old value
+ * @param bool   $emitSyslog      Emit the external syslog datagram immediately
+ * @param bool   $failOnDatabaseError Re-throw audit/revision failures for transactional callers
  * 
  * @return void
+ * @throws Throwable When strict database-error handling is requested
  */
 function logItems(
     array $SETTINGS,
@@ -2905,7 +2908,9 @@ function logItems(
     ?string $raison = null,
     ?string $encryption_type = null,
     ?string $time = null,
-    ?string $old_value = null
+    ?string $old_value = null,
+    bool $emitSyslog = true,
+    bool $failOnDatabaseError = false
 ): void {
     // Load class DB
     loadClasses('DB');
@@ -2971,6 +2976,9 @@ function logItems(
             ]
         );
     } catch (\Throwable $e) {
+        if ($failOnDatabaseError === true) {
+            throw $e;
+        }
         // Logging must never break API or UI flows
         return;
     }
@@ -2989,6 +2997,9 @@ function logItems(
                 'last_item_change'
             );
         } catch (\Throwable $e) {
+            if ($failOnDatabaseError === true) {
+                throw $e;
+            }
             // ignore logging-related DB errors
         }
     }
@@ -2997,11 +3008,14 @@ function logItems(
     // point every content change already goes through, satellites included: custom fields,
     // tags, attachments and OTP all log at_modification with a dedicated reason.
     if (itemRevisionShouldBump($action) === true) {
-        bumpItemRevision(
+        $revision = bumpItemRevision(
             $item_id,
             itemRevisionJournalAction($action, $raison),
             $id_user
         );
+        if ($failOnDatabaseError === true && $revision <= 0) {
+            throw new RuntimeException('Unable to allocate the item revision.');
+        }
     }
 
     // Prepare reason for syslog: remove internal source marker if present
@@ -3011,39 +3025,63 @@ function logItems(
         $raisonForSyslog = $parsedReason['reason'] === '' ? null : $parsedReason['reason'];
     }
 
-    // SYSLOG
-    if (isset($SETTINGS['syslog_enable']) === true && (int) $SETTINGS['syslog_enable'] === 1) {
-        // Extract reason
-        $attribute = is_null($raisonForSyslog) === true ? [''] : explode(' : ', $raisonForSyslog);
-        // Get item info if not known
-        if (empty($item_label) === true) {
-            try {
-                $dataItem = DB::queryFirstRow(
-                    'SELECT id, id_tree, label
-                    FROM ' . prefixTable('items') . '
-                    WHERE id = %i',
-                    $item_id
-                );
-                $item_label = $dataItem['label'];
-            } catch (\Throwable $e) {
-                // ignore logging-related DB errors
-            }
+    if ($emitSyslog === true) {
+        emitItemSyslog($SETTINGS, $item_id, $item_label, $action, $login, $raisonForSyslog);
+    }
+
+    // send notification if enabled
+    //notifyOnChange($item_id, $action, $SETTINGS);
+}
+
+/**
+ * Emit the external syslog representation of an item audit event.
+ *
+ * Kept separate from the database audit so transactional API mutations can commit first. A
+ * failed datagram must never turn an already committed item mutation into an HTTP failure.
+ *
+ * @param array<string, mixed> $SETTINGS TeamPass settings
+ * @param int $itemId Item identifier
+ * @param string $itemLabel Item label, resolved from the database when empty
+ * @param string $action Audit action
+ * @param string|null $login Actor login
+ * @param string|null $reason Audit reason without the API source marker
+ * @return void
+ */
+function emitItemSyslog(
+    array $SETTINGS,
+    int $itemId,
+    string $itemLabel,
+    string $action,
+    ?string $login = null,
+    ?string $reason = null
+): void {
+    if (isset($SETTINGS['syslog_enable']) === false || (int) $SETTINGS['syslog_enable'] !== 1) {
+        return;
+    }
+
+    try {
+        $attribute = $reason === null ? [''] : explode(' : ', $reason);
+        if ($itemLabel === '') {
+            $dataItem = DB::queryFirstRow(
+                'SELECT label FROM ' . prefixTable('items') . ' WHERE id = %i',
+                $itemId
+            );
+            $itemLabel = is_array($dataItem) ? (string) ($dataItem['label'] ?? '') : '';
         }
 
         send_syslog(
             'action=' . str_replace('at_', '', $action) .
                 ' attribute=' . str_replace('at_', '', $attribute[0]) .
-                ' itemno=' . $item_id .
-                ' user=' . (is_null($login) === true ? '' : addslashes((string) $login)) .
-                ' itemname="' . addslashes($item_label) . '"',
+                ' itemno=' . $itemId .
+                ' user=' . ($login === null ? '' : addslashes($login)) .
+                ' itemname="' . addslashes($itemLabel) . '"',
             $SETTINGS['syslog_host'],
             $SETTINGS['syslog_port'],
             'teampass'
         );
+    } catch (\Throwable $exception) {
+        error_log('[API] Unable to emit item syslog event: ' . $exception->getMessage());
     }
-
-    // send notification if enabled
-    //notifyOnChange($item_id, $action, $SETTINGS);
 }
 
 /**
@@ -3201,6 +3239,61 @@ function pruneItemRevisionsJournal(int $windowDays): int
 
         return (int) DB::affectedRows();
     } catch (\Throwable $e) {
+        return 0;
+    }
+}
+
+/**
+ * Remove expired API idempotency metadata without touching an active processing lease.
+ *
+ * The replay window is deliberately finite (90 days). A stale processing row is eligible
+ * only after both its lease and replay window expired, so an in-flight request is never removed.
+ * Item links are cleared first to avoid leaving technical dangling identifiers.
+ *
+ * @return int Number of idempotency records removed
+ */
+function pruneApiIdempotencyRecords(): int
+{
+    $now = time();
+    $transactionStarted = false;
+
+    try {
+        loadClasses('DB');
+        DB::startTransaction();
+        $transactionStarted = true;
+
+        DB::query(
+            'UPDATE ' . prefixTable('items') . ' AS i
+             INNER JOIN ' . prefixTable('api_idempotency') . ' AS a
+                ON a.id = i.api_idempotency_id
+             SET i.api_idempotency_id = NULL
+             WHERE a.expires_at < %i
+               AND (a.status = %s OR (a.status = %s AND a.locked_until < %i))',
+            $now,
+            'completed',
+            'processing',
+            $now
+        );
+
+        DB::delete(
+            prefixTable('api_idempotency'),
+            'expires_at < %i AND (status = %s OR (status = %s AND locked_until < %i))',
+            $now,
+            'completed',
+            'processing',
+            $now
+        );
+        $removed = (int) DB::affectedRows();
+
+        DB::commit();
+        $transactionStarted = false;
+
+        return $removed;
+    } catch (Throwable $exception) {
+        if ($transactionStarted === true) {
+            DB::rollback();
+        }
+
         return 0;
     }
 }

--- a/app/sources/main.functions.php
+++ b/app/sources/main.functions.php
@@ -3136,6 +3136,8 @@ function bumpItemRevision(
             $folderId = getItemFolderIdFromDb($itemId);
         }
 
+        $changedAt = time();
+
         DB::insert(
             prefixTable('items_revisions'),
             [
@@ -3144,7 +3146,7 @@ function bumpItemRevision(
                 'previous_folder_id' => $previousFolderId === null ? 0 : (int) $previousFolderId,
                 'action' => $action,
                 'changed_by' => $userId,
-                'changed_at' => time(),
+                'changed_at' => $changedAt,
             ]
         );
         $revision = (int) DB::insertId();
@@ -3153,7 +3155,10 @@ function bumpItemRevision(
         // journal. A purge leaves no row to update, which is expected.
         DB::update(
             prefixTable('items'),
-            ['revision' => $revision],
+            [
+                'revision' => $revision,
+                'revision_changed_at' => $changedAt,
+            ],
             'id = %i',
             $itemId
         );
@@ -3211,21 +3216,35 @@ function pruneItemRevisionsJournal(int $windowDays): int
  */
 function getItemRevision(int $itemId): int
 {
+    return getItemRevisionMetadata($itemId)['revision'];
+}
+
+/**
+ * Read the current revision and its functional change timestamp.
+ *
+ * @param int $itemId Item id
+ *
+ * @return array{revision: int, revision_changed_at: int|null}
+ */
+function getItemRevisionMetadata(int $itemId): array
+{
     if ($itemId <= 0) {
-        return 0;
+        return itemRevisionMetadataFromRow(null);
     }
 
     try {
         loadClasses('DB');
 
         $row = DB::queryFirstRow(
-            'SELECT revision FROM ' . prefixTable('items') . ' WHERE id = %i',
+            'SELECT revision, revision_changed_at
+            FROM ' . prefixTable('items') . '
+            WHERE id = %i',
             $itemId
         );
 
-        return $row === null ? 0 : (int) $row['revision'];
+        return itemRevisionMetadataFromRow($row);
     } catch (\Throwable $e) {
-        return 0;
+        return itemRevisionMetadataFromRow(null);
     }
 }
 

--- a/docs/api/api-basic.md
+++ b/docs/api/api-basic.md
@@ -553,7 +553,13 @@ curl -X GET "https://your-teampass.com/api/index.php/item/getOtp?id=123" \
 | **Method** | POST |
 | **URL** | `<Teampass URL>/api/index.php/item/create` |
 | **Content-Type** | `application/json` |
-| **Headers** | `Authorization: Bearer <token>` |
+| **Headers** | `Authorization: Bearer <token>`; optional `Idempotency-Key: <opaque-key>` |
+
+`Idempotency-Key` accepts 1–128 visible ASCII characters without spaces. It is scoped to the
+authenticated user and this operation. TeamPass keeps the completed result for 90 days: retrying
+the same functional request returns the original `201`, `Location` and body without creating
+anything again, and adds `Idempotency-Replayed: true`. Reusing the key with a changed payload
+returns `409`. A duplicate request still processing returns `409` and `Retry-After`.
 
 **Request Body (JSON):**
 ```json
@@ -607,10 +613,12 @@ curl -X GET "https://your-teampass.com/api/index.php/item/getOtp?id=123" \
 
 | Code | Description |
 | ---- | ----------- |
-| 200 | Item created successfully |
-| 400 | Missing or invalid parameters |
+| 201 | Item created successfully (including an idempotent replay) |
+| 400 | Missing/invalid parameters or invalid `Idempotency-Key` |
 | 401 | Invalid token or expired session |
 | 403 | Create permission denied or access denied to folder |
+| 409 | Key already used with another payload, or an identical request is still processing |
+| 422 | Item validation failed |
 | 500 | Server error |
 
 **Example:**
@@ -618,6 +626,7 @@ curl -X GET "https://your-teampass.com/api/index.php/item/getOtp?id=123" \
 curl -X POST "https://your-teampass.com/api/index.php/item/create" \
   -H "Authorization: Bearer YOUR_JWT_TOKEN" \
   -H "Content-Type: application/json" \
+  -H "Idempotency-Key: 550e8400-e29b-41d4-a716-446655440000" \
   -d '{
     "label": "My new item",
     "folder_id": 5,
@@ -631,6 +640,11 @@ curl -X POST "https://your-teampass.com/api/index.php/item/create" \
     "icon": "fa-solid fa-key"
   }'
 ```
+
+Run the same command again to replay its result. Keeping the key but changing, for example,
+`label` or `password` demonstrates the `409` key/payload conflict. TeamPass stores only
+server-secret HMACs of the key and functional payload, never the raw key, body, password, TOTP
+secret or custom-field values.
 
 ---
 
@@ -747,51 +761,52 @@ curl -X PUT "https://your-teampass.com/api/index.php/item/update" \
 | ---- | ----------- |
 | **Endpoint** | `item/delete` |
 | **Method** | DELETE |
-| **URL** | `<Teampass URL>/api/index.php/item/delete` |
-| **Content-Type** | `application/json` |
-| **Headers** | `Authorization: Bearer <token>` |
+| **URL** | `<Teampass URL>/api/index.php/item/delete?id=<id>&revision=<revision>` |
+| **Content-Type** | Not required (parameters are in the query string) |
+| **Headers** | `Authorization: Bearer <token>`; optional `Idempotency-Key: <opaque-key>` |
 
-**Request Body (JSON):**
-```json
-{
-  "id": 123
-}
-```
-
-**Body Parameters:**
+**Query Parameters:**
 
 | Field | Type | Required | Description |
 | ----- | ---- | -------- | ----------- |
 | `id` | integer | ✅ | Item ID to delete |
+| `revision` | integer | ❌ | Current unsigned item revision. A mismatch returns `409` before any mutation. Omitting it retains the historical last-writer-wins behavior. |
+
+The optional idempotency key uses the same syntax, user/operation scope and 90-day window as
+create. Its fingerprint includes both `id` and the optional `revision`. A replay returns the
+original success body plus `Idempotency-Replayed: true` without a second delete, audit, revision,
+cache update or WebSocket event. It therefore cannot delete an item again after a later restore.
 
 **Response (success):**
 ```json
 {
   "error": false,
   "message": "Item deleted successfully",
-  "item_id": "123"
+  "item_id": 123,
+  "revision": 4128,
+  "revision_changed_at": 1787563490
 }
 ```
+
+The revision/date pair is the delete tombstone subsequently returned by `GET /item/changes`.
 
 **Response Codes:**
 
 | Code | Description |
 | ---- | ----------- |
 | 200 | Item deleted successfully |
-| 400 | Missing ID or inconsistent data |
+| 400 | Missing ID, invalid revision or invalid idempotency key |
 | 403 | Delete permission denied or access denied — including a folder granted as `R`, `ND` or `NDNE` (check `can_delete` on [`folder/writableFolders`](#writable-folders)) |
 | 404 | Item not found |
-| 422 | HTTP method not supported (must be DELETE) |
+| 405 | HTTP method not supported (must be DELETE) |
+| 409 | Stale revision, LAPR protection, key/request conflict, or identical request still processing |
 | 500 | Server error |
 
 **Example:**
 ```bash
-curl -X DELETE "https://your-teampass.com/api/index.php/item/delete" \
+curl -X DELETE "https://your-teampass.com/api/index.php/item/delete?id=123&revision=4127" \
   -H "Authorization: Bearer YOUR_JWT_TOKEN" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "id": 123
-  }'
+  -H "Idempotency-Key: 8fe52f47-6f72-4a1a-b0d8-68a01c884d41"
 ```
 
 ---

--- a/docs/api/api-basic.md
+++ b/docs/api/api-basic.md
@@ -265,6 +265,7 @@ curl -X GET "https://your-teampass.com/api/index.php/item/inFolders?folders=[1,2
 {
   "id": 2053,
   "revision": 4127,
+  "revision_changed_at": 1787563378,
   "label": "new object for #3500 v3",
   "description": "<p>bla bla</p>",
   "pwd": "SK^dsf123s_6A}]V$t^]",
@@ -287,6 +288,7 @@ curl -X GET "https://your-teampass.com/api/index.php/item/inFolders?folders=[1,2
 | ----- | ---- | ----------- |
 | `id` | integer | Unique item ID |
 | `revision` | integer | Monotonic revision, bumped on every content change of the item or its custom fields, tags, attachments and OTP. Compare it against a cached copy to detect staleness; the larger value is the newer one. `0` means the item has not changed since revision tracking was installed. |
+| `revision_changed_at` | integer or null | Unix UTC timestamp in seconds paired with `revision`. It changes on functional content revisions, never on reads or ciphertext-only rewrites. `null` means the exact date is unknown. |
 | `label` | string | Item label |
 | `description` | string | Description (may contain HTML) |
 | `pwd` | string | Password (decrypted according to rights) |
@@ -447,6 +449,8 @@ curl -X GET "https://your-teampass.com/api/index.php/item/get?description=%25ser
 [
   {
     "id": 123,
+    "revision": 4127,
+    "revision_changed_at": 1787563378,
     "label": "Example Login",
     "login": "user@example.com",
     "url": "https://example.com",
@@ -461,6 +465,8 @@ curl -X GET "https://your-teampass.com/api/index.php/item/get?description=%25ser
 | Field | Type | Description |
 | ----- | ---- | ----------- |
 | `id` | integer | Item ID |
+| `revision` | integer | Monotonic content revision |
+| `revision_changed_at` | integer or null | Unix UTC timestamp in seconds paired with `revision`; `null` when unknown |
 | `label` | string | Label |
 | `login` | string | Login identifier |
 | `url` | string | URL |
@@ -591,7 +597,9 @@ curl -X GET "https://your-teampass.com/api/index.php/item/getOtp?id=123" \
 {
   "error": false,
   "message": "Item created successfully",
-  "newId": "658"
+  "newId": 658,
+  "revision": 4127,
+  "revision_changed_at": 1787563378
 }
 ```
 
@@ -679,9 +687,16 @@ curl -X POST "https://your-teampass.com/api/index.php/item/create" \
 {
   "error": false,
   "message": "Item updated successfully",
-  "item_id": "123"
+  "item_id": 123,
+  "revision": 4128,
+  "revision_changed_at": 1787563378
 }
 ```
+
+When `password` is present, TeamPass compares it with the current cleartext value server-side.
+Resending the same value is a password no-op: by itself it does not rewrite the ciphertext,
+redistribute sharekeys, create a password-history entry, or allocate a revision. A real change stores the previous password
+encrypted in the existing `at_pw` history; the client never sends or receives that previous value.
 
 **Response Codes:**
 
@@ -840,10 +855,10 @@ curl -X GET "https://your-teampass.com/api/index.php/item/allTags" \
   "has_more": false,
   "full_sync_required": false,
   "changed": [
-    { "id": 77, "revision": 12340, "label": "Prod database", "pwd": "…", "fields": [] }
+    { "id": 77, "revision": 12340, "revision_changed_at": 1787563378, "label": "Prod database", "pwd": "…", "fields": [] }
   ],
   "removed": [
-    { "id": 91, "revision": 12331, "reason": "deleted" }
+    { "id": 91, "revision": 12331, "revision_changed_at": 1787563100, "reason": "deleted" }
   ]
 }
 ```
@@ -856,7 +871,10 @@ curl -X GET "https://your-teampass.com/api/index.php/item/allTags" \
 | `has_more` | boolean | More changes are waiting — call again with the returned cursor |
 | `full_sync_required` | boolean | The cursor cannot be served: rebuild the cache and adopt the returned cursor |
 | `changed` | array | Items to upsert, same shape as `item/get` |
-| `removed` | array | Items to drop, with `id`, `revision` and `reason` |
+| `removed` | array | Items to drop, with `id`, `revision`, `revision_changed_at` and `reason` |
+
+The `revision` and `revision_changed_at` values always come from the same winning change. For a
+tombstone, the timestamp comes from the journal because a permanently deleted item has no row left.
 
 `reason` is one of `deleted` (soft deleted), `purged` (permanently removed) or `out_of_scope` (the item still exists but the caller can no longer read it, typically after a move into a folder they have no access to).
 

--- a/public/install/install-steps/install.js
+++ b/public/install/install-steps/install.js
@@ -324,7 +324,8 @@ function performStep5() {
         { id: 'check76', action: 'lapr_policies' },
         { id: 'check77', action: 'lapr_audit_log' },
         { id: 'check78', action: 'lapr_rate_limit' },
-        { id: 'check79', action: 'items_revisions' }
+        { id: 'check79', action: 'items_revisions' },
+        { id: 'check80', action: 'api_idempotency' }
     ];
     
     let errorOccurred = false; // Variable to track errors

--- a/public/install/install-steps/run.step5.php
+++ b/public/install/install-steps/run.step5.php
@@ -434,10 +434,12 @@ class DatabaseInstaller
             `hibp_checked_at` varchar(30) NULL DEFAULT NULL,
             `revision` INT UNSIGNED NOT NULL DEFAULT '0',
             `revision_changed_at` BIGINT UNSIGNED NULL DEFAULT NULL,
+            `api_idempotency_id` BIGINT UNSIGNED NULL DEFAULT NULL,
             PRIMARY KEY (`id`),
             KEY `restricted_inactif_idx` (`restricted_to`,`inactif`),
             INDEX items_perso_id_idx (`perso`, `id`),
-            INDEX idx_items_tree_inactif_deleted (`id_tree`, `inactif`, `deleted_at`)
+            INDEX idx_items_tree_inactif_deleted (`id_tree`, `inactif`, `deleted_at`),
+            UNIQUE KEY `uq_items_api_idempotency` (`api_idempotency_id`)
             ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;"
         );
     }
@@ -2391,6 +2393,34 @@ class DatabaseInstaller
         KEY `idx_items_revisions_changed_at` (`changed_at`)
     ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
     COMMENT='Item change journal feeding the offline synchronization delta feed'"
+        );
+    }
+
+    // Create table api_idempotency
+    private function api_idempotency()
+    {
+        DB::query(
+            'CREATE TABLE IF NOT EXISTS `' . $this->inputData['tablePrefix'] . "api_idempotency` (
+        `id` BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+        `user_id` INT UNSIGNED NOT NULL,
+        `operation` VARCHAR(50) NOT NULL,
+        `key_hash` CHAR(64) NOT NULL,
+        `request_fingerprint` CHAR(64) NOT NULL,
+        `status` ENUM('processing', 'completed') NOT NULL DEFAULT 'processing',
+        `owner_token_hash` CHAR(64) NOT NULL,
+        `resource_id` INT UNSIGNED NULL DEFAULT NULL,
+        `http_status` SMALLINT UNSIGNED NULL DEFAULT NULL,
+        `response_body` TEXT NULL DEFAULT NULL,
+        `created_at` BIGINT UNSIGNED NOT NULL,
+        `updated_at` BIGINT UNSIGNED NOT NULL,
+        `locked_until` BIGINT UNSIGNED NOT NULL DEFAULT '0',
+        `expires_at` BIGINT UNSIGNED NOT NULL,
+        PRIMARY KEY (`id`),
+        UNIQUE KEY `uq_api_idempotency_identity` (`user_id`, `operation`, `key_hash`),
+        KEY `idx_api_idempotency_cleanup` (`status`, `expires_at`, `locked_until`),
+        KEY `idx_api_idempotency_resource` (`operation`, `resource_id`)
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+    COMMENT='Replay-safe metadata for idempotent API mutations'"
         );
     }
 

--- a/public/install/install-steps/run.step5.php
+++ b/public/install/install-steps/run.step5.php
@@ -433,6 +433,7 @@ class DatabaseInstaller
             `hibp_count` int NOT NULL DEFAULT '0',
             `hibp_checked_at` varchar(30) NULL DEFAULT NULL,
             `revision` INT UNSIGNED NOT NULL DEFAULT '0',
+            `revision_changed_at` BIGINT UNSIGNED NULL DEFAULT NULL,
             PRIMARY KEY (`id`),
             KEY `restricted_inactif_idx` (`restricted_to`,`inactif`),
             INDEX items_perso_id_idx (`perso`, `id`),

--- a/public/install/upgrade_run_3.2.2.php
+++ b/public/install/upgrade_run_3.2.2.php
@@ -385,6 +385,19 @@ if ($res === false) {
     exit();
 }
 
+// Durable link between an idempotent create reservation and the item it produced.
+// NULL keeps every historical and non-idempotent creation unchanged.
+$res = addColumnIfNotExist(
+    $pre . 'items',
+    'api_idempotency_id',
+    'BIGINT UNSIGNED NULL DEFAULT NULL'
+);
+if ($res === false) {
+    echo '[{"finish":"1", "msg":"", "error":"Error adding api_idempotency_id to items table: ' . addslashes(mysqli_error($db_link)) . '"}]';
+    mysqli_close($db_link);
+    exit();
+}
+
 // Item change journal. Its AUTO_INCREMENT primary key is the globally monotonic
 // revision sequence, and its rows are the only tombstone left once an item row is
 // hard deleted or leaves the caller's visible folders.
@@ -408,6 +421,58 @@ if ($res === false) {
     echo '[{"finish":"1", "msg":"", "error":"Error creating items_revisions table: ' . addslashes(mysqli_error($db_link)) . '"}]';
     mysqli_close($db_link);
     exit();
+}
+
+// Persistent API idempotency state. Only HMACs and replay-safe response metadata are stored;
+// request bodies, raw keys and credential values never enter this table.
+$res = mysqli_query(
+    $db_link,
+    'CREATE TABLE IF NOT EXISTS `' . $pre . "api_idempotency` (
+        `id` BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+        `user_id` INT UNSIGNED NOT NULL,
+        `operation` VARCHAR(50) NOT NULL,
+        `key_hash` CHAR(64) NOT NULL,
+        `request_fingerprint` CHAR(64) NOT NULL,
+        `status` ENUM('processing', 'completed') NOT NULL DEFAULT 'processing',
+        `owner_token_hash` CHAR(64) NOT NULL,
+        `resource_id` INT UNSIGNED NULL DEFAULT NULL,
+        `http_status` SMALLINT UNSIGNED NULL DEFAULT NULL,
+        `response_body` TEXT NULL DEFAULT NULL,
+        `created_at` BIGINT UNSIGNED NOT NULL,
+        `updated_at` BIGINT UNSIGNED NOT NULL,
+        `locked_until` BIGINT UNSIGNED NOT NULL DEFAULT '0',
+        `expires_at` BIGINT UNSIGNED NOT NULL,
+        PRIMARY KEY (`id`),
+        UNIQUE KEY `uq_api_idempotency_identity` (`user_id`, `operation`, `key_hash`),
+        KEY `idx_api_idempotency_cleanup` (`status`, `expires_at`, `locked_until`),
+        KEY `idx_api_idempotency_resource` (`operation`, `resource_id`)
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+    COMMENT='Replay-safe metadata for idempotent API mutations'"
+);
+if ($res === false) {
+    echo '[{"finish":"1", "msg":"", "error":"Error creating api_idempotency table: ' . addslashes(mysqli_error($db_link)) . '"}]';
+    mysqli_close($db_link);
+    exit();
+}
+
+// Add the nullable one-to-one create link idempotently on upgraded databases.
+$indexExists = mysqli_fetch_array(mysqli_query(
+    $db_link,
+    "SELECT COUNT(*) FROM INFORMATION_SCHEMA.STATISTICS
+     WHERE TABLE_SCHEMA = DATABASE()
+       AND TABLE_NAME = '" . $pre . "items'
+       AND INDEX_NAME = 'uq_items_api_idempotency'"
+));
+if (empty($indexExists[0])) {
+    $res = mysqli_query(
+        $db_link,
+        'ALTER TABLE `' . $pre . 'items` ADD UNIQUE KEY `uq_items_api_idempotency` (`api_idempotency_id`)'
+    );
+    if ($res === false) {
+        echo '[{"finish":"1", "msg":"", "error":"Error adding items idempotency index: ' . addslashes(mysqli_error($db_link)) . '"}]';
+        mysqli_close($db_link);
+        exit();
+    }
 }
 
 // Backfill only when the current item revision still has its exact journal row. Older

--- a/public/install/upgrade_run_3.2.2.php
+++ b/public/install/upgrade_run_3.2.2.php
@@ -372,6 +372,19 @@ if ($res === false) {
     exit();
 }
 
+// Durable timestamp paired with items.revision. Unlike items.updated_at, it changes only
+// when a functional content revision is allocated and survives journal pruning.
+$res = addColumnIfNotExist(
+    $pre . 'items',
+    'revision_changed_at',
+    'BIGINT UNSIGNED NULL DEFAULT NULL'
+);
+if ($res === false) {
+    echo '[{"finish":"1", "msg":"", "error":"Error adding column revision_changed_at to items table: ' . addslashes(mysqli_error($db_link)) . '"}]';
+    mysqli_close($db_link);
+    exit();
+}
+
 // Item change journal. Its AUTO_INCREMENT primary key is the globally monotonic
 // revision sequence, and its rows are the only tombstone left once an item row is
 // hard deleted or leaves the caller's visible folders.
@@ -393,6 +406,22 @@ $res = mysqli_query(
 );
 if ($res === false) {
     echo '[{"finish":"1", "msg":"", "error":"Error creating items_revisions table: ' . addslashes(mysqli_error($db_link)) . '"}]';
+    mysqli_close($db_link);
+    exit();
+}
+
+// Backfill only when the current item revision still has its exact journal row. Older
+// journal entries may already have been pruned; their timestamp is genuinely unknown.
+$res = mysqli_query(
+    $db_link,
+    'UPDATE `' . $pre . 'items` AS i
+     INNER JOIN `' . $pre . 'items_revisions` AS r
+        ON r.`item_id` = i.`id` AND r.`revision` = i.`revision`
+     SET i.`revision_changed_at` = r.`changed_at`
+     WHERE i.`revision` > 0 AND i.`revision_changed_at` IS NULL'
+);
+if ($res === false) {
+    echo '[{"finish":"1", "msg":"", "error":"Error backfilling items.revision_changed_at: ' . addslashes(mysqli_error($db_link)) . '"}]';
     mysqli_close($db_link);
     exit();
 }

--- a/tests/Unit/Api/ApiItemIdempotencyTest.php
+++ b/tests/Unit/Api/ApiItemIdempotencyTest.php
@@ -194,7 +194,10 @@ class ApiItemIdempotencyTest extends TestCase
         self::assertLessThan(strpos($create, '$this->insertNewItem('), strpos($create, 'DB::startTransaction();'));
         self::assertLessThan(strpos($create, 'DB::commit();'), strpos($create, 'completeReservation('));
         self::assertGreaterThan(strpos($create, 'DB::commit();'), strrpos($create, 'emitItemSyslog('));
-        self::assertStringNotContainsString('$e->getMessage()', $create);
+        $createLogStart = strrpos($create, 'error_log(');
+        $createLogEnd = strpos($create, ');', (int) $createLogStart);
+        $createLog = substr($create, (int) $createLogStart, (int) $createLogEnd - (int) $createLogStart);
+        self::assertStringNotContainsString('$e->getMessage()', $createLog);
 
         $deleteStart = strpos($model, 'public function deleteItem(');
         $delete = substr($model, (int) $deleteStart);
@@ -202,7 +205,10 @@ class ApiItemIdempotencyTest extends TestCase
         self::assertLessThan(strpos($delete, "'inactif' => '1'"), strpos($delete, '$expectedRevision !== null'));
         self::assertLessThan(strpos($delete, 'DB::commit();'), strpos($delete, 'completeReservation('));
         self::assertGreaterThan(strpos($delete, 'DB::commit();'), strrpos($delete, 'emitItemSyslog('));
-        self::assertStringNotContainsString('$e->getMessage()', $delete);
+        $deleteLogStart = strrpos($delete, 'error_log(');
+        $deleteLogEnd = strpos($delete, ');', (int) $deleteLogStart);
+        $deleteLog = substr($delete, (int) $deleteLogStart, (int) $deleteLogEnd - (int) $deleteLogStart);
+        self::assertStringNotContainsString('$e->getMessage()', $deleteLog);
     }
 
     public function testControllerKeepsKeysOptionalAndShortCircuitsCompletedReplays(): void

--- a/tests/Unit/Api/ApiItemIdempotencyTest.php
+++ b/tests/Unit/Api/ApiItemIdempotencyTest.php
@@ -1,0 +1,269 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../../app/api/Model/ApiIdempotencyModel.php';
+require_once __DIR__ . '/../../../app/api/Controller/Api/BaseController.php';
+require_once __DIR__ . '/../../../app/api/Controller/Api/ItemController.php';
+
+/**
+ * Behavioural and persistence-contract tests for idempotent item mutations.
+ */
+class ApiItemIdempotencyTest extends TestCase
+{
+    private ApiIdempotencyModel $model;
+
+    protected function setUp(): void
+    {
+        $this->model = new ApiIdempotencyModel('unit-test-idempotency-secret');
+    }
+
+    public function testKeyValidationAcceptsOpaqueVisibleAscii(): void
+    {
+        $key = '550e8400-e29b-41d4-a716-446655440000';
+
+        self::assertSame($key, ApiIdempotencyModel::validateKey($key));
+    }
+
+    /**
+     * @dataProvider invalidKeyProvider
+     */
+    public function testKeyValidationRejectsEmptyMalformedAndOversizedValues(string $key): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        ApiIdempotencyModel::validateKey($key);
+    }
+
+    /**
+     * @return array<string, array{string}>
+     */
+    public static function invalidKeyProvider(): array
+    {
+        return [
+            'empty' => [''],
+            'space' => ['not opaque'],
+            'control' => ["bad\nkey"],
+            'non-ascii' => ['clé'],
+            'too long' => [str_repeat('a', ApiIdempotencyModel::MAX_KEY_LENGTH + 1)],
+        ];
+    }
+
+    public function testFingerprintIgnoresObjectPropertyOrderButCoversSecrets(): void
+    {
+        $first = [
+            'label' => 'Database',
+            'password' => 'First-secret',
+            'fields' => [['id' => 4, 'value' => 'Sensitive field']],
+            'totp' => 'JBSWY3DPEHPK3PXP',
+        ];
+        $reordered = [
+            'totp' => 'JBSWY3DPEHPK3PXP',
+            'fields' => [['value' => 'Sensitive field', 'id' => 4]],
+            'password' => 'First-secret',
+            'label' => 'Database',
+        ];
+
+        $fingerprint = $this->model->fingerprint($first);
+        self::assertSame($fingerprint, $this->model->fingerprint($reordered));
+        self::assertNotSame($fingerprint, $this->model->fingerprint(array_replace($first, ['password' => 'Other-secret'])));
+        self::assertMatchesRegularExpression('/^[a-f0-9]{64}$/', $fingerprint);
+        self::assertStringNotContainsString('First-secret', $fingerprint);
+        self::assertStringNotContainsString('JBSWY3DPEHPK3PXP', $fingerprint);
+        self::assertNotSame(
+            $fingerprint,
+            (new ApiIdempotencyModel('another-server-secret'))->fingerprint($first)
+        );
+    }
+
+    public function testDeleteFingerprintCoversItemAndExpectedRevision(): void
+    {
+        $original = $this->model->fingerprint(['item_id' => 7, 'revision' => 12]);
+
+        self::assertNotSame($original, $this->model->fingerprint(['item_id' => 8, 'revision' => 12]));
+        self::assertNotSame($original, $this->model->fingerprint(['item_id' => 7, 'revision' => 13]));
+        self::assertNotSame($original, $this->model->fingerprint(['item_id' => 7, 'revision' => null]));
+    }
+
+    public function testExistingRecordStateMachineDistinguishesReplayConflictAndProcessing(): void
+    {
+        $fingerprint = $this->model->fingerprint(['item_id' => 7, 'revision' => 12]);
+        $now = 1_800_000_000;
+
+        self::assertSame(
+            ['state' => 'replay'],
+            $this->model->evaluateRecord([
+                'request_fingerprint' => $fingerprint,
+                'status' => 'completed',
+                'locked_until' => 0,
+            ], $fingerprint, $now)
+        );
+        self::assertSame(
+            ['state' => 'conflict'],
+            $this->model->evaluateRecord([
+                'request_fingerprint' => str_repeat('0', 64),
+                'status' => 'completed',
+                'locked_until' => 0,
+            ], $fingerprint, $now)
+        );
+        self::assertSame(
+            ['state' => 'processing', 'retry_after' => 20],
+            $this->model->evaluateRecord([
+                'request_fingerprint' => $fingerprint,
+                'status' => 'processing',
+                'locked_until' => $now + 20,
+            ], $fingerprint, $now)
+        );
+        self::assertSame(
+            ['state' => 'stale'],
+            $this->model->evaluateRecord([
+                'request_fingerprint' => $fingerprint,
+                'status' => 'processing',
+                'locked_until' => $now - 1,
+            ], $fingerprint, $now)
+        );
+    }
+
+    public function testDeleteRevisionParserAcceptsOmissionAndUnsignedRange(): void
+    {
+        $controller = new ItemController();
+        $method = new ReflectionMethod($controller, 'parseOptionalRevision');
+        $method->setAccessible(true);
+
+        self::assertNull($method->invoke($controller, ['id' => 1]));
+        self::assertSame(0, $method->invoke($controller, ['revision' => '0']));
+        self::assertSame(4294967295, $method->invoke($controller, ['revision' => '4294967295']));
+    }
+
+    /**
+     * @dataProvider invalidRevisionProvider
+     */
+    public function testDeleteRevisionParserRejectsMalformedValues($revision): void
+    {
+        $controller = new ItemController();
+        $method = new ReflectionMethod($controller, 'parseOptionalRevision');
+        $method->setAccessible(true);
+
+        $this->expectException(InvalidArgumentException::class);
+        $method->invoke($controller, ['revision' => $revision]);
+    }
+
+    /**
+     * @return array<string, array{mixed}>
+     */
+    public static function invalidRevisionProvider(): array
+    {
+        return [
+            'empty' => [''],
+            'negative' => ['-1'],
+            'decimal' => ['1.5'],
+            'scientific' => ['1e2'],
+            'overflow' => ['4294967296'],
+            'float' => [1.0],
+        ];
+    }
+
+    public function testSchemaScopesKeysPerUserAndOperationWithoutSecretColumns(): void
+    {
+        $install = (string) file_get_contents(__DIR__ . '/../../../public/install/install-steps/run.step5.php');
+        $upgrade = (string) file_get_contents(__DIR__ . '/../../../public/install/upgrade_run_3.2.2.php');
+
+        foreach ([$install, $upgrade] as $schema) {
+            $tableStart = strpos($schema, 'api_idempotency` (');
+            self::assertNotFalse($tableStart);
+            $tableDefinition = substr($schema, (int) $tableStart, 1800);
+
+            self::assertStringContainsString('api_idempotency', $schema);
+            self::assertStringContainsString('`user_id`, `operation`, `key_hash`', $schema);
+            self::assertStringContainsString('`request_fingerprint` CHAR(64)', $schema);
+            self::assertStringNotContainsString('`raw_key`', $tableDefinition);
+            self::assertStringNotContainsString('`request_body`', $tableDefinition);
+            self::assertStringNotContainsString('`password`', $tableDefinition);
+            self::assertStringNotContainsString('`totp_secret`', $tableDefinition);
+        }
+    }
+
+    public function testCreateAndDeleteFinalizeReplayMetadataInsideTheirMutationTransactions(): void
+    {
+        $model = (string) file_get_contents(__DIR__ . '/../../../app/api/Model/ItemModel.php');
+
+        $createStart = strpos($model, 'public function addItem(');
+        $createEnd = strpos($model, 'private function getFaviconUrl', (int) $createStart);
+        $create = substr($model, (int) $createStart, (int) $createEnd - (int) $createStart);
+        self::assertLessThan(strpos($create, '$this->insertNewItem('), strpos($create, 'DB::startTransaction();'));
+        self::assertLessThan(strpos($create, 'DB::commit();'), strpos($create, 'completeReservation('));
+        self::assertGreaterThan(strpos($create, 'DB::commit();'), strrpos($create, 'emitItemSyslog('));
+        self::assertStringNotContainsString('$e->getMessage()', $create);
+
+        $deleteStart = strpos($model, 'public function deleteItem(');
+        $delete = substr($model, (int) $deleteStart);
+        self::assertLessThan(strpos($delete, "'inactif' => '1'"), strpos($delete, 'FOR UPDATE'));
+        self::assertLessThan(strpos($delete, "'inactif' => '1'"), strpos($delete, '$expectedRevision !== null'));
+        self::assertLessThan(strpos($delete, 'DB::commit();'), strpos($delete, 'completeReservation('));
+        self::assertGreaterThan(strpos($delete, 'DB::commit();'), strrpos($delete, 'emitItemSyslog('));
+        self::assertStringNotContainsString('$e->getMessage()', $delete);
+    }
+
+    public function testControllerKeepsKeysOptionalAndShortCircuitsCompletedReplays(): void
+    {
+        $controller = (string) file_get_contents(
+            __DIR__ . '/../../../app/api/Controller/Api/ItemController.php'
+        );
+
+        $createStart = strpos($controller, 'public function createAction(');
+        $createEnd = strpos($controller, 'public function getAction(', (int) $createStart);
+        $create = substr($controller, (int) $createStart, (int) $createEnd - (int) $createStart);
+        self::assertStringContainsString('$idempotencyModel = null;', $create);
+        self::assertLessThan(strpos($create, '->reserve('), strpos($create, 'checkNewItemData('));
+        self::assertLessThan(strpos($create, '$itemModel->addItem('), strpos($create, "['state'] === 'replay'"));
+        self::assertStringContainsString('Idempotency-Replayed: true', $create);
+        self::assertStringContainsString('releaseReservation(', $create);
+
+        $deleteStart = strpos($controller, 'public function deleteAction(');
+        $delete = substr($controller, (int) $deleteStart);
+        self::assertStringContainsString('$idempotencyModel = null;', $delete);
+        self::assertLessThan(strpos($delete, '->reserve('), strpos($delete, 'canDeleteInFolder('));
+        self::assertLessThan(strpos($delete, '$itemModel->deleteItem('), strpos($delete, "['state'] === 'replay'"));
+        self::assertStringContainsString('Idempotency-Replayed: true', $delete);
+        self::assertStringContainsString('releaseReservation(', $delete);
+    }
+
+    public function testMaintenanceKeepsActiveProcessingLeases(): void
+    {
+        $maintenance = (string) file_get_contents(__DIR__ . '/../../../app/sources/main.functions.php');
+        $start = strpos($maintenance, 'function pruneApiIdempotencyRecords()');
+        self::assertNotFalse($start);
+        $block = substr($maintenance, (int) $start, 2200);
+
+        self::assertStringContainsString('expires_at < %i', $block);
+        self::assertStringContainsString('locked_until < %i', $block);
+        self::assertStringNotContainsString('locked_until > %i', $block);
+    }
+
+    public function testOpenApiDocumentsCreateAndDeleteIdempotencyAndDeleteRevision(): void
+    {
+        $spec = json_decode(
+            (string) file_get_contents(__DIR__ . '/../../../app/api/openapi.json'),
+            true,
+            512,
+            JSON_THROW_ON_ERROR
+        );
+
+        self::assertSame(
+            '#/components/parameters/IdempotencyKey',
+            $spec['paths']['/item/create']['post']['parameters'][0]['$ref']
+        );
+        self::assertSame(
+            '#/components/parameters/IdempotencyKey',
+            $spec['paths']['/item/delete']['delete']['parameters'][0]['$ref']
+        );
+        self::assertSame('revision', $spec['paths']['/item/delete']['delete']['parameters'][2]['name']);
+        self::assertArrayHasKey('409', $spec['paths']['/item/create']['post']['responses']);
+        self::assertArrayHasKey('409', $spec['paths']['/item/delete']['delete']['responses']);
+        self::assertArrayHasKey(
+            'revision_changed_at',
+            $spec['paths']['/item/delete']['delete']['responses']['200']['content']['application/json']['schema']['properties']
+        );
+    }
+}

--- a/tests/Unit/Api/ItemPasswordHistoryTest.php
+++ b/tests/Unit/Api/ItemPasswordHistoryTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Wiring guards for encrypted password history on API updates.
+ */
+class ItemPasswordHistoryTest extends TestCase
+{
+    private function itemModelSource(): string
+    {
+        $source = file_get_contents(__DIR__ . '/../../../app/api/Model/ItemModel.php');
+        self::assertIsString($source);
+
+        return str_replace("\r\n", "\n", $source);
+    }
+
+    public function testRevisionPreconditionRunsBeforePasswordRecovery(): void
+    {
+        $source = $this->itemModelSource();
+        $precondition = strpos($source, '// Optimistic concurrency.');
+        $passwordUpdate = strpos($source, '// Handle password update');
+
+        self::assertNotFalse($precondition);
+        self::assertNotFalse($passwordUpdate);
+        self::assertLessThan($passwordUpdate, $precondition);
+    }
+
+    public function testPasswordRecoveryIsMigrationAwareAndFailsClosed(): void
+    {
+        $source = $this->itemModelSource();
+        $start = strpos($source, 'private function getItemPasswordForUpdate(');
+        $end = strpos($source, 'private function getFolderSettings(', (int) $start);
+        self::assertNotFalse($start);
+        self::assertNotFalse($end);
+        $helper = substr($source, (int) $start, (int) $end - (int) $start);
+
+        self::assertStringContainsString('SELECT share_key, increment_id', $helper);
+        self::assertStringContainsString('decryptUserObjectKeyWithMigration(', $helper);
+        self::assertStringContainsString("'sharekeys_items'", $helper);
+        self::assertStringContainsString("throw new UnexpectedValueException('The current item password cannot be decrypted.')", $helper);
+    }
+
+    public function testOldPasswordIsPreparedBeforeMutationAndLoggedEncryptedAfterSharekeys(): void
+    {
+        $source = $this->itemModelSource();
+        $passwordUpdate = strpos($source, '// Handle password update');
+        self::assertNotFalse($passwordUpdate);
+        $updatePath = substr($source, (int) $passwordUpdate);
+
+        $prepareHistory = strpos($updatePath, "cryption(\$currentPassword, '', 'encrypt')");
+        $itemWrite = strpos($updatePath, "DB::update(\n                    prefixTable('items')");
+        $sharekeys = strpos($updatePath, "storeUsersShareKey(\n                    'sharekeys_items'");
+        $passwordAudit = strpos($updatePath, "'at_pw'");
+
+        self::assertNotFalse($prepareHistory);
+        self::assertNotFalse($itemWrite);
+        self::assertNotFalse($sharekeys);
+        self::assertNotFalse($passwordAudit);
+        self::assertLessThan($itemWrite, $prepareHistory);
+        self::assertLessThan($passwordAudit, $sharekeys);
+        self::assertStringContainsString('$encryptedPreviousPassword', $updatePath);
+    }
+
+    public function testSecretsAreNotIncludedInApiErrorLogs(): void
+    {
+        $source = $this->itemModelSource();
+
+        self::assertDoesNotMatchRegularExpression('/error_log\([^;]*\$(?:currentPassword|newPassword|encryptedPreviousPassword)/s', $source);
+    }
+}

--- a/tests/Unit/Api/ItemPasswordHistoryTest.php
+++ b/tests/Unit/Api/ItemPasswordHistoryTest.php
@@ -62,6 +62,12 @@ class ItemPasswordHistoryTest extends TestCase
         self::assertLessThan($itemWrite, $prepareHistory);
         self::assertLessThan($passwordAudit, $sharekeys);
         self::assertStringContainsString('$encryptedPreviousPassword', $updatePath);
+        self::assertStringContainsString('if ($passwordChanged === true) {', $updatePath);
+        self::assertStringContainsString('(string) $encryptedPreviousPassword', $updatePath);
+        self::assertStringNotContainsString(
+            'if ($passwordChanged === true && $encryptedPreviousPassword !== null)',
+            $updatePath
+        );
     }
 
     public function testSecretsAreNotIncludedInApiErrorLogs(): void

--- a/tests/Unit/Api/ItemRevisionTimestampTest.php
+++ b/tests/Unit/Api/ItemRevisionTimestampTest.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Contract and schema guards for the durable item revision timestamp.
+ */
+class ItemRevisionTimestampTest extends TestCase
+{
+    private function readSource(string $relativePath): string
+    {
+        $path = __DIR__ . '/../../..' . $relativePath;
+        self::assertFileExists($path, "Source file '$relativePath' not found");
+        $source = file_get_contents($path);
+        self::assertIsString($source);
+
+        return $source;
+    }
+
+    public function testFreshInstallAndUpgradePersistTheTimestamp(): void
+    {
+        $install = $this->readSource('/public/install/install-steps/run.step5.php');
+        $upgrade = $this->readSource('/public/install/upgrade_run_3.2.2.php');
+
+        self::assertStringContainsString('`revision_changed_at` BIGINT UNSIGNED NULL DEFAULT NULL', $install);
+        self::assertStringContainsString("'revision_changed_at'", $upgrade);
+        self::assertStringContainsString('BIGINT UNSIGNED NULL DEFAULT NULL', $upgrade);
+        self::assertStringContainsString('r.`revision` = i.`revision`', $upgrade);
+        self::assertStringContainsString('i.`revision_changed_at` IS NULL', $upgrade);
+        self::assertStringNotContainsString('SET i.`revision_changed_at` = i.`updated_at`', $upgrade);
+    }
+
+    public function testOneTimestampValueIsWrittenToTheJournalAndItem(): void
+    {
+        $source = $this->readSource('/app/sources/main.functions.php');
+        $start = strpos($source, 'function bumpItemRevision(');
+        $end = strpos($source, 'function pruneItemRevisionsJournal(', (int) $start);
+        self::assertNotFalse($start);
+        self::assertNotFalse($end);
+        $function = substr($source, (int) $start, (int) $end - (int) $start);
+
+        self::assertSame(1, substr_count($function, '$changedAt = time();'));
+        self::assertSame(2, substr_count($function, "'revision_changed_at' => \$changedAt") + substr_count($function, "'changed_at' => \$changedAt"));
+        self::assertStringContainsString("'changed_at' => \$changedAt", $function);
+        self::assertStringContainsString("'revision_changed_at' => \$changedAt", $function);
+    }
+
+    public function testOpenApiExposesTimestampEverywhereRevisionIsReturned(): void
+    {
+        $spec = json_decode($this->readSource('/app/api/openapi.json'), true);
+        self::assertIsArray($spec);
+
+        foreach (['Item', 'ItemSummary', 'CreatedResult'] as $schemaName) {
+            self::assertArrayHasKey(
+                'revision_changed_at',
+                $spec['components']['schemas'][$schemaName]['properties'],
+                "$schemaName must expose revision_changed_at"
+            );
+        }
+
+        $updateProperties = $spec['paths']['/item/update']['put']['responses']['200']['content']['application/json']['schema']['properties'];
+        self::assertArrayHasKey('revision_changed_at', $updateProperties);
+
+        $removedProperties = $spec['paths']['/item/changes']['get']['responses']['200']['content']['application/json']['schema']['properties']['removed']['items']['properties'];
+        self::assertArrayHasKey('revision_changed_at', $removedProperties);
+    }
+
+    public function testDedicatedFindByUrlAndDeltaPathsReturnTheTimestamp(): void
+    {
+        $controller = $this->readSource('/app/api/Controller/Api/ItemController.php');
+        $model = $this->readSource('/app/api/Model/ItemModel.php');
+
+        self::assertStringContainsString('i.revision, i.revision_changed_at', $controller);
+        self::assertStringContainsString("'revision_changed_at' => \$row['revision_changed_at']", $controller);
+        self::assertStringContainsString('r.action, r.changed_at', $model);
+        self::assertStringContainsString("'revision_changed_at' => (int) \$row['changed_at']", $model);
+        self::assertStringContainsString("\$item['revision_changed_at'] = (int) \$winners[\$changedItemId]['changed_at']", $model);
+    }
+}

--- a/tests/Unit/ItemRevisionsLogicTest.php
+++ b/tests/Unit/ItemRevisionsLogicTest.php
@@ -194,10 +194,10 @@ class ItemRevisionsLogicTest extends TestCase
     public function testScanKeepsOnlyTheLastEntryPerItem(): void
     {
         $rows = [
-            ['revision' => 10, 'item_id' => 7, 'action' => 'updated'],
-            ['revision' => 11, 'item_id' => 9, 'action' => 'created'],
-            ['revision' => 12, 'item_id' => 7, 'action' => 'moved'],
-            ['revision' => 13, 'item_id' => 7, 'action' => 'deleted'],
+            ['revision' => 10, 'item_id' => 7, 'action' => 'updated', 'changed_at' => 1000],
+            ['revision' => 11, 'item_id' => 9, 'action' => 'created', 'changed_at' => 1100],
+            ['revision' => 12, 'item_id' => 7, 'action' => 'moved', 'changed_at' => 1200],
+            ['revision' => 13, 'item_id' => 7, 'action' => 'deleted', 'changed_at' => 1300],
         ];
 
         $winners = itemRevisionDedupeScan($rows);
@@ -205,7 +205,42 @@ class ItemRevisionsLogicTest extends TestCase
         self::assertCount(2, $winners);
         self::assertSame(13, (int) $winners[7]['revision']);
         self::assertSame('deleted', $winners[7]['action']);
+        self::assertSame(1300, (int) $winners[7]['changed_at']);
         self::assertSame(11, (int) $winners[9]['revision']);
+        self::assertSame(1100, (int) $winners[9]['changed_at']);
+    }
+
+    public function testRevisionMetadataKeepsRevisionAndTimestampPaired(): void
+    {
+        self::assertSame(
+            ['revision' => 42, 'revision_changed_at' => 1_787_563_378],
+            itemRevisionMetadataFromRow([
+                'revision' => '42',
+                'revision_changed_at' => '1787563378',
+            ])
+        );
+    }
+
+    public function testUnknownRevisionTimestampIsNeverInvented(): void
+    {
+        self::assertSame(
+            ['revision' => 0, 'revision_changed_at' => null],
+            itemRevisionMetadataFromRow(null)
+        );
+        self::assertSame(
+            ['revision' => 0, 'revision_changed_at' => null],
+            itemRevisionMetadataFromRow([
+                'revision' => 0,
+                'revision_changed_at' => 1_787_563_378,
+            ])
+        );
+        self::assertSame(
+            ['revision' => 42, 'revision_changed_at' => null],
+            itemRevisionMetadataFromRow([
+                'revision' => 42,
+                'revision_changed_at' => null,
+            ])
+        );
     }
 
     public function testScanIgnoresRowsWithoutAnItem(): void

--- a/tests/Unit/ItemUpdateLogicTest.php
+++ b/tests/Unit/ItemUpdateLogicTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../app/sources/item_update_logic.php';
+
+/**
+ * Behavioural tests for DB-free API item update decisions.
+ */
+class ItemUpdateLogicTest extends TestCase
+{
+    public function testResubmittingTheSamePasswordIsNotAChange(): void
+    {
+        self::assertFalse(itemPasswordHasChanged('same-secret', 'same-secret'));
+        self::assertFalse(itemPasswordHasChanged('', ''));
+        self::assertFalse(itemPasswordHasChanged("binary\0secret", "binary\0secret"));
+    }
+
+    public function testDifferentPasswordsAreAChange(): void
+    {
+        self::assertTrue(itemPasswordHasChanged('old-secret', 'new-secret'));
+        self::assertTrue(itemPasswordHasChanged('', 'new-secret'));
+        self::assertTrue(itemPasswordHasChanged('Secret', 'secret'));
+    }
+
+    public function testComparisonUsesTheTimingSafePrimitive(): void
+    {
+        $source = file_get_contents(__DIR__ . '/../../app/sources/item_update_logic.php');
+        self::assertIsString($source);
+        self::assertStringContainsString('hash_equals($currentPassword, $submittedPassword)', $source);
+    }
+}


### PR DESCRIPTION
## Description

This PR aligns API password updates with the TeamPass web application and exposes a durable date
for the latest functional item revision. It addresses two requirements from the mobile client:

1. Preserve the former password in TeamPass history when the password is changed through the API.
2. Return the exact date associated with the current item revision so clients can display the last
   functional modification date.

### Encrypted password history for API updates

When `PUT /item/update` receives a non-empty password, the server now:

1. Evaluates the optional optimistic-concurrency `revision` precondition before password work.
2. Recovers the current object key through `decryptUserObjectKeyWithMigration()`, preserving the
   transparent phpseclib v1-to-v3 migration behavior.
3. Decrypts the current password with `teampassDecryptPasswordValue()`.
4. Compares the current and submitted passwords with `hash_equals()`.
5. Encrypts the previous cleartext password with the TeamPass application key before mutating the
   item.
6. Updates the password and its sharekeys through the existing API flow.
7. Adds an `at_modification` / `at_pw` entry to `log_items`, with the encrypted previous password
   in `old_value` and `TP_ENCRYPTION_NAME` as its encryption type.

If the current password or its key cannot be recovered, the request fails with `422` before the
item is changed. Failure to prepare the encrypted history value returns a generic `500` response
without exposing cryptographic details.

Submitting the current password is a password no-op. By itself, it does not rewrite the
ciphertext, redistribute sharekeys, add a history entry, or allocate a new revision.

### Durable item revision timestamp

The items table receives a nullable `BIGINT UNSIGNED` column named `revision_changed_at`. This is
the Unix UTC timestamp paired with the current `revision`; it is not a general row update date.

`bumpItemRevision()` computes one timestamp and stores it in both:

- `items_revisions.changed_at`; and
- `items.revision_changed_at`, alongside `items.revision`.

The revision and timestamp therefore remain one logical pair. Reads, access logs and
ciphertext-only migrations continue not to allocate functional revisions.

`revision_changed_at` is returned by:

- `GET /item/get`
- `GET /item/inFolders`
- `GET /item/findByUrl`
- `GET /item/changes`, for changed items and removed-item tombstones
- `POST /item/create`
- `PUT /item/update`

The delta feed takes both values from the winning journal entry after per-item deduplication. This
prevents a scanned revision from being paired with the timestamp of a newer concurrent item state.
Tombstone timestamps also come from the journal because a purged item no longer has an item row.

### Install, upgrade and compatibility

- Fresh installations create `items.revision_changed_at` in
  `public/install/install-steps/run.step5.php`.
- Upgrades add the column idempotently in `public/install/upgrade_run_3.2.2.php`.
- The upgrade backfills a date only when the exact current `(item_id, revision)` journal row still
  exists. Revision `0` and revisions whose journal entry was pruned remain `NULL`.
- The migration deliberately does not fall back to `items.updated_at`, whose semantics are not
  reliable for a functional content revision.
- The API change is additive. Existing clients may ignore the new field; clients that consume it
  must accept `null` when an exact date is unavailable.
- The normal TeamPass install/upgrade process must run before the updated API serves item queries,
  because those queries select the new column.

### Atomicity

This PR keeps the existing TeamPass API write model. It does not introduce a new transaction
across the item row, sharekey distribution, audit logging, cache refreshes and WebSocket side
effects.

Within that model, the revision precondition, current-password recovery and history encryption all
run before the item mutation. The existing item-write, dependent-sharekey and audit/cache ordering
is retained. A broader all-or-nothing transaction would require a separate refactor of helpers that
perform multiple writes and intentionally isolate audit failures from the main operation.

The OpenAPI 3.1 contract and the API and architecture documentation are updated accordingly.

## Related issue

No related issue number was provided.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (existing behaviour changes)
- [x] Documentation
- [ ] Translation
- [ ] Refactor / maintenance

## How has this been tested?

The following local static checks were completed successfully:

- `app/api/openapi.json` parses successfully with PowerShell `ConvertFrom-Json`.
- The OpenAPI schemas expose `revision_changed_at` for full items, item summaries, create/update
  results and removed-item tombstones.
- Source guards confirm that the revision precondition and encrypted-history preparation occur
  before the item write, and that the password audit entry occurs after sharekey work.
- Both fresh-install and upgrade definitions contain the new column, and the upgrade uses the
  exact `(item_id, revision)` journal join for its backfill.
- The 15 files published on `guerricv/TeamPass:api_update` exactly match the reviewed local files.
- The branch is 15 commits ahead and 0 commits behind `nilsteampassnet/TeamPass:develop`.
- No conflict markers, `var_dump()` calls or `console.log()` calls were found in the PR files.

Tests added or updated:

- `ItemUpdateLogicTest` covers unchanged and changed passwords and the timing-safe comparison.
- `ItemPasswordHistoryTest` guards precondition ordering, migration-aware recovery, fail-closed
  behavior, history preparation, audit ordering and secret-free error logging.
- `ItemRevisionsLogicTest` covers revision/timestamp normalization and delta deduplication.
- `ItemRevisionTimestampTest` covers both schema paths, exact backfill, paired timestamp writes,
  OpenAPI coverage, `findByUrl`, delta items and tombstones.

PHP syntax checks, PHPUnit, PHPStan and database-backed install/upgrade scenarios were not executed
locally because this workspace has no PHP CLI, WSL installation or test database. GitHub currently
reports no check runs for the branch head. Opening the PR against `develop` should trigger the
repository's Quality workflow (PHPUnit and PHPStan) and CodeQL workflow.

No runtime role matrix has therefore been exercised yet: admin, manager, standard and read-only
users are untested, with personal folders both enabled and disabled. The following scenarios should
be covered before merge:

1. Change an item password through the API and confirm that the former password appears in the web
   history as an encrypted `at_pw` value.
2. Submit the same password alone and confirm that the revision, timestamp, ciphertext, sharekeys
   and history remain unchanged.
3. Verify item reads and delta synchronization with public and personal folders.
4. Verify a fresh installation and an upgrade with revision `0`, an exact journal match and a
   pruned journal entry.
5. Verify changed-item and delete/purge tombstone revision/timestamp pairs.

## Checklist

- [ ] PHPStan level 4 passes (`php app/vendor/bin/phpstan analyse --memory-limit=2G`)
- [ ] The test suite passes (`php app/vendor/phpunit/phpunit/phpunit`)
- [x] Every new public function has a docblock
- [x] Variable names and comments are in English
- [x] No `var_dump()` or `console.log()` left in the code
- [x] New `app/sources/*.queries.php` files have a matching `public/sources/` proxy shim
  (not applicable: no query handler was added)
- [x] Changes to `teampassclasses` were applied to **both** copies (`app/includes/libraries/` and `app/vendor/`)
  (not applicable: no `teampassclasses` file was changed)
- [x] `app/vendor/composer/` is in its production form (`git checkout -- app/vendor/composer/`)
  (no `app/vendor/` file is present in the branch diff)

## Impact on install / upgrade

- [ ] No schema change
- [ ] Schema change — an `install/upgrade_run_X.X.X.php` script is included and the fresh install path was tested

Schema changes are included in both `public/install/upgrade_run_3.2.2.php` and the fresh-install
path. The checkbox remains open because the fresh installation and upgrade were not executed
against a database in this workspace.

## Screenshots

Not applicable. This PR changes the API, database schema and backend behavior without adding or
changing a web UI.
