### PR TITLE
Pr5343 part1

### DIFF
--- a/.claude/docs/api-reference.md
+++ b/.claude/docs/api-reference.md
@@ -151,9 +151,14 @@ Get item(s) by ID or label.
 
 **Pagination:** label/description searches return `X-Total-Count` (total matches in accessible folders, before per-item sharekey filtering).
 
-**Response:** array of item objects `{ id, revision, label, description, login, email, url, password, path, folder_id, folder_label, has_otp, favicon_url, tags, fields }`.
+**Response:** array of item objects `{ id, revision, revision_changed_at, label, description, login, email, url, password, path, folder_id, folder_label, has_otp, favicon_url, tags, fields }`.
 
 **`revision`** — monotonic item revision, allocated from the `teampass_items_revisions` journal on every content change (item row, custom fields, tags, attachments, OTP, move, delete, restore). `0` = never changed since the column was introduced. Also returned by `item/inFolders`, `item/findByUrl`, `item/create` and `item/update`. See `architecture-item-revisions.md`.
+
+**`revision_changed_at`** — Unix UTC timestamp in seconds paired with `revision`. It changes only
+when a functional content revision is allocated, never on a read or ciphertext-only rewrite.
+`null` means the exact date is not known, notably for revision 0 or when an upgrade could not find
+the current revision in the prunable journal. Returned everywhere `revision` is returned.
 
 **Custom fields:** `fields` is an array of `{ id, title, type, masked, value }` for the item's folder-associated categories. Encrypted values are decrypted via `decryptUserObjectKeyWithMigration()` on `sharekeys_fields` (+ `base64_decode`); empty when no sharekey is available yet. Only present when `item_extra_fields` is enabled. Also returned by `item/inFolders`.
 
@@ -181,7 +186,7 @@ Find items by URL match.
 
 **Params:** `url` (string). The `%` and `_` characters are escaped before the LIKE query.
 
-**Response:** array of `{ id, label, login, url, folder_id, has_otp, favicon_url }`. Empty result → `200` + `[]`.
+**Response:** array of `{ id, revision, revision_changed_at, label, login, url, folder_id, has_otp, favicon_url }`. Empty result → `200` + `[]`.
 
 **Permissions:** `allowed_to_read`.
 
@@ -210,7 +215,7 @@ Delta feed for offline clients (mobile vault). Answers "what must I apply since 
 
 **Params:** `since` (int, **required**, exclusive; `0` on a first sync), `limit` (default 200, max 1000).
 
-**Response:** `{ cursor, has_more, full_sync_required, changed[], removed[] }`. `changed` carries full item payloads (same shape and same code path as `item/get`); `removed` is `{ id, revision, reason }` with `reason` in `deleted` | `purged` | `out_of_scope`.
+**Response:** `{ cursor, has_more, full_sync_required, changed[], removed[] }`. `changed` carries full item payloads (same shape and same code path as `item/get`); `removed` is `{ id, revision, revision_changed_at, reason }` with `reason` in `deleted` | `purged` | `out_of_scope`. The revision/date pair comes from the winning journal row after deduplication.
 
 **Cursor-based, not offset-based** — a change feed has no stable total, so no `X-Total-Count`. Store `cursor`, resend it as `since`, repeat while `has_more`.
 
@@ -244,7 +249,7 @@ Create a new item.
 
 **Custom fields:** `fields` = array of `{ id, value }` (field id + value). Encrypt-before-INSERT for encrypted categories; creator sharekey created synchronously, other users via the `new_item` background task. Only fields tied to the folder are stored; empty values ignored. Requires `item_extra_fields`.
 
-**Response 201:** `{ error: false, message, newId }` + `Location: /api/v1/item/get?id=<newId>` (path-absolute reference). Validation failures → `422`; missing fields → `400`; folder not allowed / read-only → `403`.
+**Response 201:** `{ error: false, message, newId, revision, revision_changed_at }` + `Location: /api/v1/item/get?id=<newId>` (path-absolute reference). Validation failures → `422`; missing fields → `400`; folder not allowed / read-only → `403`.
 
 **Permissions:** `allowed_to_create`. Blocked with 403 if folder is read-only for user.
 
@@ -257,6 +262,12 @@ Update an existing item. **Only PUT is accepted** — POST returns 405.
 **Body:** `id` (required), at least one of: `label`, `password`, `description`, `login`, `email`, `url`, `tags`, `anyone_can_modify`, `icon`, `folder_id`, `totp`, `fields`.
 
 **Optimistic concurrency — `revision` (optional).** The revision the client's edit was based on. When it differs from `items.revision`, the update is rejected with `409` and **nothing is written**; omitting it keeps last-writer-wins, so existing clients are unaffected. It is a **precondition, not an updatable field**: it is absent from the `$updateableFields` list in `ItemController::updateAction()`, so `{id, revision}` alone still answers `400 'At least one supported field to update must be provided.'`, and it never triggers the personal→shared move conflict guard.
+
+**Password history.** When a non-empty `password` is supplied, the server decrypts the current
+value before any mutation and compares it with `hash_equals()`. An unchanged password is a password
+no-op: by itself it causes no ciphertext rewrite, sharekey fan-out, password-history row or revision. A real change stores the
+previous value in `log_items.old_value`, encrypted with the application master key and tagged
+`at_pw`, exactly like the web UI. Failure to recover or prepare the old value aborts before mutation.
 
 **Custom fields:** `fields` = array of `{ id, value }`. Created if absent, updated only when the value changed (current value decrypted for comparison); encrypted fields re-encrypted and sharekeys refreshed synchronously for all eligible users (consistent with the password path). Empty values ignored. Requires `item_extra_fields`.
 

--- a/.claude/docs/architecture-item-revisions.md
+++ b/.claude/docs/architecture-item-revisions.md
@@ -1,6 +1,6 @@
 # Item Revisions & Offline Synchronization
 
-> Last updated: 2026-08-19 — branch `feat/item-revision-id`, target release 3.2.2
+> Last updated: 2026-08-24 — target release 3.2.2
 > Design study: `workReadmeFiles/item-revision-id-study.md`
 
 Gives every item a **monotonic revision ID** so an offline client (the mobile vault) can tell
