### PR TITLE
Run the test suite from a standalone PHPUnit phar

### DIFF
--- a/.claude/skills/prepare-release/SKILL.md
+++ b/.claude/skills/prepare-release/SKILL.md
@@ -111,11 +111,12 @@ runs green in the normal dev state. Exit code is non-zero on any failure; warnin
 **Failures block the release. Warnings are triaged, not ignored** — each one is either fixed
 or explicitly justified to the user.
 
-Binaries (Composer vendor dir is `app/vendor`, and `app/vendor/bin/phpunit` is not executable):
+Binaries (Composer vendor dir is `app/vendor`; PHPUnit runs from the standalone phar, which is
+the only entry point that works against the committed production autoloader):
 
 ```bash
 php app/vendor/bin/phpstan analyse --no-progress --memory-limit=1G
-php app/vendor/phpunit/phpunit/phpunit --no-coverage
+php _tools/phpunit.phar --no-coverage
 ```
 
 Manual checks the gate does not cover — run them when the range touches the matching area:
@@ -304,10 +305,15 @@ the stale one. Run this after the merge instead:
 ```bash
 rm -rf app/vendor/phpstan app/vendor/phpunit app/vendor/symfony/cache
 composer install
-php app/vendor/phpunit/phpunit/phpunit          # expect: OK (1344 tests, 38419 assertions)
+git checkout -- app/vendor/composer/            # restores the production autoloader
+php _tools/phpunit.phar                         # expect: OK (~1500 tests, all green)
 php app/vendor/bin/phpstan analyse --memory-limit=2G
-git checkout -- app/vendor/composer/            # LAST — see below, it disarms the toolchain
 ```
+
+The tests no longer have to run *between* the install and the restore: `_tools/phpunit.phar`
+carries its own dependencies and never reads `app/vendor/composer/`. PHPStan is the same story —
+`app/vendor/bin/phpstan` loads `phpstan.phar`. Only `composer-license-checker` still needs the
+dev autoloader, so run it before the restore if the release calls for it.
 
 The `rm -rf` is **not** optional, and it is the part nobody guesses. Those three packages keep
 untracked *generated* files that git has no reason to delete — `phpstan/phpstan/turbo-ext/`
@@ -319,19 +325,21 @@ with `Could not scan for classes inside ".../symfony/cache/Traits/ValueWrapper.p
 not appear to be a file nor a folder`, leaving the autoloader ungenerated. Deleting a directory
 that happens to be already gone costs nothing; missing one breaks the whole install.
 
-**The order of those last three lines is not free, and it changed in 3.2.1.7.** The committed
-`app/vendor/composer/` is now the **production** autoloader (`composer install --no-dev`), because
-the archive is built from the index and must not require dev files it does not carry — see check 10
-of the release gate. `composer install` rewrites those seven tracked files into their *dev* form,
-which is what makes PHPUnit and PHPStan runnable at all; `git checkout -- app/vendor/composer/`
-puts the production form back. So run the toolchain **between** the two, never after: with the
-production autoloader on disk, `php app/vendor/phpunit/phpunit/phpunit` dies with
-`Class "PHPUnit\TextUI\Application" not found` even though the package sits right there.
+**Why the restore matters.** The committed `app/vendor/composer/` is the **production**
+autoloader (`composer install --no-dev`), because the archive is built from the index and must not
+require dev files it does not carry — see check 10 of the release gate. `composer install` rewrites
+those seven tracked files into their *dev* form, and `git checkout -- app/vendor/composer/` puts
+the production form back. That restore is mandatory before committing anything or regenerating the
+checksums — committing the dev autoloader is exactly the bug 3.2.1.7 had to fix, it fatals every
+installation, and the `Committed autoloader is production-only` CI job now rejects it.
 
