### PR TITLE
Fix search in nested personal folders

### DIFF
--- a/app/sources/find.queries.php
+++ b/app/sources/find.queries.php
@@ -145,35 +145,7 @@ if (count($folders) === 0) {
     exit;
 }
 
-//Get current user "personal folder" ID
-$row = DB::queryFirstRow(
-    'SELECT id FROM ' . prefixTable('nested_tree') . ' WHERE title = %i',
-    intval($session->get('user-id'))
-);
-//get list of personal folders
-$arrayPf = [];
 $crit = [];
-$listPf = '';
-if (empty($row['id']) === false) {
-    $rows = DB::query(
-        'SELECT id FROM ' . prefixTable('nested_tree') . '
-        WHERE personal_folder = 1 AND NOT parent_id = %i AND NOT title = %i',
-        filter_var($row['id'], FILTER_SANITIZE_NUMBER_INT),
-        filter_var($session->get('user-id'), FILTER_SANITIZE_NUMBER_INT)
-    );
-    foreach ($rows as $record) {
-        if (! in_array($record['id'], $arrayPf)) {
-            //build an array of personal folders ids
-            array_push($arrayPf, $record['id']);
-            //build also a string with those ids
-            if (empty($listPf)) {
-                $listPf = $record['id'];
-            } else {
-                $listPf .= ', ' . $record['id'];
-            }
-        }
-    }
-}
 
 /* BUILD QUERY */
 //Paging
@@ -230,7 +202,6 @@ if (empty($search_criteria) === false) {
         '7' => $search_criteria,
         '8' => $search_criteria,
         '9' => $search_criteria,
-        'pf' => $arrayPf,
     ];
 }
 
@@ -248,16 +219,10 @@ if (count($crit) === 0) {
         '7' => $search_criteria,
         '8' => $search_criteria,
         '9' => $search_criteria,
-        'pf' => $arrayPf,
     ];
 }
 