@@ -22,7 +22,8 @@ too coarse. That workaround can now be replaced by a revision check.
 ## Data model
 
 ```sql
-teampass_items.revision  INT UNSIGNED NOT NULL DEFAULT 0   -- latest journal revision
+teampass_items.revision             INT UNSIGNED NOT NULL DEFAULT 0
+teampass_items.revision_changed_at  BIGINT UNSIGNED NULL  -- timestamp paired with revision
 
 teampass_items_revisions:
   revision           INT UNSIGNED AUTO_INCREMENT PRIMARY KEY  -- THE global sequence
@@ -38,9 +39,10 @@ teampass_items_revisions:
 (`revA != revB`) and "what changed since X?" (`revision > cursor`). A per-item counter cannot do
 the second.
 
-**No backfill.** `revision = 0` means "never changed since tracking was installed", which is
-consistent for every client — they only ever compare an item against *their own* cached copy. Same
-precedent as the `hibp_*` columns, where the default *is* the migration.
+**Revision 0 is not backfilled.** It means "never changed since tracking was installed" and its
+`revision_changed_at` is `NULL`. During upgrade, a positive revision timestamp is backfilled only
+when the exact `(item_id, revision)` row is still present in the journal. If pruning already removed
+that row, the date remains `NULL` rather than being guessed from the unreliable `items.updated_at`.
 
 **The journal is not a history.** It records *that* a change happened and in which folder, never
 *what* the value was. Item history stays `teampass_log_items` (+ `old_value` for passwords).
@@ -68,10 +70,12 @@ would make every offline client re-download an item nobody touched.
 (`main.queries.php:3375`) and the custom-field re-encryption (`fields.queries.php`, `edit_field` /
 `dataIsEncryptedInDB`) change the stored bytes but not the plaintext the client caches.
 
-**Per-request memo.** `update_item` calls `logItems()` once per changed attribute (~15× per save);
+`bumpItemRevision()` computes one `changedAt = time()` value and stores it in both the journal row
+and `items.revision_changed_at` alongside `items.revision`. **Per-request memo.** `update_item` calls
+`logItems()` once per changed attribute (~15× per save);
 the memo collapses them into one revision. A later call in the same request **rewrites the stored
 row in place** when it knows more — a deletion, or the source folder of a move
-(`itemRevisionShouldUpgradeEntry()`). `resetItemRevisionMemo()` is called per subtask by
+(`itemRevisionShouldUpgradeEntry()`) — it never changes the timestamp. `resetItemRevisionMemo()` is called per subtask by
 `background_tasks___worker.php`, which is long-lived.
 
 **Rule: a new item write path that does not go through `logItems()` must bump explicitly.** The
@@ -87,9 +91,14 @@ five that exist today:
 
 ## API surface
 
-- `revision` returned by `item/get`, `item/inFolders`, `item/findByUrl`, `item/create`, `item/update`
+- `revision` and `revision_changed_at` returned by `item/get`, `item/inFolders`,
+  `item/findByUrl`, `item/create`, `item/update`
 - `GET /api/v1/item/changes?since=&limit=` — the delta feed (see `api-reference.md`)
 - `PUT /api/v1/item/update` accepts an optional `revision` precondition → `409` on mismatch
+
+`revision_changed_at` is a Unix UTC timestamp in seconds, or `NULL` when no reliable date exists.
+The delta feed takes the pair from the winning journal row after deduplication; tombstones cannot
+read from `items` because a purged item no longer has a row.
 
 ## The sync window setting
 

--- a/app/api/Controller/Api/ItemController.php
+++ b/app/api/Controller/Api/ItemController.php
@@ -662,7 +662,8 @@ class ItemController extends BaseController
                 } else {
                     // Query items with the specific URL
                     $rows = DB::query(
-                        "SELECT i.id, i.label, i.login, i.url, i.id_tree, i.favicon_url, i.revision,
+                        "SELECT i.id, i.label, i.login, i.url, i.id_tree, i.favicon_url,
+                                i.revision, i.revision_changed_at,
                                 CASE WHEN o.enabled = 1 THEN 1 ELSE 0 END AS has_otp
                         FROM " . prefixTable('items') . " AS i
                         LEFT JOIN " . prefixTable('items_otp') . " AS o ON (o.item_id = i.id)
@@ -697,6 +698,9 @@ class ItemController extends BaseController
                         $ret[] = [
                             'id' => (int) $row['id'],
                             'revision' => (int) $row['revision'],
+                            'revision_changed_at' => $row['revision_changed_at'] === null
+                                ? null
+                                : (int) $row['revision_changed_at'],
                             'label' => $row['label'],
                             'login' => $row['login'],
                             'url' => $row['url'],

--- a/app/api/Model/ItemModel.php
+++ b/app/api/Model/ItemModel.php
@@ -80,7 +80,7 @@ class ItemModel
         $rows = DB::query(
             "SELECT i.id, i.label, i.description, i.pw, i.pw_iv, i.url, i.id_tree, i.login, i.email,
                 i.viewed_no, i.fa_icon, i.inactif, i.perso, i.favicon_url, i.anyone_can_modify,
-                i.revision,
+                i.revision, i.revision_changed_at,
                 t.title as folder_label,
                 io.secret as otp_secret,
                 io.algorithm as otp_algorithm,
@@ -168,6 +168,9 @@ class ItemModel
                 [
                     'id' => (int) $row['id'],
                     'revision' => (int) $row['revision'],
+                    'revision_changed_at' => $row['revision_changed_at'] === null
+                        ? null
+                        : (int) $row['revision_changed_at'],
                     'label' => $row['label'],
                     'description' => $row['description'],
                     'pwd' => $pwd,
@@ -289,7 +292,7 @@ class ItemModel
     ): array {
         // 1. Scan the journal window.
         $journalRows = DB::query(
-            'SELECT r.revision, r.item_id, r.action
+            'SELECT r.revision, r.item_id, r.action, r.changed_at
             FROM ' . prefixTable('items_revisions') . ' AS r
             WHERE r.revision > %i' . $journalScopeSql . '
             ORDER BY r.revision ASC
@@ -355,6 +358,7 @@ class ItemModel
                 $removed[] = [
                     'id' => (int) $itemId,
                     'revision' => (int) $row['revision'],
+                    'revision_changed_at' => (int) $row['changed_at'],
                     'reason' => $verdict['reason'],
                 ];
                 continue;
@@ -376,6 +380,18 @@ class ItemModel
                 0,
                 [array_keys($toDeliver)]
             );
+
+            // The journal winner defines the cursor contract. A concurrent later update may
+            // already be visible in items, so explicitly keep the revision/timestamp pair from
+            // the winning journal row scanned by this page.
+            foreach ($changed as &$item) {
+                $changedItemId = (int) $item['id'];
+                if (isset($winners[$changedItemId]) === true) {
+                    $item['revision'] = (int) $winners[$changedItemId]['revision'];
+                    $item['revision_changed_at'] = (int) $winners[$changedItemId]['changed_at'];
+                }
+            }
+            unset($item);
         }
 
         // 6. An item whose sharekeys are still being distributed cannot be handed over yet.
@@ -503,12 +519,15 @@ class ItemModel
             // waiting for a manual dashboard scan (no-op when the dashboard is disabled).
             refreshItemHealthAfterSave((int) $newID, $userId, (string) $plaintextPasswordForHealth, $SETTINGS);
 
+            $revisionMetadata = getItemRevisionMetadata((int) $newID);
+
             // Success response
             return [
                 'error' => false,
                 'message' => 'Item added successfully',
                 'newId' => $newID,
-                'revision' => getItemRevision((int) $newID),
+                'revision' => $revisionMetadata['revision'],
+                'revision_changed_at' => $revisionMetadata['revision_changed_at'],
             ];
 
         } catch (Exception $e) {
@@ -687,6 +706,41 @@ class ItemModel
         string $userPrivateKey,
         array $currentItem
     ): string {
+        try {
+            return $this->getItemPasswordForUpdate(
+                $itemId,
+                $userId,
+                $userPrivateKey,
+                $currentItem
+            );
+        } catch (UnexpectedValueException $e) {
+            error_log('[API] ItemModel password comparison failed for item ' . $itemId);
+
+            return "\0lapr-undecryptable";
+        }
+    }
+
+    /**
+     * Recover the current cleartext password before an API password update.
+     *
+     * The migration-aware sharekey path is mandatory. Any missing or unusable key fails
+     * before the caller mutates the item, so a successful password update never knowingly
+     * creates a gap in the encrypted password history.
+     *
+     * @param int    $itemId         Item id
+     * @param int    $userId         Caller id
+     * @param string $userPrivateKey Caller RSA private key (cleartext)
+     * @param array  $currentItem    Current items row
+     *
+     * @return string Current cleartext password
+     * @throws UnexpectedValueException When the password cannot be recovered safely
+     */
+    private function getItemPasswordForUpdate(
+        int $itemId,
+        int $userId,
+        string $userPrivateKey,
+        array $currentItem
+    ): string {
         if (empty($currentItem['pw']) === true) {
             return '';
         }
@@ -698,33 +752,40 @@ class ItemModel
             $userId,
             $itemId
         );
-        if (DB::count() === 0) {
-            return "\0lapr-undecryptable";
+        if ($userKey === null) {
+            throw new UnexpectedValueException('The current item password cannot be decrypted.');
         }
 
         $userPublicKey = (string) DB::queryFirstField(
             'SELECT public_key FROM ' . prefixTable('users') . ' WHERE id = %i',
             $userId
         );
-
-        try {
-            return teampassDecryptPasswordValue(
-                (string) $currentItem['pw'],
-                decryptUserObjectKeyWithMigration(
-                    $userKey['share_key'],
-                    $userPrivateKey,
-                    $userPublicKey,
-                    (int) $userKey['increment_id'],
-                    'sharekeys_items'
-                ),
-                (int) ($currentItem['pw_len'] ?? 0),
-                (string) ($currentItem['pw_iv'] ?? '')
-            );
-        } catch (Exception $e) {
-            error_log('[API] ItemModel LAPR password comparison failed for item ' . $itemId . ': ' . $e->getMessage());
-
-            return "\0lapr-undecryptable";
+        if ($userPublicKey === '') {
+            throw new UnexpectedValueException('The current item password cannot be decrypted.');
         }
+
+        $objectKey = decryptUserObjectKeyWithMigration(
+            (string) $userKey['share_key'],
+            $userPrivateKey,
+            $userPublicKey,
+            (int) $userKey['increment_id'],
+            'sharekeys_items'
+        );
+        if ($objectKey === '') {
+            throw new UnexpectedValueException('The current item password cannot be decrypted.');
+        }
+
+        $password = teampassDecryptPasswordValue(
+            (string) $currentItem['pw'],
+            $objectKey,
+            (int) ($currentItem['pw_len'] ?? 0),
+            (string) ($currentItem['pw_iv'] ?? '')
+        );
+        if ($password === '' && (int) ($currentItem['pw_len'] ?? 0) > 0) {
+            throw new UnexpectedValueException('The current item password cannot be decrypted.');
+        }
+
+        return $password;
     }
 
     /**
@@ -1479,6 +1540,7 @@ class ItemModel
         try {
             include_once API_ROOT_PATH . '/../sources/main.functions.php';
             include_once API_ROOT_PATH . '/../sources/lapr.functions.php';
+            include_once API_ROOT_PATH . '/../sources/item_update_logic.php';
 
             // Load config
             $configManager = new ConfigManager();
@@ -1530,11 +1592,14 @@ class ItemModel
                 // rejected. A password that cannot be decrypted fails closed.
                 $laprPasswordChanged = isset($params['password'])
                     && (string) $params['password'] !== ''
-                    && (string) $params['password'] !== $this->getItemPasswordForComparison(
-                        $itemId,
-                        (int) $userData['id'],
-                        $userPrivateKey,
-                        $currentItem
+                    && itemPasswordHasChanged(
+                        $this->getItemPasswordForComparison(
+                            $itemId,
+                            (int) $userData['id'],
+                            $userPrivateKey,
+                            $currentItem
+                        ),
+                        (string) $params['password']
                     );
                 if ($laprLoginChanged === true || $laprPasswordChanged === true) {
                     return [
@@ -1564,6 +1629,8 @@ class ItemModel
             $updateData = [];
             $passwordKey = null;
             $newPassword = null;
+            $encryptedPreviousPassword = null;
+            $passwordChanged = false;
             $hasTotpUpdate = array_key_exists('totp', $params)
                 || array_key_exists('totp_algorithm', $params)
                 || array_key_exists('totp_digits', $params)
@@ -1700,11 +1767,6 @@ class ItemModel
                 }
             }
 
-            // Generate favicon URL if URL is provided and favicon_url is empty
-            if (empty($currentItem['url']) === false) {
-                $updateData['favicon_url'] = $this->getFaviconUrl($currentItem['url']);
-            }
-
             // Each field is stored the way the web form stores it, so an update cannot
             // reintroduce the markup that validateData() strips on creation
             // (GHSA-r298-6mxv-j9hc).
@@ -1734,9 +1796,16 @@ class ItemModel
                 }
             }
 
+            // Regenerate the favicon only when this request actually changes the URL.
+            if (isset($params['url']) && isset($params['favicon_url']) === false) {
+                $updateData['favicon_url'] = empty($updateData['url']) === true
+                    ? ''
+                    : $this->getFaviconUrl((string) $updateData['url']);
+            }
+
             // Handle password update
             if (isset($params['password']) && !empty($params['password'])) {
-                $newPassword = $params['password'];
+                $newPassword = (string) $params['password'];
 
                 // Validate password length
                 if (strlen($newPassword) > $SETTINGS['pwd_maximum_length']) {
@@ -1747,22 +1816,42 @@ class ItemModel
                     ];
                 }
 
-                // Get folder ID for complexity check
-                $folderId = isset($updateData['id_tree']) ? $updateData['id_tree'] : $currentItem['id_tree'];
+                $currentPassword = $this->getItemPasswordForUpdate(
+                    $itemId,
+                    (int) $userData['id'],
+                    $userPrivateKey,
+                    $currentItem
+                );
 
-                // Get folder settings
-                $itemInfos = $this->getFolderSettings((int) $folderId);
+                if (itemPasswordHasChanged($currentPassword, $newPassword) === true) {
+                    // Prepare the history ciphertext before mutating the item. A master-key
+                    // failure therefore cannot produce a successful update with no old_value.
+                    $previousValue = cryption($currentPassword, '', 'encrypt');
+                    if (($previousValue['error'] ?? true) !== false
+                        || empty($previousValue['string']) === true
+                    ) {
+                        throw new RuntimeException('Failed to prepare encrypted password history.');
+                    }
+                    $encryptedPreviousPassword = (string) $previousValue['string'];
 
-                // Check password complexity — capture score to avoid re-running zxcvbn on the ciphertext
-                $complexityLevel = $this->checkPasswordComplexity($newPassword, array_merge($itemInfos, ['folderId' => $folderId]));
+                    // Get folder ID for complexity check
+                    $folderId = isset($updateData['id_tree']) ? $updateData['id_tree'] : $currentItem['id_tree'];
 
-                // Encrypt password
-                $cryptedData = $this->encryptPassword($newPassword);
-                $passwordKey = $cryptedData['passwordKey'];
-                $updateData['pw'] = $cryptedData['encrypted'];
-                $updateData['pw_iv'] = $cryptedData['meta'] ?? '';
-                $updateData['pw_len'] = strlen($newPassword);
-                $updateData['complexity_level'] = $complexityLevel;
+                    // Get folder settings
+                    $itemInfos = $this->getFolderSettings((int) $folderId);
+
+                    // Check password complexity — capture score to avoid re-running zxcvbn on the ciphertext
+                    $complexityLevel = $this->checkPasswordComplexity($newPassword, array_merge($itemInfos, ['folderId' => $folderId]));
+
+                    // Encrypt password
+                    $cryptedData = $this->encryptPassword($newPassword);
+                    $passwordKey = $cryptedData['passwordKey'];
+                    $updateData['pw'] = $cryptedData['encrypted'];
+                    $updateData['pw_iv'] = $cryptedData['meta'] ?? '';
+                    $updateData['pw_len'] = strlen($newPassword);
+                    $updateData['complexity_level'] = $complexityLevel;
+                    $passwordChanged = true;
+                }
             }
 
             $otpConfiguration = null;
@@ -1803,8 +1892,13 @@ class ItemModel
                 );
             }
             
+            $hasGeneralUpdate = empty($updateData) === false
+                || $hasTotpUpdate === true
+                || isset($params['tags'])
+                || (isset($params['fields']) && is_array($params['fields']));
+
             // Update the item
-            if (!empty($updateData) || $hasTotpUpdate === true) {
+            if (empty($updateData) === false || $hasTotpUpdate === true) {
                 $updateData['updated_at'] = time();
 
                 DB::update(
@@ -1915,17 +2009,38 @@ class ItemModel
                     $moveContext['target_folder_id'],
                     $moveContext['target_folder_title']
                 );
-            } else {
+            }
+
+            if ($passwordChanged === true) {
+                logItems(
+                    $SETTINGS,
+                    $itemId,
+                    (string) $label,
+                    (int) $userData['id'],
+                    'at_modification',
+                    (string) $userData['username'],
+                    'at_pw',
+                    TP_ENCRYPTION_NAME,
+                    null,
+                    (string) $encryptedPreviousPassword
+                );
+            } elseif (is_array($moveContext) === false && $hasGeneralUpdate === true) {
                 logItems($SETTINGS, $itemId, $label, $userData['id'], 'at_modification', $userData['username']);
+            }
+
+            if (is_array($moveContext) === false && $hasGeneralUpdate === true) {
                 updateCacheTable('update_value', $itemId, (int) $userData['id']);
             }
+
+            $revisionMetadata = getItemRevisionMetadata($itemId);
 
             // Success response
             return [
                 'error' => false,
                 'message' => 'Item updated successfully',
                 'item_id' => $itemId,
-                'revision' => getItemRevision($itemId),
+                'revision' => $revisionMetadata['revision'],
+                'revision_changed_at' => $revisionMetadata['revision_changed_at'],
             ];
 
         } catch (InvalidArgumentException | UnexpectedValueException $e) {

--- a/app/api/openapi.json
+++ b/app/api/openapi.json
@@ -552,6 +552,10 @@
                                                     "revision": {
                                                         "type": "integer"
                                                     },
+                                                    "revision_changed_at": {
+                                                        "type": "integer",
+                                                        "description": "Unix UTC timestamp in seconds of the winning journal revision."
+                                                    },
                                                     "reason": {
                                                         "type": "string",
                                                         "enum": [
@@ -713,6 +717,13 @@
                                         "revision": {
                                             "type": "integer",
                                             "description": "Revision of the item after the update"
+                                        },
+                                        "revision_changed_at": {
+                                            "type": [
+                                                "integer",
+                                                "null"
+                                            ],
+                                            "description": "Unix UTC timestamp in seconds paired with the returned revision; null when the date is unknown."
                                         }
                                     }
                                 }
@@ -1189,6 +1200,13 @@
                         "type": "integer",
                         "description": "Monotonic revision of the item, bumped on every content change. Compare it against a cached copy to detect staleness; the larger value is the newer one."
                     },
+                    "revision_changed_at": {
+                        "type": [
+                            "integer",
+                            "null"
+                        ],
+                        "description": "Unix UTC timestamp in seconds paired with revision. It changes on functional content revisions, never on reads or ciphertext-only rewrites; null means the date is unknown."
+                    },
                     "label": {
                         "type": "string"
                     },
@@ -1296,6 +1314,13 @@
                     "revision": {
                         "type": "integer",
                         "description": "Monotonic revision of the item, bumped on every content change. Compare it against a cached copy to detect staleness; the larger value is the newer one."
+                    },
+                    "revision_changed_at": {
+                        "type": [
+                            "integer",
+                            "null"
+                        ],
+                        "description": "Unix UTC timestamp in seconds paired with revision; null when the date is unknown."
                     },
                     "label": {
                         "type": "string"
@@ -1637,6 +1662,13 @@
                     "revision": {
                         "type": "integer",
                         "description": "Revision allocated to the new item"
+                    },
+                    "revision_changed_at": {
+                        "type": [
+                            "integer",
+                            "null"
+                        ],
+                        "description": "Unix UTC timestamp in seconds paired with the allocated revision; null when the date is unknown."
                     }
                 }
             },

--- a/app/sources/item_revisions_logic.php
+++ b/app/sources/item_revisions_logic.php
@@ -241,6 +241,35 @@ function itemRevisionDedupeScan(array $rows): array
 }
 
 /**
+ * Normalize the revision metadata read from an item row.
+ *
+ * Revision 0 predates revision tracking and therefore never has a reliable timestamp.
+ *
+ * @param array<string, mixed>|null $row Item row containing revision metadata
+ *
+ * @return array{revision: int, revision_changed_at: int|null}
+ */
+function itemRevisionMetadataFromRow(?array $row): array
+{
+    if ($row === null) {
+        return [
+            'revision' => 0,
+            'revision_changed_at' => null,
+        ];
+    }
+
+    $revision = (int) ($row['revision'] ?? 0);
+    $changedAt = $row['revision_changed_at'] ?? null;
+
+    return [
+        'revision' => $revision,
+        'revision_changed_at' => $revision > 0 && $changedAt !== null
+            ? (int) $changedAt
+            : null,
+    ];
+}
+
+/**
  * Decide what a client must do with an item that changed.
  *
  * @param int                 $itemId          Item id

--- a/app/sources/item_update_logic.php
+++ b/app/sources/item_update_logic.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Teampass - a collaborative passwords manager.
+ * ---
+ * This file is part of the TeamPass project.
+ *
+ * TeamPass is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * TeamPass is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Certain components of this file may be under different licenses. For
+ * details, see the `licenses` directory or individual file headers.
+ * ---
+ * DB-free decisions used by the API item update path.
+ *
+ * @file      item_update_logic.php
+ * @author    Nils Laumaillé (nils@teampass.net)
+ * @copyright 2009-2026 Teampass.net
+ * @license   GPL-3.0
+ * @see       https://www.teampass.net
+ */
+
+/**
+ * Tell whether a submitted password differs from the current cleartext value.
+ *
+ * @param string $currentPassword   Current server-side cleartext password
+ * @param string $submittedPassword New password received by the API
+ *
+ * @return bool True only for an actual password change
+ */
+function itemPasswordHasChanged(string $currentPassword, string $submittedPassword): bool
+{
+    return hash_equals($currentPassword, $submittedPassword) === false;
+}

--- a/app/sources/main.functions.php
+++ b/app/sources/main.functions.php
@@ -3282,6 +3282,8 @@ function bumpItemRevision(
             $folderId = getItemFolderIdFromDb($itemId);
         }
 
+        $changedAt = time();
+
         DB::insert(
             prefixTable('items_revisions'),
             [
@@ -3290,7 +3292,7 @@ function bumpItemRevision(
                 'previous_folder_id' => $previousFolderId === null ? 0 : (int) $previousFolderId,
                 'action' => $action,
                 'changed_by' => $userId,
-                'changed_at' => time(),
+                'changed_at' => $changedAt,
             ]
         );
         $revision = (int) DB::insertId();
@@ -3299,7 +3301,10 @@ function bumpItemRevision(
         // journal. A purge leaves no row to update, which is expected.
         DB::update(
             prefixTable('items'),
-            ['revision' => $revision],
+            [
+                'revision' => $revision,
+                'revision_changed_at' => $changedAt,
+            ],
             'id = %i',
             $itemId
         );
@@ -3357,21 +3362,35 @@ function pruneItemRevisionsJournal(int $windowDays): int
  */
 function getItemRevision(int $itemId): int
 {
+    return getItemRevisionMetadata($itemId)['revision'];
+}
+
+/**
+ * Read the current revision and its functional change timestamp.
+ *
+ * @param int $itemId Item id
+ *
+ * @return array{revision: int, revision_changed_at: int|null}
+ */
+function getItemRevisionMetadata(int $itemId): array
+{
     if ($itemId <= 0) {
-        return 0;
+        return itemRevisionMetadataFromRow(null);
     }
 
     try {
         loadClasses('DB');
 
         $row = DB::queryFirstRow(
-            'SELECT revision FROM ' . prefixTable('items') . ' WHERE id = %i',
+            'SELECT revision, revision_changed_at
+            FROM ' . prefixTable('items') . '
+            WHERE id = %i',
             $itemId
         );
 
-        return $row === null ? 0 : (int) $row['revision'];
+        return itemRevisionMetadataFromRow($row);
     } catch (\Throwable $e) {
-        return 0;
+        return itemRevisionMetadataFromRow(null);
     }
 }
 

--- a/docs/api/api-basic.md
+++ b/docs/api/api-basic.md
@@ -265,6 +265,7 @@ curl -X GET "https://your-teampass.com/api/index.php/item/inFolders?folders=[1,2
 {
   "id": 2053,
   "revision": 4127,
+  "revision_changed_at": 1787563378,
   "label": "new object for #3500 v3",
   "description": "<p>bla bla</p>",
   "pwd": "SK^dsf123s_6A}]V$t^]",
@@ -287,6 +288,7 @@ curl -X GET "https://your-teampass.com/api/index.php/item/inFolders?folders=[1,2
 | ----- | ---- | ----------- |
 | `id` | integer | Unique item ID |
 | `revision` | integer | Monotonic revision, bumped on every content change of the item or its custom fields, tags, attachments and OTP. Compare it against a cached copy to detect staleness; the larger value is the newer one. `0` means the item has not changed since revision tracking was installed. |
+| `revision_changed_at` | integer or null | Unix UTC timestamp in seconds paired with `revision`. It changes on functional content revisions, never on reads or ciphertext-only rewrites. `null` means the exact date is unknown. |
 | `label` | string | Item label |
 | `description` | string | Description (may contain HTML) |
 | `pwd` | string | Password (decrypted according to rights) |
@@ -447,6 +449,8 @@ curl -X GET "https://your-teampass.com/api/index.php/item/get?description=%25ser
 [
   {
     "id": 123,
+    "revision": 4127,
+    "revision_changed_at": 1787563378,
     "label": "Example Login",
     "login": "user@example.com",
     "url": "https://example.com",
@@ -461,6 +465,8 @@ curl -X GET "https://your-teampass.com/api/index.php/item/get?description=%25ser
 | Field | Type | Description |
 | ----- | ---- | ----------- |
 | `id` | integer | Item ID |
+| `revision` | integer | Monotonic content revision |
+| `revision_changed_at` | integer or null | Unix UTC timestamp in seconds paired with `revision`; `null` when unknown |
 | `label` | string | Label |
 | `login` | string | Login identifier |
 | `url` | string | URL |
@@ -591,7 +597,9 @@ curl -X GET "https://your-teampass.com/api/index.php/item/getOtp?id=123" \
 {
   "error": false,
   "message": "Item created successfully",
-  "newId": "658"
+  "newId": 658,
+  "revision": 4127,
+  "revision_changed_at": 1787563378
 }
 ```
 