-That `git checkout` is still mandatory before committing anything or regenerating the checksums —
-committing the dev autoloader is exactly the bug 3.2.1.7 had to fix, and it fatals every
-installation. The same rule holds outside a release: to run the suite locally, `composer install`
-first, and restore `app/vendor/composer/` before you commit.
+Historically the toolchain had to run *between* the install and the restore, because
+`php app/vendor/phpunit/phpunit/phpunit` dies with `Class "PHPUnit\TextUI\Application" not found`
+against the production autoloader. That constraint is gone: run the tests from
+`_tools/phpunit.phar` (untracked, gitignored via `/_tools/*`, excluded from the admin integrity
+check) and the restore can happen first. Reinstall the phar with the snippet in
+`.github/CONTRIBUTING.md` if it is missing, keeping its version aligned with
+`.github/workflows/quality.yml`.
 
 ```bash
 git checkout master

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -55,40 +55,54 @@ composer install
 The web root is `public/`; the application code lives in `app/`. Install through
 `/install/install.php`.
 
-### ⚠️ Repairing the dev toolchain
+### Setting up the dev toolchain
 
 `composer.json` sets `vendor-dir` to `app/vendor`, so Composer binaries live in `app/vendor/bin/`
 — **not** `vendor/bin/`.
 
-The dev dependencies are untracked, so any checkout or merge deletes them while leaving generated
-residue behind. Because their directories still exist, Composer believes they are installed and
-skips them. On top of that, the committed `app/vendor/composer/` is the **production** autoloader
-and maps no dev package. The symptom is `Class "PHPUnit\TextUI\Application" not found` with the
-package sitting right there — and `composer dump-autoload` does not fix it.
+**Install PHPUnit as a standalone phar.** Do not use `app/vendor/phpunit/phpunit/phpunit`: it
+resolves its classes through `app/vendor/composer/`, which is committed in its **production**
+form and maps no dev package. The symptom is `Class "PHPUnit\TextUI\Application" not found`
+with the package sitting right there, and `composer dump-autoload` does not fix it. The phar
+carries its own dependencies and is immune — the same reason `app/vendor/bin/phpstan` works
+(it is a phar too).
+
+```bash
+mkdir -p _tools
+curl -sL -o _tools/phpunit.phar    https://phar.phpunit.de/phpunit-10.5.64.phar
+curl -sL -o /tmp/phpunit.phar.asc  https://phar.phpunit.de/phpunit-10.5.64.phar.asc
+gpg --keyserver hkps://keys.openpgp.org \
+    --recv-keys D8406D0D82947747293778314AA394086372C20A         # Sebastian Bergmann
+gpg --verify /tmp/phpunit.phar.asc _tools/phpunit.phar           # expect: Good signature
+chmod +x _tools/phpunit.phar
+```
+
+`_tools/` is gitignored, so the phar survives every checkout and merge. Keep its version in step
+with `.github/workflows/quality.yml`, which resolves `phpunit/phpunit: ^10.5` from the lock file.
+
+**The other dev tools still come from Composer**, and they carry a trap. The dev dependencies are
+untracked, so any checkout or merge deletes them while leaving generated residue behind; because
+their directories still exist, Composer believes they are installed and skips them.
 
 ```bash
 rm -rf app/vendor/phpstan app/vendor/phpunit app/vendor/symfony/cache
 composer install
-
-php app/vendor/phpunit/phpunit/phpunit                  # run the tests
-php app/vendor/bin/phpstan analyse --memory-limit=2G    # run the analyser
-
-git checkout -- app/vendor/composer/                    # LAST — restores the production autoloader
+git checkout -- app/vendor/composer/                    # restores the production autoloader
 ```
 
-The `rm -rf` is not optional and the order of the last three commands is not free: `composer
-install` rewrites `app/vendor/composer/` into its *dev* form (which is what makes the tools
-runnable), so run them **between** the install and the restore.
+The `rm -rf` is not optional — without it `composer install` repairs nothing for those three
+packages.
 
-> **Always run `git checkout -- app/vendor/composer/` before committing.** Shipping the dev
-> autoloader fatals every installation.
+> **Always run `git checkout -- app/vendor/composer/` before committing.** `composer install`
+> rewrites it into its *dev* form, and shipping that autoloader fatals every installation. The
+> `Committed autoloader is production-only` CI job rejects a pull request that carries it.
 
 ---
 
 ## Running the checks
 
 ```bash