-// Do NOT show the items in PERSONAL FOLDERS
-if (empty($listPf) === false) {
-    $sWhere = 'WHERE ' . $sWhere . ' AND c.id_tree NOT IN %ls_pf ';
-} else {
-    $sWhere = 'WHERE ' . $sWhere;
-}
+$sWhere = 'WHERE ' . $sWhere;
 
 // Do queries
 DB::query(

--- a/app/sources/palette.queries.php
+++ b/app/sources/palette.queries.php
@@ -44,6 +44,7 @@ use TeampassClasses\ConfigManager\ConfigManager;
 // Load functions
 require_once 'main.functions.php';
 require_once __DIR__ . '/palette.functions.php';
+require_once __DIR__ . '/search.functions.php';
 
 // init
 loadClasses('DB');
@@ -143,26 +144,12 @@ switch ($post_type) {
         if (count($accessibleFolders) > 0) {
             $tree = new NestedTree(prefixTable('nested_tree'), 'id', 'parent_id', 'title');
 
-            // Belt-and-braces: exclude foreign personal folders (same rule as the
-            // search page, on top of the accessible-folders scope). The user's own
-            // personal tree (root titled with the user id + its children) stays in.
-            $otherPersonalFolders = [];
-            $pfRoot = DB::queryFirstRow(
-                'SELECT id FROM ' . prefixTable('nested_tree') . ' WHERE title = %i',
-                (int) $session->get('user-id')
+            // Use the same ACL primitive as both search pages. In particular,
+            // own personal folders remain searchable at every nesting depth.
+            $searchableFolders = searchResolveFolderScope(
+                $accessibleFolders,
+                (array) ($session->get('user-forbiden_personal_folders') ?? [])
             );
-            if (empty($pfRoot['id']) === false) {
-                $pfRows = DB::query(
-                    'SELECT id FROM ' . prefixTable('nested_tree') . '
-                    WHERE personal_folder = 1 AND NOT parent_id = %i AND NOT title = %i',
-                    (int) $pfRoot['id'],
-                    (int) $session->get('user-id')
-                );
-                foreach ($pfRows as $pfRow) {
-                    $otherPersonalFolders[] = (int) $pfRow['id'];
-                }
-            }
-            $searchableFolders = array_values(array_diff($accessibleFolders, $otherPersonalFolders));
 
             if (count($searchableFolders) > 0) {
                 // Items — from the search cache (labels/logins/urls/tags, no secret).

--- a/app/sources/search.functions.php
+++ b/app/sources/search.functions.php
@@ -42,8 +42,8 @@ declare(strict_types=1);
  * Resolve the folder scope a search may read from.
  *
  * This is the single authorization primitive of the search feature. It is
- * shared by find.queries.php (legacy quick search) and search.queries.php
- * so the two can never diverge.
+ * shared by find.queries.php (legacy quick search), search.queries.php, and
+ * palette.queries.php so the three entry points cannot diverge.
  *
  * Two rules, both mandatory:
  *  - a caller-supplied subtree only ever *narrows* the scope. It is

--- a/tests/Unit/SearchFolderScopeTest.php
+++ b/tests/Unit/SearchFolderScopeTest.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;
 
-// Real production logic (DB-free) shared by find.queries.php and
-// search.queries.php.
+// Real production logic (DB-free) shared by find.queries.php,
+// search.queries.php, and palette.queries.php.
 require_once __DIR__ . '/../../app/sources/search.functions.php';
 
 /**
@@ -45,6 +45,45 @@ class SearchFolderScopeTest extends TestCase
     public function testForeignPersonalFoldersAreSubtracted(): void
     {
         $this->assertSame([3, 9], searchResolveFolderScope([3, 7, 9], [7]));
+    }
+
+    public function testOwnDeeplyNestedPersonalFoldersRemainSearchable(): void
+    {
+        // 10 -> 11 -> 12 models a personal root, child, and grandchild.
+        // Only the foreign personal tree (20 -> 21) must be removed.
+        $this->assertSame(
+            [10, 11, 12],
+            searchResolveFolderScope([10, 11, 12, 20, 21], [20, 21])
+        );
+    }
+
+    public function testLimitedSearchCanTargetADeepOwnPersonalFolder(): void
+    {
+        $this->assertSame(
+            [12],
+            searchResolveFolderScope([10, 11, 12], [], [12])
+        );
+    }
+
+    public function testAllItemSearchHandlersUseTheSharedFolderScope(): void
+    {
+        foreach (['find.queries.php', 'search.queries.php', 'palette.queries.php'] as $handler) {
+            $source = file_get_contents(__DIR__ . '/../../app/sources/' . $handler);
+
+            $this->assertIsString($source);
+            $this->assertStringContainsString('searchResolveFolderScope(', $source, $handler);
+        }
+    }
+
+    public function testLegacyPersonalFolderDepthHeuristicIsNotUsed(): void
+    {
+        foreach (['find.queries.php', 'palette.queries.php'] as $handler) {
+            $source = file_get_contents(__DIR__ . '/../../app/sources/' . $handler);
+
+            $this->assertIsString($source);
+            $this->assertStringNotContainsString('NOT parent_id = %i AND NOT title = %i', $source, $handler);
+            $this->assertStringNotContainsString('c.id_tree NOT IN %ls_pf', $source, $handler);
+        }
     }
 
     public function testDenialBeatsAnExplicitlyRequestedSubtree(): void


### PR DESCRIPTION
## Description

This PR fixes inconsistent search results for items and folders located more than one level below a user's personal-folder root.

The command palette and the legacy quick search on the Items page applied an additional parent-based heuristic after resolving the user's accessible folders. That heuristic kept the personal root and its direct children, but incorrectly treated deeper descendants as foreign personal folders. As a result, an item could be visible while browsing its folder and discoverable from the full Search page, yet remain absent from both `Ctrl+K` and the Items-page search.

The change:

- makes the command palette use the existing `searchResolveFolderScope()` authorization primitive;
- removes the redundant depth-based personal-folder exclusion from `find.queries.php`;
- keeps limited search as an intersection with the authorized folder scope;
- continues to exclude folders belonging to other users' personal trees;
- applies the corrected scope to both item and folder results in the command palette;
- adds regression coverage for deeply nested personal folders and all three search entry points.

No cache rebuild, schema migration, or configuration change is required.

## Related issue

No linked issue. The problem was reproduced in a lab with a standard user's item stored in a deeply nested personal folder.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (existing behaviour changes)
- [ ] Documentation
- [ ] Translation
- [ ] Refactor / maintenance

## How has this been tested?

Regression tests were added to verify that:

- a personal root, its child, and its grandchild remain searchable;
- a limited search can target a deeply nested personal folder;
- `find.queries.php`, `search.queries.php`, and `palette.queries.php` all use the shared folder-scope resolver;
- the former parent-depth heuristic cannot be reintroduced unnoticed.

Local validation performed:

- all four modified PHP files were parsed successfully for syntax errors;
- `git diff --check` completed successfully;
- the final diff was reviewed against `develop` and contains no unrelated changes.

The PHPUnit suite and PHPStan were not run locally because no PHP runtime is available in the local development environment. They are intentionally left unchecked below for CI verification.

Manual verification scenario:

- standard user with personal folders enabled;
- search for a deeply nested personal item through `Ctrl+K`;
- search for its containing folder through `Ctrl+K`;
- search for the item from the Items page with limited search both disabled and enabled;
- confirm that the full Search page continues to return the same item.

Admin, manager, and read-only roles were not manually exercised because the defect is specific to a standard user's own personal-folder hierarchy. The shared authorization primitive continues to subtract forbidden personal folders for every role.

## Checklist

- [ ] PHPStan level 4 passes (`php app/vendor/bin/phpstan analyse --memory-limit=2G`)
- [ ] The test suite passes (`php _tools/phpunit.phar` — see CONTRIBUTING.md for the one-time setup)
- [x] Every new public function has a docblock
- [x] Variable names and comments are in English
- [x] No `var_dump()` or `console.log()` left in the code
- [x] New `app/sources/*.queries.php` files have a matching `public/sources/` proxy shim
- [x] Changes to `teampassclasses` were applied to **both** copies (`app/includes/libraries/` and `app/vendor/`)
- [x] `app/vendor/composer/` is in its production form (`git checkout -- app/vendor/composer/`)

The proxy-shim and dual-copy checklist entries are not applicable because this PR adds no handler and changes no `teampassclasses` package.

## Impact on install / upgrade

- [x] No schema change
- [ ] Schema change — an `install/upgrade_run_X.X.X.php` script is included and the fresh install path was tested

## Screenshots

Not applicable. This PR changes search authorization and result scoping without changing the user interface.