@@ -679,9 +687,16 @@ curl -X POST "https://your-teampass.com/api/index.php/item/create" \
 {
   "error": false,
   "message": "Item updated successfully",
-  "item_id": "123"
+  "item_id": 123,
+  "revision": 4128,
+  "revision_changed_at": 1787563378
 }
 ```
+
+When `password` is present, TeamPass compares it with the current cleartext value server-side.
+Resending the same value is a password no-op: by itself it does not rewrite the ciphertext,
+redistribute sharekeys, create a password-history entry, or allocate a revision. A real change stores the previous password
+encrypted in the existing `at_pw` history; the client never sends or receives that previous value.
 
 **Response Codes:**
 
@@ -840,10 +855,10 @@ curl -X GET "https://your-teampass.com/api/index.php/item/allTags" \
   "has_more": false,
   "full_sync_required": false,
   "changed": [
-    { "id": 77, "revision": 12340, "label": "Prod database", "pwd": "…", "fields": [] }
+    { "id": 77, "revision": 12340, "revision_changed_at": 1787563378, "label": "Prod database", "pwd": "…", "fields": [] }
   ],
   "removed": [
-    { "id": 91, "revision": 12331, "reason": "deleted" }
+    { "id": 91, "revision": 12331, "revision_changed_at": 1787563100, "reason": "deleted" }
   ]
 }
 ```