-php app/vendor/phpunit/phpunit/phpunit                  # unit tests
+php _tools/phpunit.phar                                 # unit tests
 php app/vendor/bin/phpstan analyse --memory-limit=2G    # static analysis, level 4
 php app/vendor/bin/composer-license-checker             # dependency license compliance
 ```

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -23,7 +23,7 @@
 ## Checklist
 
 - [ ] PHPStan level 4 passes (`php app/vendor/bin/phpstan analyse --memory-limit=2G`)
-- [ ] The test suite passes (`php app/vendor/phpunit/phpunit/phpunit`)
+- [ ] The test suite passes (`php _tools/phpunit.phar` — see CONTRIBUTING.md for the one-time setup)
 - [ ] Every new public function has a docblock
 - [ ] Variable names and comments are in English
 - [ ] No `var_dump()` or `console.log()` left in the code

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,39 +21,64 @@ so the Composer binaries live under `app/vendor/bin/`, not `vendor/bin/`.
 
 ```bash
 php app/vendor/bin/phpstan analyse --memory-limit=2G   # PHPStan level 4 (config: phpstan.neon)
+php _tools/phpunit.phar                                # Unit tests
 php app/vendor/bin/composer-license-checker            # License compliance
 composer install                                       # PHP dependencies
 php app/scripts/background_tasks___handler.php         # Background tasks
