### PR TITLE
Fix the PHPStan CI job: declare SECUREFILE in settings.sample.php

### DIFF
--- a/app/config/settings.sample.php
+++ b/app/config/settings.sample.php
@@ -19,6 +19,10 @@ define("DB_SSL", false); // if DB over SSL then comment this line
 define("DB_CONNECT_OPTIONS", array(
     MYSQLI_OPT_CONNECT_TIMEOUT => 10
 ));
+// Name of the file holding the application master key, inside TEAMPASS_SECRETS
+// (a constant defined in app/config/include.php as TEAMPASS_ROOT/secrets).
+// The installer replaces this empty value with a random file name.
+define("SECUREFILE", "");
 define("IKEY", "");
 define("SKEY", "");
 define("HOST", "");

--- a/app/files_reference.txt
+++ b/app/files_reference.txt
@@ -67,7 +67,7 @@ app/config/.htaccess 81594a7af3d0a392c24aada056204b79
 app/config/emails_templates.php 5dd31985ddd8bd531e8b7392053db9db
 app/config/include.php b2b9189c72326c976bc96bd2d35ff173
 app/config/index.html 5f1f28d1adcb7eac03989f0ca3e7068e
-app/config/settings.sample.php b428568d86d89390da3f0e0137a14802
+app/config/settings.sample.php 15ed7c39ba4b70e0157292265f938860
 app/core/command-palette.js.php e4e3fd01a173bfdcbd02c96ea679375a
 app/core/extension-autoconfig.js.php 55768fb83ec46e63557dcb0bb247d22d
 app/core/item-classification.js.php dde3300540213102eefcd528af22f9aa

--- a/files_reference.txt
+++ b/files_reference.txt
@@ -67,7 +67,7 @@ app/config/.htaccess 81594a7af3d0a392c24aada056204b79
 app/config/emails_templates.php 5dd31985ddd8bd531e8b7392053db9db
 app/config/include.php b2b9189c72326c976bc96bd2d35ff173
 app/config/index.html 5f1f28d1adcb7eac03989f0ca3e7068e
-app/config/settings.sample.php b428568d86d89390da3f0e0137a14802
+app/config/settings.sample.php 15ed7c39ba4b70e0157292265f938860
 app/core/command-palette.js.php e4e3fd01a173bfdcbd02c96ea679375a
 app/core/extension-autoconfig.js.php 55768fb83ec46e63557dcb0bb247d22d
 app/core/item-classification.js.php dde3300540213102eefcd528af22f9aa


### PR DESCRIPTION
## Description

The `Quality` workflow has never passed since it was added (`3d94a8c87`, 2026-08-20). Its
`PHPStan (level 4)` job fails on **every** branch — `develop`, `master` and every pull request —
with nine occurrences of `Constant SECUREFILE not found.`

### Cause

The job bootstraps PHPStan with a placeholder `app/config/settings.php` copied from
`app/config/settings.sample.php`, because the real file holds the database credentials and is
never committed:

```yaml
- run: cp app/config/settings.sample.php app/config/settings.php
```

That sample was out of sync with what the installer actually writes. It declares every constant
of a generated `settings.php` **except `SECUREFILE`**, which `run.step6.php:445` and
`tp.functions.php:109` do write. Listing the constant in `dynamicConstantNames` (`phpstan.neon`)
does not help — that only prevents PHPStan from inlining the value, it does not declare it.

Reported sites: `main.functions.php:99,2007,4529,5388`, `dashboard.queries.php:382`,
`scan_pre_migration.php:136,335`, `fix_integrity_hash.php:47`, `read-db-version.php:58`.

### Fix

Declare `SECUREFILE` with an empty value in the sample, at the exact position the installer
places it in a generated file, and refresh the two `files_reference.txt` integrity entries.

No PHP code loads `settings.sample.php` — only the workflow and the two checksum lists reference
it — so this is inert at runtime.

### Verification

PHPStan was run locally under the exact CI conditions (bootstrapped on a copy of the patched
sample): **exit 0, no error**.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Translation
- [ ] Refactor / maintenance

## Impact on install / upgrade

- [x] No schema change

🤖 Generated with [Claude Code](https://claude.com/claude-code)