@@ -856,7 +871,10 @@ curl -X GET "https://your-teampass.com/api/index.php/item/allTags" \
 | `has_more` | boolean | More changes are waiting — call again with the returned cursor |
 | `full_sync_required` | boolean | The cursor cannot be served: rebuild the cache and adopt the returned cursor |
 | `changed` | array | Items to upsert, same shape as `item/get` |
-| `removed` | array | Items to drop, with `id`, `revision` and `reason` |
+| `removed` | array | Items to drop, with `id`, `revision`, `revision_changed_at` and `reason` |
+
+The `revision` and `revision_changed_at` values always come from the same winning change. For a
+tombstone, the timestamp comes from the journal because a permanently deleted item has no row left.
 
 `reason` is one of `deleted` (soft deleted), `purged` (permanently removed) or `out_of_scope` (the item still exists but the caller can no longer read it, typically after a move into a folder they have no access to).
 

--- a/public/install/install-steps/run.step5.php
+++ b/public/install/install-steps/run.step5.php
@@ -433,6 +433,7 @@ class DatabaseInstaller
             `hibp_count` int NOT NULL DEFAULT '0',
             `hibp_checked_at` varchar(30) NULL DEFAULT NULL,
             `revision` INT UNSIGNED NOT NULL DEFAULT '0',
