### PR TITLE
Fix fatal error on invalid save_user_location requests

### DIFF
--- a/app/sources/main.queries.php
+++ b/app/sources/main.queries.php
@@ -45,6 +45,7 @@ use TeampassClasses\EmailService\EmailSettings;
 
 // Load functions
 require_once 'main.functions.php';
+require_once __DIR__ . '/main_queries_logic.php';
 
 loadClasses('DB');
 $session = SessionManager::getSession();
@@ -526,9 +527,26 @@ function userHandler(string $post_type, array|null|string $dataReceived, array $
             );
 
         case 'save_user_location'://action_user
+            if (
+                isSaveUserLocationRequestValid(
+                    $dataReceived,
+                    $post_key,
+                    (string) $session->get('key')
+                ) === false
+            ) {
+                http_response_code(400);
+
+                return prepareExchangedData(
+                    array(
+                        'error' => true,
+                    ),
+                    'encode'
+                );
+            }
+
             return userSaveIp(
                 (int) $session->get('user-id'),
-                (string) filter_var($dataReceived['action'], FILTER_SANITIZE_FULL_SPECIAL_CHARS),
+                'perform',
             );
 
         /*

--- a/app/sources/main_queries_logic.php
+++ b/app/sources/main_queries_logic.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Teampass - a collaborative passwords manager.
+ * ---
+ * This file is part of the TeamPass project.
+ *
+ * TeamPass is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * TeamPass is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Certain components of this file may be under different licenses. For
+ * details, see the `licenses` directory or individual file headers.
+ * ---
+ * DB-free validation shared by the main AJAX handler and its unit tests.
+ *
+ * @file      main_queries_logic.php
+ * @author    Teampass Community
+ * @copyright 2009-2026 Teampass.net
+ * @license   GPL-3.0
+ * @see       https://www.teampass.net
+ */
+
+/**
+ * Validate a request that records the current user's IP address.
+ *
+ * @param array<string, mixed>|null|string $dataReceived Decoded request payload
+ * @param string                          $postKey      Key sent by the client
+ * @param string                          $sessionKey   Current server-side session key
+ *
+ * @return bool True only for a complete request from the current session
+ */
+function isSaveUserLocationRequestValid(
+    array|null|string $dataReceived,
+    string $postKey,
+    string $sessionKey
+): bool {
+    if (
+        $sessionKey === ''
+        || hash_equals($sessionKey, $postKey) === false
+        || is_array($dataReceived) === false
+    ) {
+        return false;
+    }
+
+    return ($dataReceived['action'] ?? null) === 'perform';
+}

--- a/tests/Unit/SaveUserLocationLogicTest.php
+++ b/tests/Unit/SaveUserLocationLogicTest.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../app/sources/main_queries_logic.php';
+
+/**
+ * Behavioural and integration tests for save_user_location request validation.
+ */
+class SaveUserLocationLogicTest extends TestCase
+{
+    public function testAcceptsTheExpectedPayloadFromTheCurrentSession(): void
+    {
+        self::assertTrue(
+            isSaveUserLocationRequestValid(
+                ['user_id' => 42, 'action' => 'perform'],
+                'current-session-key',
+                'current-session-key'
+            )
+        );
+    }
+
+    /**
+     * @dataProvider invalidRequestProvider
+     *
+     * @param array<string, mixed>|null|string $payload
+     */
+    public function testRejectsIncompleteMalformedOrStaleRequests(
+        array|null|string $payload,
+        string $postKey,
+        string $sessionKey
+    ): void {
+        self::assertFalse(isSaveUserLocationRequestValid($payload, $postKey, $sessionKey));
+    }
+
+    /**
+     * @return iterable<string, array{array<string, mixed>|null|string, string, string}>
+     */
+    public static function invalidRequestProvider(): iterable
+    {
+        yield 'missing payload' => ['', 'current-session-key', 'current-session-key'];
+        yield 'null payload' => [null, 'current-session-key', 'current-session-key'];
+        yield 'missing action' => [[], 'current-session-key', 'current-session-key'];
+        yield 'unexpected action' => [['action' => 'skip'], 'current-session-key', 'current-session-key'];
+        yield 'non-string action' => [['action' => true], 'current-session-key', 'current-session-key'];
+        yield 'stale client key' => [['action' => 'perform'], 'old-session-key', 'current-session-key'];
+        yield 'missing session key' => [['action' => 'perform'], '', ''];
+    }
+
+    public function testMainHandlerValidatesBeforeSavingTheLocation(): void
+    {
+        $source = file_get_contents(__DIR__ . '/../../app/sources/main.queries.php');
+        self::assertIsString($source);
+
+        $caseStart = strpos($source, "case 'save_user_location'");
+        $caseEnd = strpos($source, 'default :', (int) $caseStart);
+        self::assertIsInt($caseStart);
+        self::assertIsInt($caseEnd);
+
+        $caseBody = substr($source, $caseStart, $caseEnd - $caseStart);
+        $validationPosition = strpos($caseBody, 'isSaveUserLocationRequestValid(');
+        $savePosition = strpos($caseBody, 'userSaveIp(');
+
+        self::assertIsInt($validationPosition);
+        self::assertIsInt($savePosition);
+        self::assertLessThan($savePosition, $validationPosition);
+        self::assertStringContainsString('http_response_code(400);', $caseBody);
+        self::assertStringNotContainsString("\$dataReceived['action']", $caseBody);
+    }
+}