-php app/vendor/phpunit/phpunit/phpunit                 # Unit tests — see caveat below
 ```
 
 A full PHPStan run takes several minutes — launch it in the background rather than blocking on it.
 
-**PHPUnit does not run from a fresh checkout — repair the toolchain first.** The dev
-dependencies are untracked, so any checkout or merge deletes them while leaving generated
-residue behind (`phpstan/phpstan/turbo-ext/`, the Redis proxies under `symfony/cache/Traits/`,
-the `Xdebug*` files). Their directory survives, Composer only checks that a package directory
-*exists*, so it considers them installed and skips them. On top of that the committed
-`app/vendor/composer/` is the **production** autoloader (`composer install --no-dev`) and maps
-no dev package. Symptom: `Class "PHPUnit\TextUI\Application" not found` with the package
-sitting right there. `composer dump-autoload` does **not** help — `phpunit/phpunit` is absent
-from `installed.json`.
+**Run the tests with `_tools/phpunit.phar`, never with `app/vendor/phpunit/phpunit/phpunit`.**
+The Composer-installed entry point resolves its classes through `app/vendor/composer/`, and that
+directory is committed in its **production** form (`composer install --no-dev`), which maps no
+dev package. Symptom: `Class "PHPUnit\TextUI\Application" not found` with the package sitting
+right there. `composer dump-autoload` does not help — `phpunit/phpunit` is absent from
+`installed.json`. Worse, the obvious repair (`composer install`) rewrites the autoloader into its
+dev form, and the mandatory `git checkout -- app/vendor/composer/` that must follow disarms the
+tests again. The loop has no stable exit.
+
+The phar has none of that coupling — it carries its own dependencies and never reads
+`app/vendor/composer/`, exactly like `app/vendor/bin/phpstan` does with `phpstan.phar`. It lives
+in `_tools/`, which is gitignored (`/_tools/*`) and excluded from the admin integrity check
+(`$excludeDirs` in `getAllFiles()`), so no checkout, merge or release can remove it.
+
+```bash
+php _tools/phpunit.phar                         # expect: OK (~1500 tests, all green)
+php app/vendor/bin/phpstan analyse --memory-limit=2G
+```
+
+If `_tools/phpunit.phar` is missing (fresh clone — it is untracked by design), reinstall it and
+verify the signature. Keep the version aligned with `.github/workflows/quality.yml`, which runs
+whatever `composer install` resolves for `phpunit/phpunit: ^10.5`:
+
+```bash
+mkdir -p _tools
+curl -sL -o _tools/phpunit.phar     https://phar.phpunit.de/phpunit-10.5.64.phar
+curl -sL -o /tmp/phpunit.phar.asc   https://phar.phpunit.de/phpunit-10.5.64.phar.asc
+gpg --keyserver hkps://keys.openpgp.org \
+    --recv-keys D8406D0D82947747293778314AA394086372C20A          # Sebastian Bergmann
+gpg --verify /tmp/phpunit.phar.asc _tools/phpunit.phar            # expect: Good signature
+chmod +x _tools/phpunit.phar
+```
+
+**`composer install` is still needed for the other dev tools** (`composer-license-checker`, and
+PHPStan on a fresh clone). It leaves the same trap behind, so the old recovery still applies to
+them — and only to them:
 
 ```bash
 rm -rf app/vendor/phpstan app/vendor/phpunit app/vendor/symfony/cache
 composer install
-php app/vendor/phpunit/phpunit/phpunit          # expect: OK (1344 tests, 38419 assertions)
-php app/vendor/bin/phpstan analyse --memory-limit=2G
-git checkout -- app/vendor/composer/            # LAST — it disarms the toolchain again
+git checkout -- app/vendor/composer/            # restore the production autoloader
 ```
 
-The `rm -rf` is not optional: without it `composer install` repairs nothing for those three
-packages. The order of the last three lines is not free either — `composer install` rewrites
-`app/vendor/composer/` into its *dev* form, which is what makes the tools runnable, and the
-final `git checkout` puts the production form back. Run the toolchain **between** the two.
-That restore is mandatory before committing: shipping the dev autoloader fatals every
-installation (the bug 3.2.1.7 had to fix). Full rationale in
-`.claude/skills/prepare-release/SKILL.md` §7.
+The `rm -rf` is not optional: any checkout or merge deletes the untracked dev packages while
+leaving generated residue behind (`phpstan/phpstan/turbo-ext/`, the Redis proxies under
+`symfony/cache/Traits/`, the `Xdebug*` files); the directory survives, Composer only checks that a
+package directory *exists*, so it considers them installed and skips them. The final restore is
+mandatory before committing: shipping the dev autoloader fatals every installation (the bug
+3.2.1.7 had to fix), and the `Committed autoloader is production-only` CI job rejects it. Full
+rationale in `.claude/skills/prepare-release/SKILL.md` §7.
 
 Database schema: initial install via `/install/install.php`, upgrades via `/install/upgrade.php` + `/install/upgrade_run_*.php`.
 

--- a/app/files_reference.txt
+++ b/app/files_reference.txt
@@ -10,7 +10,7 @@
 .claude/docs/architecture-websocket.md a13c93e7892930eecbc28fb2bf0625cb
 .claude/skills/debug-issue/skill.md f6ca42b7fce135a9dbe1b01f651e35a4
 .claude/skills/explore-codebase/skill.md 72bcdd4382c8389e22970964cbdf73e3
-.claude/skills/prepare-release/SKILL.md fce84d491864b96b8fc0b6cdf5eb711b
+.claude/skills/prepare-release/SKILL.md 20607344865ea17668491fb926a159f1
 .claude/skills/prepare-release/references/release-notes-template.md badd1136b921f1688af11ad73280e59e
 .claude/skills/prepare-release/scripts/regenerate_checksums.sh 5fd902eff9daf706d5dc864356f814a2
 .claude/skills/refactor-safely/skill.md 48b6d7fd4e9a3dcef923e9e32f8a75d0
@@ -18,12 +18,12 @@
 .dockerignore e7e9c8e0c6d6cde4bf3246467c908427
 .eslintignore cc8a871db6475bf238fe4c09602f181d
 .eslintrc 92303d813331f34d6428b5eec6979e63
-.github/CONTRIBUTING.md 34328f0cf40fe975fe942578530162cb
+.github/CONTRIBUTING.md a04eda68c2801928f5ce356310814154
 .github/FUNDING.yml 85b41af5b443f15df8041493159da95e
 .github/ISSUE_TEMPLATE/bug_report.yml 73c9532a938fa5941c6afe63f66ef968
 .github/ISSUE_TEMPLATE/config.yml 3f877caabd7f83d65a66fd8d25a6738d
 .github/ISSUE_TEMPLATE/feature_request.yml f7d1a2cabea59be111b30ea228a2eadb
-.github/PULL_REQUEST_TEMPLATE.md 58b4d08036d3a909d757cbeb03055fa0
+.github/PULL_REQUEST_TEMPLATE.md c83e119d1ad35bc879b4ab75fef6a462
 .github/SUPPORT.md d839d7ce6f3691728500132503bf6d6d
 .github/codeql/codeql-config.yml 58dc1dba0781d7eaf775ef42ce22ef3c
 .github/dependabot.yml 123b62ac94b15d370328f5ebcbeaf627
@@ -34,7 +34,7 @@
 .gitignore 23549df59304608d467850acdecc37e3
 .phpstan-baseline.neon 67f61e8b639c017bee8a946b3799e46c
 .scrutinizer.yml 81051bcc2cf1bedf378224b0a93e2877
-CLAUDE.md 751ec3965bea977fa590c7dccd51accb
+CLAUDE.md 98afbdf010a8467134fad8c3f9412946
 CODE_OF_CONDUCT.md b0a15b407957b5a13797b84f3ce4e171
 DOCKER-HUB-README.md 12807831b6f0b750407a50d125068032
 Dockerfile 61be1cd79a32134c1ac82bc4375c50fe
@@ -13223,7 +13223,7 @@ public/sources/users.queries.php 542e21f0d353483a5fdd47b5ea1ffb5c
 public/sources/users_purge.functions.php 0923d1096424f928de1437866bd3efa8
 public/sources/utilities.queries.php f0a7cc58f4637386ed597b851f83a55e
 public/sources/utils.queries.php 8dff1c43473e071c9e440298d16db6d4
-scripts/release_check.sh 9abdad196af9bc6c5be7699b6ea890b2
+scripts/release_check.sh f8e48e7cb93cba3ee030f970af5c6156
 secrets/.gitkeep d41d8cd98f00b204e9800998ecf8427e
 storage/backups/.gitkeep d41d8cd98f00b204e9800998ecf8427e
 storage/config/.gitkeep d41d8cd98f00b204e9800998ecf8427e

--- a/files_reference.txt
+++ b/files_reference.txt
@@ -10,7 +10,7 @@
 .claude/docs/architecture-websocket.md a13c93e7892930eecbc28fb2bf0625cb
 .claude/skills/debug-issue/skill.md f6ca42b7fce135a9dbe1b01f651e35a4
 .claude/skills/explore-codebase/skill.md 72bcdd4382c8389e22970964cbdf73e3
-.claude/skills/prepare-release/SKILL.md fce84d491864b96b8fc0b6cdf5eb711b
+.claude/skills/prepare-release/SKILL.md 20607344865ea17668491fb926a159f1
 .claude/skills/prepare-release/references/release-notes-template.md badd1136b921f1688af11ad73280e59e
 .claude/skills/prepare-release/scripts/regenerate_checksums.sh 5fd902eff9daf706d5dc864356f814a2
 .claude/skills/refactor-safely/skill.md 48b6d7fd4e9a3dcef923e9e32f8a75d0
@@ -18,12 +18,12 @@
 .dockerignore e7e9c8e0c6d6cde4bf3246467c908427
 .eslintignore cc8a871db6475bf238fe4c09602f181d
 .eslintrc 92303d813331f34d6428b5eec6979e63
-.github/CONTRIBUTING.md 34328f0cf40fe975fe942578530162cb
+.github/CONTRIBUTING.md a04eda68c2801928f5ce356310814154
 .github/FUNDING.yml 85b41af5b443f15df8041493159da95e
 .github/ISSUE_TEMPLATE/bug_report.yml 73c9532a938fa5941c6afe63f66ef968
 .github/ISSUE_TEMPLATE/config.yml 3f877caabd7f83d65a66fd8d25a6738d
 .github/ISSUE_TEMPLATE/feature_request.yml f7d1a2cabea59be111b30ea228a2eadb
-.github/PULL_REQUEST_TEMPLATE.md 58b4d08036d3a909d757cbeb03055fa0
+.github/PULL_REQUEST_TEMPLATE.md c83e119d1ad35bc879b4ab75fef6a462
 .github/SUPPORT.md d839d7ce6f3691728500132503bf6d6d
 .github/codeql/codeql-config.yml 58dc1dba0781d7eaf775ef42ce22ef3c
 .github/dependabot.yml 123b62ac94b15d370328f5ebcbeaf627
@@ -34,7 +34,7 @@
 .gitignore 23549df59304608d467850acdecc37e3
 .phpstan-baseline.neon 67f61e8b639c017bee8a946b3799e46c
 .scrutinizer.yml 81051bcc2cf1bedf378224b0a93e2877
-CLAUDE.md 751ec3965bea977fa590c7dccd51accb
+CLAUDE.md 98afbdf010a8467134fad8c3f9412946
 CODE_OF_CONDUCT.md b0a15b407957b5a13797b84f3ce4e171
 DOCKER-HUB-README.md 12807831b6f0b750407a50d125068032
 Dockerfile 61be1cd79a32134c1ac82bc4375c50fe
@@ -13223,7 +13223,7 @@ public/sources/users.queries.php 542e21f0d353483a5fdd47b5ea1ffb5c
 public/sources/users_purge.functions.php 0923d1096424f928de1437866bd3efa8
 public/sources/utilities.queries.php f0a7cc58f4637386ed597b851f83a55e
 public/sources/utils.queries.php 8dff1c43473e071c9e440298d16db6d4
-scripts/release_check.sh 9abdad196af9bc6c5be7699b6ea890b2
+scripts/release_check.sh f8e48e7cb93cba3ee030f970af5c6156
 secrets/.gitkeep d41d8cd98f00b204e9800998ecf8427e
 storage/backups/.gitkeep d41d8cd98f00b204e9800998ecf8427e
 storage/config/.gitkeep d41d8cd98f00b204e9800998ecf8427e

--- a/scripts/release_check.sh
+++ b/scripts/release_check.sh
@@ -40,7 +40,13 @@ cd "$ROOT"
 # --- Resolve binaries ----------------------------------------------------------
 PHP_BIN="$(command -v php || true)"
 PHPSTAN="$ROOT/app/vendor/bin/phpstan"
-PHPUNIT_PHAR="$ROOT/app/vendor/phpunit/phpunit/phpunit"
+# The standalone phar is preferred: it carries its own dependencies, so it runs against the
+# committed *production* autoloader, which the Composer entry point cannot do. Fall back to
+# the Composer binary for a tree where `composer install` was just run.
+PHPUNIT_PHAR="$ROOT/_tools/phpunit.phar"
+if [ ! -f "$PHPUNIT_PHAR" ]; then
+    PHPUNIT_PHAR="$ROOT/app/vendor/phpunit/phpunit/phpunit"
+fi
 
 EN_LANG="app/includes/language/english.php"
 FR_LANG="app/includes/language/french.php"


### PR DESCRIPTION
## Description

`php app/vendor/phpunit/phpunit/phpunit` cannot work from a normal checkout, and the documented repair does not stick.

The binary resolves its classes through `app/vendor/composer/`, which is committed in its **production** form (`composer install --no-dev`) and maps no dev package — so it dies with `Class "PHPUnit\TextUI\Application" not found` even though `app/vendor/phpunit/phpunit/` is sitting right there. `composer install` fixes that by rewriting the autoloader into its dev form, but the restore that must follow it, `git checkout -- app/vendor/composer/`, disarms the tests again. The loop has no stable exit, so in practice the suite is unrunnable at rest. `scripts/release_check.sh` reported PHPUnit as failed for the same reason.

### Fix

Run the tests from the standalone phar. It carries its own dependencies and never reads `app/vendor/composer/` — which is precisely why `app/vendor/bin/phpstan` has never suffered from this: it loads `phpstan.phar`.

The file lives in `_tools/`, which is **already** gitignored (`/_tools/*`) and **already** excluded from the admin integrity check (`$excludeDirs` in `getAllFiles()`, `app/sources/admin.queries.php`). No checkout, merge or release can remove it, and it never reaches a release archive.

- `scripts/release_check.sh` prefers `_tools/phpunit.phar`, falling back to the Composer binary for a tree where `composer install` was just run.
- `.github/CONTRIBUTING.md` carries the install snippet, pinned to the version the CI workflow resolves (10.5.64), with GPG verification against Sebastian Bergmann's key `D8406D0D82947747293778314AA394086372C20A`.
- `CLAUDE.md` and the release runbook are updated; the "run the toolchain *between* the install and the restore" constraint is gone.
- `app/files_reference.txt` / `files_reference.txt` checksums refreshed for the changed files.

**The CI workflow is deliberately unchanged.** It runs `composer install` in a throwaway runner, where the dev autoloader is the right answer and the lock file is the version source of truth.

### Verification

```
php _tools/phpunit.phar
OK (1497 tests, 41333 assertions)
```

Run against the committed **production** autoloader (`installed.json` → `dev: false`), and again with `app/vendor/phpunit/` renamed out of the way, to prove the phar has no dependency on the Composer-installed package.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation
- [ ] Translation
- [x] Refactor / maintenance

## Impact on install / upgrade

- [x] No schema change

🤖 Generated with [Claude Code](https://claude.com/claude-code)