+            `revision_changed_at` BIGINT UNSIGNED NULL DEFAULT NULL,
             PRIMARY KEY (`id`),
             KEY `restricted_inactif_idx` (`restricted_to`,`inactif`),
             INDEX items_perso_id_idx (`perso`, `id`),

--- a/public/install/upgrade_run_3.2.2.php
+++ b/public/install/upgrade_run_3.2.2.php
@@ -372,6 +372,19 @@ if ($res === false) {
     exit();
 }
 
+// Durable timestamp paired with items.revision. Unlike items.updated_at, it changes only
+// when a functional content revision is allocated and survives journal pruning.
+$res = addColumnIfNotExist(
+    $pre . 'items',
+    'revision_changed_at',
+    'BIGINT UNSIGNED NULL DEFAULT NULL'
+);
+if ($res === false) {
+    echo '[{"finish":"1", "msg":"", "error":"Error adding column revision_changed_at to items table: ' . addslashes(mysqli_error($db_link)) . '"}]';
+    mysqli_close($db_link);
+    exit();
+}
+
 // Item change journal. Its AUTO_INCREMENT primary key is the globally monotonic
 // revision sequence, and its rows are the only tombstone left once an item row is
 // hard deleted or leaves the caller's visible folders.
@@ -393,6 +406,22 @@ $res = mysqli_query(
 );
 if ($res === false) {
     echo '[{"finish":"1", "msg":"", "error":"Error creating items_revisions table: ' . addslashes(mysqli_error($db_link)) . '"}]';
+    mysqli_close($db_link);
+    exit();
+}
+
+// Backfill only when the current item revision still has its exact journal row. Older
+// journal entries may already have been pruned; their timestamp is genuinely unknown.
+$res = mysqli_query(
+    $db_link,
+    'UPDATE `' . $pre . 'items` AS i
+     INNER JOIN `' . $pre . 'items_revisions` AS r
+        ON r.`item_id` = i.`id` AND r.`revision` = i.`revision`
+     SET i.`revision_changed_at` = r.`changed_at`
+     WHERE i.`revision` > 0 AND i.`revision_changed_at` IS NULL'
+);
+if ($res === false) {
+    echo '[{"finish":"1", "msg":"", "error":"Error backfilling items.revision_changed_at: ' . addslashes(mysqli_error($db_link)) . '"}]';
     mysqli_close($db_link);
     exit();
 }