### PR DESCRIPTION
## Description

A production PHP-FPM log exposed an intermittent fatal error in the `save_user_location` route:

```text
TypeError: Cannot access offset of type string on string in userHandler()
```

`mainQuery()` intentionally represents missing `data` or a failed decode/decryption as an empty string. `userHandler()` accepts that union type, but the `save_user_location` case accessed `$dataReceived['action']` without first proving that the decoded payload was an array. A malformed request, an expired/stale client session key, or a request without usable encrypted data could therefore terminate the PHP request instead of being rejected cleanly.

This PR adds a small database-free validation helper for this route. Before storing the user's location, it now verifies that:

- the current session key is non-empty and matches the posted key using `hash_equals()`;
- the decoded payload is an array;
- its `action` is exactly `perform`.

Rejected requests return HTTP 400 with the usual encrypted error response. Returning a non-2xx status is important here because the current jQuery caller sets `location_stored=1` from its success callback. Valid requests keep using the authenticated session user ID; no client-provided user ID is trusted.

Focused unit tests cover the valid request, malformed payload variants, stale or empty session keys, and the route wiring that must validate before calling `userSaveIp()`.

## Related issue

No GitHub issue — observed in production logs.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (existing behaviour changes)
- [ ] Documentation
- [ ] Translation
- [ ] Refactor / maintenance

## How has this been tested?

- `git diff --check upstream/develop...HEAD`
- Manual review of the route wiring and all malformed-input branches
- Added `tests/Unit/SaveUserLocationLogicTest.php`
- GitHub CI: PHPStan level 4 and the complete PHPUnit suite passed on PHP 8.2 and PHP 8.3

PHPStan and PHPUnit could not be run locally because this workstation has no PHP runtime; both were validated by the PR CI. Role and personal-folder combinations are not applicable to this database-free request-validation change; it does not alter permissions, the UI, or folder behavior.

## Checklist

- [x] PHPStan level 4 passes (`php app/vendor/bin/phpstan analyse --memory-limit=2G`)
- [x] The test suite passes (`php _tools/phpunit.phar` — see CONTRIBUTING.md for the one-time setup)
- [x] Every new public function has a docblock
- [x] Variable names and comments are in English
- [x] No `var_dump()` or `console.log()` left in the changed code
- [x] New `app/sources/*.queries.php` files have a matching `public/sources/` proxy shim (not applicable: no query handler was added)
- [x] Changes to `teampassclasses` were applied to **both** copies (`app/includes/libraries/` and `app/vendor/`) (not applicable: neither copy was changed)
- [x] `app/vendor/composer/` is in its production form (`git checkout -- app/vendor/composer/`)

## Impact on install / upgrade

- [x] No schema change
- [ ] Schema change — an `install/upgrade_run_X.X.X.php` script is included and the fresh install path was tested

## Screenshots

Not applicable — backend robustness change with no UI changes.