--- a/tests/Unit/Api/ItemPasswordHistoryTest.php
+++ b/tests/Unit/Api/ItemPasswordHistoryTest.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Wiring guards for encrypted password history on API updates.
+ */
+class ItemPasswordHistoryTest extends TestCase
+{
+    private function itemModelSource(): string
+    {
+        $source = file_get_contents(__DIR__ . '/../../../app/api/Model/ItemModel.php');
+        self::assertIsString($source);
+
+        return str_replace("\r\n", "\n", $source);
+    }
+
+    public function testRevisionPreconditionRunsBeforePasswordRecovery(): void
+    {
+        $source = $this->itemModelSource();
+        $precondition = strpos($source, '// Optimistic concurrency.');
+        $passwordUpdate = strpos($source, '// Handle password update');
+
+        self::assertNotFalse($precondition);
+        self::assertNotFalse($passwordUpdate);
+        self::assertLessThan($passwordUpdate, $precondition);
+    }
+
+    public function testPasswordRecoveryIsMigrationAwareAndFailsClosed(): void
+    {
+        $source = $this->itemModelSource();
+        $start = strpos($source, 'private function getItemPasswordForUpdate(');
+        $end = strpos($source, 'private function getFolderSettings(', (int) $start);
+        self::assertNotFalse($start);
+        self::assertNotFalse($end);
+        $helper = substr($source, (int) $start, (int) $end - (int) $start);
+
+        self::assertStringContainsString('SELECT share_key, increment_id', $helper);
+        self::assertStringContainsString('decryptUserObjectKeyWithMigration(', $helper);
+        self::assertStringContainsString("'sharekeys_items'", $helper);
+        self::assertStringContainsString("throw new UnexpectedValueException('The current item password cannot be decrypted.')", $helper);
+    }
+
+    public function testOldPasswordIsPreparedBeforeMutationAndLoggedEncryptedAfterSharekeys(): void
+    {
+        $source = $this->itemModelSource();
+        $passwordUpdate = strpos($source, '// Handle password update');
+        self::assertNotFalse($passwordUpdate);
+        $updatePath = substr($source, (int) $passwordUpdate);
+
+        $prepareHistory = strpos($updatePath, "cryption(\$currentPassword, '', 'encrypt')");
+        $itemWrite = strpos($updatePath, "DB::update(\n                    prefixTable('items')");
+        $sharekeys = strpos($updatePath, "storeUsersShareKey(\n                    'sharekeys_items'");
+        $passwordAudit = strpos($updatePath, "'at_pw'");
+
+        self::assertNotFalse($prepareHistory);
+        self::assertNotFalse($itemWrite);
+        self::assertNotFalse($sharekeys);
+        self::assertNotFalse($passwordAudit);
+        self::assertLessThan($itemWrite, $prepareHistory);
+        self::assertLessThan($passwordAudit, $sharekeys);
+        self::assertStringContainsString('$encryptedPreviousPassword', $updatePath);
+        self::assertStringContainsString('if ($passwordChanged === true) {', $updatePath);
+        self::assertStringContainsString('(string) $encryptedPreviousPassword', $updatePath);
+        self::assertStringNotContainsString(
+            'if ($passwordChanged === true && $encryptedPreviousPassword !== null)',
+            $updatePath
+        );
+    }
+
+    public function testSecretsAreNotIncludedInApiErrorLogs(): void
+    {
+        $source = $this->itemModelSource();
+
+        self::assertDoesNotMatchRegularExpression('/error_log\([^;]*\$(?:currentPassword|newPassword|encryptedPreviousPassword)/s', $source);
+    }
+}

--- a/tests/Unit/Api/ItemRevisionTimestampTest.php
+++ b/tests/Unit/Api/ItemRevisionTimestampTest.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Contract and schema guards for the durable item revision timestamp.
+ */
+class ItemRevisionTimestampTest extends TestCase
+{
+    private function readSource(string $relativePath): string
+    {
+        $path = __DIR__ . '/../../..' . $relativePath;
+        self::assertFileExists($path, "Source file '$relativePath' not found");
+        $source = file_get_contents($path);
+        self::assertIsString($source);
+
+        return $source;
+    }
+
+    public function testFreshInstallAndUpgradePersistTheTimestamp(): void
+    {
+        $install = $this->readSource('/public/install/install-steps/run.step5.php');
+        $upgrade = $this->readSource('/public/install/upgrade_run_3.2.2.php');
+
+        self::assertStringContainsString('`revision_changed_at` BIGINT UNSIGNED NULL DEFAULT NULL', $install);
+        self::assertStringContainsString("'revision_changed_at'", $upgrade);
+        self::assertStringContainsString('BIGINT UNSIGNED NULL DEFAULT NULL', $upgrade);
+        self::assertStringContainsString('r.`revision` = i.`revision`', $upgrade);
+        self::assertStringContainsString('i.`revision_changed_at` IS NULL', $upgrade);
+        self::assertStringNotContainsString('SET i.`revision_changed_at` = i.`updated_at`', $upgrade);
+    }
+
+    public function testOneTimestampValueIsWrittenToTheJournalAndItem(): void
+    {
+        $source = $this->readSource('/app/sources/main.functions.php');
+        $start = strpos($source, 'function bumpItemRevision(');
+        $end = strpos($source, 'function pruneItemRevisionsJournal(', (int) $start);
+        self::assertNotFalse($start);
+        self::assertNotFalse($end);
+        $function = substr($source, (int) $start, (int) $end - (int) $start);
+
+        self::assertSame(1, substr_count($function, '$changedAt = time();'));
+        self::assertSame(2, substr_count($function, "'revision_changed_at' => \$changedAt") + substr_count($function, "'changed_at' => \$changedAt"));
+        self::assertStringContainsString("'changed_at' => \$changedAt", $function);
+        self::assertStringContainsString("'revision_changed_at' => \$changedAt", $function);
+    }
+
+    public function testOpenApiExposesTimestampEverywhereRevisionIsReturned(): void
+    {
+        $spec = json_decode($this->readSource('/app/api/openapi.json'), true);
+        self::assertIsArray($spec);
+
+        foreach (['Item', 'ItemSummary', 'CreatedResult'] as $schemaName) {
+            self::assertArrayHasKey(
+                'revision_changed_at',
+                $spec['components']['schemas'][$schemaName]['properties'],
+                "$schemaName must expose revision_changed_at"
+            );
+        }
+
+        $updateProperties = $spec['paths']['/item/update']['put']['responses']['200']['content']['application/json']['schema']['properties'];
+        self::assertArrayHasKey('revision_changed_at', $updateProperties);
+
+        $removedProperties = $spec['paths']['/item/changes']['get']['responses']['200']['content']['application/json']['schema']['properties']['removed']['items']['properties'];
+        self::assertArrayHasKey('revision_changed_at', $removedProperties);
+    }
+
+    public function testDedicatedFindByUrlAndDeltaPathsReturnTheTimestamp(): void
+    {
+        $controller = $this->readSource('/app/api/Controller/Api/ItemController.php');
+        $model = $this->readSource('/app/api/Model/ItemModel.php');
+
+        self::assertStringContainsString('i.revision, i.revision_changed_at', $controller);
+        self::assertStringContainsString("'revision_changed_at' => \$row['revision_changed_at']", $controller);
+        self::assertStringContainsString('r.action, r.changed_at', $model);
+        self::assertStringContainsString("'revision_changed_at' => (int) \$row['changed_at']", $model);
+        self::assertStringContainsString("\$item['revision_changed_at'] = (int) \$winners[\$changedItemId]['changed_at']", $model);
+    }
+}

--- a/tests/Unit/ItemRevisionsLogicTest.php
+++ b/tests/Unit/ItemRevisionsLogicTest.php
@@ -194,10 +194,10 @@ class ItemRevisionsLogicTest extends TestCase
     public function testScanKeepsOnlyTheLastEntryPerItem(): void
     {
         $rows = [
-            ['revision' => 10, 'item_id' => 7, 'action' => 'updated'],
-            ['revision' => 11, 'item_id' => 9, 'action' => 'created'],
-            ['revision' => 12, 'item_id' => 7, 'action' => 'moved'],
-            ['revision' => 13, 'item_id' => 7, 'action' => 'deleted'],
+            ['revision' => 10, 'item_id' => 7, 'action' => 'updated', 'changed_at' => 1000],
+            ['revision' => 11, 'item_id' => 9, 'action' => 'created', 'changed_at' => 1100],
+            ['revision' => 12, 'item_id' => 7, 'action' => 'moved', 'changed_at' => 1200],
+            ['revision' => 13, 'item_id' => 7, 'action' => 'deleted', 'changed_at' => 1300],
         ];
 
         $winners = itemRevisionDedupeScan($rows);
@@ -205,7 +205,42 @@ class ItemRevisionsLogicTest extends TestCase
         self::assertCount(2, $winners);
         self::assertSame(13, (int) $winners[7]['revision']);
         self::assertSame('deleted', $winners[7]['action']);
+        self::assertSame(1300, (int) $winners[7]['changed_at']);
         self::assertSame(11, (int) $winners[9]['revision']);
+        self::assertSame(1100, (int) $winners[9]['changed_at']);
+    }
+
+    public function testRevisionMetadataKeepsRevisionAndTimestampPaired(): void
+    {
+        self::assertSame(
+            ['revision' => 42, 'revision_changed_at' => 1_787_563_378],
+            itemRevisionMetadataFromRow([
+                'revision' => '42',
+                'revision_changed_at' => '1787563378',
+            ])
+        );
+    }
+
+    public function testUnknownRevisionTimestampIsNeverInvented(): void
+    {
+        self::assertSame(
+            ['revision' => 0, 'revision_changed_at' => null],
+            itemRevisionMetadataFromRow(null)
+        );
+        self::assertSame(
+            ['revision' => 0, 'revision_changed_at' => null],
+            itemRevisionMetadataFromRow([
+                'revision' => 0,
+                'revision_changed_at' => 1_787_563_378,
+            ])
+        );
+        self::assertSame(
+            ['revision' => 42, 'revision_changed_at' => null],
+            itemRevisionMetadataFromRow([
+                'revision' => 42,
+                'revision_changed_at' => null,
+            ])
+        );
     }
 
     public function testScanIgnoresRowsWithoutAnItem(): void

--- a/tests/Unit/ItemUpdateLogicTest.php
+++ b/tests/Unit/ItemUpdateLogicTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../app/sources/item_update_logic.php';
+
+/**
+ * Behavioural tests for DB-free API item update decisions.
+ */
+class ItemUpdateLogicTest extends TestCase
+{
+    public function testResubmittingTheSamePasswordIsNotAChange(): void
+    {
+        self::assertFalse(itemPasswordHasChanged('same-secret', 'same-secret'));
+        self::assertFalse(itemPasswordHasChanged('', ''));
+        self::assertFalse(itemPasswordHasChanged("binary\0secret", "binary\0secret"));
+    }
+
+    public function testDifferentPasswordsAreAChange(): void
+    {
+        self::assertTrue(itemPasswordHasChanged('old-secret', 'new-secret'));
+        self::assertTrue(itemPasswordHasChanged('', 'new-secret'));
+        self::assertTrue(itemPasswordHasChanged('Secret', 'secret'));
+    }
+
+    public function testComparisonUsesTheTimingSafePrimitive(): void
+    {
+        $source = file_get_contents(__DIR__ . '/../../app/sources/item_update_logic.php');
+        self::assertIsString($source);
+        self::assertStringContainsString('hash_equals($currentPassword, $submittedPassword)', $source);
+    }
+}


### PR DESCRIPTION
## Description

This PR aligns API password updates with the TeamPass web application and exposes a durable date
for the latest functional item revision. It addresses two requirements from the mobile client:

1. Preserve the former password in TeamPass history when the password is changed through the API.
2. Return the exact date associated with the current item revision so clients can display the last
   functional modification date.

### Encrypted password history for API updates

When `PUT /item/update` receives a non-empty password, the server now:

1. Evaluates the optional optimistic-concurrency `revision` precondition before password work.
2. Recovers the current object key through `decryptUserObjectKeyWithMigration()`, preserving the
   transparent phpseclib v1-to-v3 migration behavior.
3. Decrypts the current password with `teampassDecryptPasswordValue()`.
4. Compares the current and submitted passwords with `hash_equals()`.
5. Encrypts the previous cleartext password with the TeamPass application key before mutating the
   item.
6. Updates the password and its sharekeys through the existing API flow.
7. Adds an `at_modification` / `at_pw` entry to `log_items`, with the encrypted previous password
   in `old_value` and `TP_ENCRYPTION_NAME` as its encryption type.

If the current password or its key cannot be recovered, the request fails with `422` before the
item is changed. Failure to prepare the encrypted history value returns a generic `500` response
without exposing cryptographic details.

Submitting the current password is a password no-op. By itself, it does not rewrite the
ciphertext, redistribute sharekeys, add a history entry, or allocate a new revision.

### Durable item revision timestamp

The items table receives a nullable `BIGINT UNSIGNED` column named `revision_changed_at`. This is
the Unix UTC timestamp paired with the current `revision`; it is not a general row update date.

`bumpItemRevision()` computes one timestamp and stores it in both:

- `items_revisions.changed_at`; and
- `items.revision_changed_at`, alongside `items.revision`.

The revision and timestamp therefore remain one logical pair. Reads, access logs and
ciphertext-only migrations continue not to allocate functional revisions.

`revision_changed_at` is returned by:

- `GET /item/get`
- `GET /item/inFolders`
- `GET /item/findByUrl`
- `GET /item/changes`, for changed items and removed-item tombstones
- `POST /item/create`
- `PUT /item/update`

The delta feed takes both values from the winning journal entry after per-item deduplication. This
prevents a scanned revision from being paired with the timestamp of a newer concurrent item state.
Tombstone timestamps also come from the journal because a purged item no longer has an item row.

### Install, upgrade and compatibility

- Fresh installations create `items.revision_changed_at` in
  `public/install/install-steps/run.step5.php`.
- Upgrades add the column idempotently in `public/install/upgrade_run_3.2.2.php`.
- The upgrade backfills a date only when the exact current `(item_id, revision)` journal row still
  exists. Revision `0` and revisions whose journal entry was pruned remain `NULL`.
- The migration deliberately does not fall back to `items.updated_at`, whose semantics are not
  reliable for a functional content revision.
- The API change is additive. Existing clients may ignore the new field; clients that consume it
  must accept `null` when an exact date is unavailable.
- The normal TeamPass install/upgrade process must run before the updated API serves item queries,
  because those queries select the new column.

### Atomicity

This PR keeps the existing TeamPass API write model. It does not introduce a new transaction
across the item row, sharekey distribution, audit logging, cache refreshes and WebSocket side
effects.

Within that model, the revision precondition, current-password recovery and history encryption all
run before the item mutation. The existing item-write, dependent-sharekey and audit/cache ordering
is retained. A broader all-or-nothing transaction would require a separate refactor of helpers that
perform multiple writes and intentionally isolate audit failures from the main operation.

The OpenAPI 3.1 contract and the API and architecture documentation are updated accordingly.

## Related issue

No related issue number was provided.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (existing behaviour changes)
- [x] Documentation
- [ ] Translation
- [ ] Refactor / maintenance

## How has this been tested?

The following local static checks were completed successfully:

- `app/api/openapi.json` parses successfully with PowerShell `ConvertFrom-Json`.
- The OpenAPI schemas expose `revision_changed_at` for full items, item summaries, create/update
  results and removed-item tombstones.
- Source guards confirm that the revision precondition and encrypted-history preparation occur
  before the item write, and that the password audit entry occurs after sharekey work.
- Both fresh-install and upgrade definitions contain the new column, and the upgrade uses the
  exact `(item_id, revision)` journal join for its backfill.
- The 15 files published on `guerricv/TeamPass:api_update` exactly match the reviewed local files.
- The branch is 15 commits ahead and 0 commits behind `nilsteampassnet/TeamPass:develop`.
- No conflict markers, `var_dump()` calls or `console.log()` calls were found in the PR files.

Tests added or updated:

- `ItemUpdateLogicTest` covers unchanged and changed passwords and the timing-safe comparison.
- `ItemPasswordHistoryTest` guards precondition ordering, migration-aware recovery, fail-closed
  behavior, history preparation, audit ordering and secret-free error logging.
- `ItemRevisionsLogicTest` covers revision/timestamp normalization and delta deduplication.
- `ItemRevisionTimestampTest` covers both schema paths, exact backfill, paired timestamp writes,
  OpenAPI coverage, `findByUrl`, delta items and tombstones.

PHP syntax checks, PHPUnit, PHPStan and database-backed install/upgrade scenarios were not executed
locally because this workspace has no PHP CLI, WSL installation or test database. GitHub currently
reports no check runs for the branch head. Opening the PR against `develop` should trigger the
repository's Quality workflow (PHPUnit and PHPStan) and CodeQL workflow.

No runtime role matrix has therefore been exercised yet: admin, manager, standard and read-only
users are untested, with personal folders both enabled and disabled. The following scenarios should
be covered before merge:

1. Change an item password through the API and confirm that the former password appears in the web
   history as an encrypted `at_pw` value.
2. Submit the same password alone and confirm that the revision, timestamp, ciphertext, sharekeys
   and history remain unchanged.
3. Verify item reads and delta synchronization with public and personal folders.
4. Verify a fresh installation and an upgrade with revision `0`, an exact journal match and a
   pruned journal entry.
5. Verify changed-item and delete/purge tombstone revision/timestamp pairs.

## Checklist

- [ ] PHPStan level 4 passes (`php app/vendor/bin/phpstan analyse --memory-limit=2G`)
- [ ] The test suite passes (`php app/vendor/phpunit/phpunit/phpunit`)
- [x] Every new public function has a docblock
- [x] Variable names and comments are in English
- [x] No `var_dump()` or `console.log()` left in the code
- [x] New `app/sources/*.queries.php` files have a matching `public/sources/` proxy shim
  (not applicable: no query handler was added)
- [x] Changes to `teampassclasses` were applied to **both** copies (`app/includes/libraries/` and `app/vendor/`)
  (not applicable: no `teampassclasses` file was changed)
- [x] `app/vendor/composer/` is in its production form (`git checkout -- app/vendor/composer/`)
  (no `app/vendor/` file is present in the branch diff)

## Impact on install / upgrade

- [ ] No schema change
- [ ] Schema change — an `install/upgrade_run_X.X.X.php` script is included and the fresh install path was tested

Schema changes are included in both `public/install/upgrade_run_3.2.2.php` and the fresh-install
path. The checkbox remains open because the fresh installation and upgrade were not executed
against a database in this workspace.

## Screenshots

Not applicable. This PR changes the API, database schema and backend behavior without adding or
changing a web UI.
