### PR TITLE
Add idempotent item mutations and conditional delete

### DIFF
--- a/.claude/docs/api-reference.md
+++ b/.claude/docs/api-reference.md
@@ -249,12 +249,13 @@ Create a new item.
 
 **Optional idempotency:** `Idempotency-Key: <opaque-key>` (1–128 visible ASCII characters,
 without spaces). Its identity is scoped to the authenticated user and `item.create`. The first
-accepted request returns the normal `201`; an identical replay within 90 days returns the exact
-stored result and `Idempotency-Replayed: true` without repeating any write or side effect. Reusing
-the key with a different functional payload returns `409`. A concurrent request still holding the
-key's processing lease also returns `409` with `Retry-After`. The fingerprint covers every
-functional create field, including credential, TOTP and custom-field values, but is a
-server-secret HMAC: neither those values, the request body nor the raw key is persisted.
+accepted request returns the normal `201`; an identical replay within the configured offline-sync
+window (`offline_sync_window_days`, 90 days by default, `0` for no limit) returns the exact stored
+result and `Idempotency-Replayed: true` without repeating any write or side effect. Reusing the key
+with a different functional payload returns `409`. A concurrent request still holding the key's
+processing lease also returns `409` with `Retry-After`. The fingerprint covers every functional
+create field, including credential, TOTP and custom-field values, but is a server-secret HMAC:
+neither those values, the request body nor the raw key is persisted.
 
 **Custom fields:** `fields` = array of `{ id, value }` (field id + value). Encrypt-before-INSERT for encrypted categories; creator sharekey created synchronously, other users via the `new_item` background task. Only fields tied to the folder are stored; empty values ignored. Requires `item_extra_fields`.
 
@@ -323,9 +324,10 @@ Soft-delete an item.
 **Params:** `id` (int), optional `revision` (unsigned 32-bit integer). When supplied, `revision`
 is an optimistic-concurrency precondition checked against the locked item row immediately before
 the mutation. A mismatch returns `409` with no delete, audit, revision, cache change or WebSocket
-event. Omitting it preserves the historical last-writer-wins behavior.
+event. Omitting it or sending an empty query value preserves the historical last-writer-wins
+behavior.
 
-**Optional idempotency:** `Idempotency-Key` follows the same syntax and 90-day replay window as
+**Optional idempotency:** `Idempotency-Key` follows the same syntax and configured replay window as
 create, scoped to the authenticated user and `item.delete`. Its fingerprint contains the item id
 and the expected revision (including omission). A replay returns the original successful result
 with `Idempotency-Replayed: true`; it never deletes again, so a later restoration is not undone.

--- a/.claude/docs/api-reference.md
+++ b/.claude/docs/api-reference.md
@@ -247,9 +247,18 @@ Create a new item.
 
 **Body:** `label`, `password`, `folder_id`, optional `description`, `login`, `email`, `url`, `tags`, `totp`, `fields`.
 
+**Optional idempotency:** `Idempotency-Key: <opaque-key>` (1–128 visible ASCII characters,
+without spaces). Its identity is scoped to the authenticated user and `item.create`. The first
+accepted request returns the normal `201`; an identical replay within 90 days returns the exact
+stored result and `Idempotency-Replayed: true` without repeating any write or side effect. Reusing
+the key with a different functional payload returns `409`. A concurrent request still holding the
+key's processing lease also returns `409` with `Retry-After`. The fingerprint covers every
+functional create field, including credential, TOTP and custom-field values, but is a
+server-secret HMAC: neither those values, the request body nor the raw key is persisted.
+
 **Custom fields:** `fields` = array of `{ id, value }` (field id + value). Encrypt-before-INSERT for encrypted categories; creator sharekey created synchronously, other users via the `new_item` background task. Only fields tied to the folder are stored; empty values ignored. Requires `item_extra_fields`.
 
-**Response 201:** `{ error: false, message, newId, revision, revision_changed_at }` + `Location: /api/v1/item/get?id=<newId>` (path-absolute reference). Validation failures → `422`; missing fields → `400`; folder not allowed / read-only → `403`.
+**Response 201:** `{ error: false, message, newId, revision, revision_changed_at }` + `Location: /api/v1/item/get?id=<newId>` (path-absolute reference). An idempotent replay preserves both. Validation failures → `422`; missing fields or invalid idempotency key → `400`; folder not allowed / read-only → `403`.
 
 **Permissions:** `allowed_to_create`. Blocked with 403 if folder is read-only for user.
 
@@ -311,7 +320,20 @@ The password guard compares against the **decrypted** current value, so resendin
 
 Soft-delete an item.
 
-**Params:** `id` (int).
+**Params:** `id` (int), optional `revision` (unsigned 32-bit integer). When supplied, `revision`
+is an optimistic-concurrency precondition checked against the locked item row immediately before
+the mutation. A mismatch returns `409` with no delete, audit, revision, cache change or WebSocket
+event. Omitting it preserves the historical last-writer-wins behavior.
+
+**Optional idempotency:** `Idempotency-Key` follows the same syntax and 90-day replay window as
+create, scoped to the authenticated user and `item.delete`. Its fingerprint contains the item id
+and the expected revision (including omission). A replay returns the original successful result
+with `Idempotency-Replayed: true`; it never deletes again, so a later restoration is not undone.
+The same key with another item or revision returns `409`; an in-progress request returns `409` and
+`Retry-After`.
+
+**Response 200:** `{ error: false, message, item_id, revision, revision_changed_at }`. The
+revision/date pair is the deletion revision later exposed by `GET /item/changes`.
 
 **LAPR:** `409` while the item is still referenced by a non-deleted managed account or enrolled endpoint — remove the managed account or reconfigure the endpoint first. The relationship has no FK, so deleting the item would orphan it and break rotation or endpoint authentication. Inactive when the LAPR module is disabled.
 
@@ -457,7 +479,7 @@ The key is `extension_url` (value = `cpassman_url`) — the doc previously named
 | 403 | Permission denied (folder read-only, admin required, CRUD rights missing) |
 | 404 | Resource not found / unknown route |
 | 405 | HTTP method not supported for this endpoint (`Allow:` header lists supported methods) |
-| 409 | The supplied `revision` no longer matches the item (optimistic concurrency on `item/update`), the resource changed while the request was being processed (concurrent personal→shared item move), or the operation conflicts with a LAPR relationship (managed login/password update, move to a personal folder, delete of a linked item) |
+| 409 | The supplied `revision` no longer matches the item (`item/update` or `item/delete`), an idempotency key was reused with another request or is still processing, the resource changed while the request was being processed (concurrent personal→shared item move), or the operation conflicts with a LAPR relationship (managed login/password update, move to a personal folder, delete of a linked item) |
 | 422 | Validation failed (password rules, invalid complexity/access_rights, personal→shared move combined with another update or with unrecoverable keys, current password not recoverable on a password update — retryable while the sharekey fan-out is still running) |
 | 429 | Rate limit exceeded (`api_rate_limit_per_minute`) — `Retry-After` header gives the wait in seconds |
 | 500 | Internal server error (details logged server-side, not returned to client) |

--- a/.claude/docs/architecture-api-idempotency.md
+++ b/.claude/docs/architecture-api-idempotency.md
@@ -65,8 +65,7 @@ writes then share one transaction with idempotency completion:
 - item row and the durable create link;
 - item/sharekey/custom-field/tag/TOTP writes;
 - audit and revision writes;
-- cache, health and background-task rows;
-- the queued WebSocket event;
+- item cache and the queued WebSocket event;
 - replay status and response.
 
 Delete similarly locks the item row, evaluates the optional revision and LAPR guard, applies the
@@ -83,10 +82,11 @@ This ordering covers the important failure windows:
   replay state.
 
 The queued WebSocket event is a database row and therefore follows the transaction. Actual
-delivery occurs later and is naturally outside it. External UDP syslog emission is deliberately
-deferred until after commit; a replay never emits it again. There is therefore a narrow at-most-once
-window where a process crash immediately after commit can omit that external datagram. The durable
-TeamPass audit row remains in the SQL transaction.
+delivery occurs later and is naturally outside it. The security-posture cache refresh, creation of
+the share-key fan-out task and external UDP syslog emission are deliberately deferred until after
+commit; a replay never repeats them. In particular, launching the detached background handler only
+after commit ensures that its separate database connection can see the item and its task rows. The
+durable TeamPass audit row remains in the SQL transaction.
 
 TeamPass's audit/revision helpers remain best-effort for historical callers. These two
 transactional API paths enable their strict mode and additionally verify that a new revision/date
@@ -101,14 +101,17 @@ while the item remains addressable and the record remains in its replay window.
 
 ## Cleanup
 
-Completed records are kept for 90 days, matching the default offline synchronization window. The
-existing orphan-maintenance task clears expired `items.api_idempotency_id` links and deletes the
-corresponding records. A processing record is removed only when both its replay window and lease
-have expired, so maintenance never deletes an active request.
+Each record uses the configured offline synchronization window (`offline_sync_window_days`, 90 days
+by default). Setting the window to `0` gives both offline synchronization and idempotency replays no
+time limit; these rows carry `expires_at = 0` and cleanup excludes them. The existing
+orphan-maintenance task first locks expired reservations, then clears their
+`items.api_idempotency_id` links and deletes the corresponding records. A processing record is
+removed only when both its replay window and lease have expired, so maintenance never deletes an
+active request.
 
 After cleanup, reusing an old key is a new operation. Clients must therefore keep retryable
-offline intents within the documented 90-day window, just as they must perform a full sync after
-falling outside the revision window.
+offline intents within the configured window, just as they must perform a full sync after falling
+outside the revision window.
 
 ## Examples
 
@@ -140,4 +143,4 @@ curl -i -X DELETE \
 ```
 
 A stale `revision` returns `409` before the delete or any of its side effects. Omitting `revision`
-keeps the historical last-writer-wins behavior.
+or sending an empty query value keeps the historical last-writer-wins behavior.

--- a/.claude/docs/architecture-api-idempotency.md
+++ b/.claude/docs/architecture-api-idempotency.md
@@ -1,0 +1,143 @@
+# API Item Mutation Idempotency
+
+> Target release: 3.2.2
+
+TeamPass accepts an optional `Idempotency-Key` on `POST /item/create` and
+`DELETE /item/delete`. It is intended for offline clients that may lose an HTTP response and must
+retry without creating a second item or deleting a restored item again.
+
+## Public contract
+
+The header is an opaque value containing 1–128 visible ASCII characters (`0x21`–`0x7e`), without
+spaces. A UUID is recommended but not required. Empty, non-ASCII, control-character and oversized
+values return `400`.
+
+An identity is the tuple `(authenticated user, operation, HMAC(key))`. Create and delete are
+separate scopes, and the same raw key used by two users never collides.
+
+For a valid key:
+
+| State | Result |
+|---|---|
+| First request | Normal mutation: `201` for create, `200` for delete |
+| Completed, same fingerprint | Stored status/body, plus `Idempotency-Replayed: true` |
+| Same identity, different fingerprint | `409 Conflict`, no write |
+| Another request owns the active processing lease | `409 Conflict` plus `Retry-After` |
+| Expired processing lease | One request atomically takes ownership and resumes |
+
+Without the header, no idempotency record is created and the legacy API behavior is retained.
+
+Create fingerprints include the folder, label, login, password, email, URL, description, tags,
+TOTP secret and parameters, custom fields, icon and `anyone_can_modify`. Delete fingerprints
+include the item id and the optional expected revision. Associative keys are sorted recursively;
+list order remains significant.
+
+The fingerprint and key hash are HMAC-SHA-256 values derived from the TeamPass instance secret
+with a domain-separated subkey. The table never stores or logs the raw key, JSON body, password,
+TOTP secret or custom-field values. Stored response bodies contain only replay-safe identifiers,
+revision metadata and public success messages.
+
+## Persistence
+
+`teampass_api_idempotency` contains:
+
+- identity: `user_id`, `operation`, `key_hash` with a composite unique key;
+- intent: `request_fingerprint`;
+- ownership: `status`, `owner_token_hash`, `locked_until`;
+- replay metadata: `resource_id`, `http_status`, `response_body`;
+- lifecycle: `created_at`, `updated_at`, `expires_at`.
+
+`teampass_items.api_idempotency_id` is a nullable unique link used only by keyed creates. It makes
+a committed item discoverable from a stale reservation even if the PHP process died before it
+could return the response. Historical and non-keyed items keep `NULL`.
+
+## Transaction and crash behavior
+
+Reservation uses a short, persistent five-minute processing lease. Syntax, global rights, basic
+payload and folder rights are checked before create reservation. Delete rights are checked before
+its reservation in the current controller flow. Model-level validation may still fail after
+reservation; a failed or rolled-back request removes only the reservation owned by that request,
+so a corrected retry is not blocked.
+
+External favicon/DNS resolution is completed before the create transaction. The functional SQL
+writes then share one transaction with idempotency completion:
+
+- item row and the durable create link;
+- item/sharekey/custom-field/tag/TOTP writes;
+- audit and revision writes;
+- cache, health and background-task rows;
+- the queued WebSocket event;
+- replay status and response.
+
+Delete similarly locks the item row, evaluates the optional revision and LAPR guard, applies the
+soft delete and its SQL side effects, then completes the replay record before commit.
+
+This ordering covers the important failure windows:
+
+- crash before mutation: the transaction has no functional write; the lease can later be taken;
+- crash during mutation: InnoDB rolls back both functional writes and completion;
+- commit followed by a lost HTTP response: the completed response is replayed;
+- stale create row with a committed linked item: recovery reconstructs and finalizes the safe
+  create response without running side effects;
+- concurrent duplicate: the unique identity gives one owner; contenders receive processing or
+  replay state.
+
+The queued WebSocket event is a database row and therefore follows the transaction. Actual
+delivery occurs later and is naturally outside it. External UDP syslog emission is deliberately
+deferred until after commit; a replay never emits it again. There is therefore a narrow at-most-once
+window where a process crash immediately after commit can omit that external datagram. The durable
+TeamPass audit row remains in the SQL transaction.
+
+TeamPass's audit/revision helpers remain best-effort for historical callers. These two
+transactional API paths enable their strict mode and additionally verify that a new revision/date
+pair was persisted; a failure therefore rolls back create/delete instead of completing an
+idempotency record with a missing audit or tombstone.
+
+A completed delete is replayed, never executed again. If the item is restored later, retrying the
+old key cannot delete the restored state. If the item is eventually hard-purged or the caller no
+longer passes the controller's current access checks, the endpoint may return `404`/`403` before
+reaching its completed record; it still never repeats the mutation. Normal replay is guaranteed
+while the item remains addressable and the record remains in its replay window.
+
+## Cleanup
+
+Completed records are kept for 90 days, matching the default offline synchronization window. The
+existing orphan-maintenance task clears expired `items.api_idempotency_id` links and deletes the
+corresponding records. A processing record is removed only when both its replay window and lease
+have expired, so maintenance never deletes an active request.
+
+After cleanup, reusing an old key is a new operation. Clients must therefore keep retryable
+offline intents within the documented 90-day window, just as they must perform a full sync after
+falling outside the revision window.
+
+## Examples
+
+First creation:
+
+```bash
+curl -i -X POST "https://teampass.example/api/index.php/item/create" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -H "Idempotency-Key: 550e8400-e29b-41d4-a716-446655440000" \
+  -d '{"folder_id":3,"label":"Router","password":"secret","login":"admin","email":"","url":"","tags":"","anyone_can_modify":0}'
+```
+
+Repeating the same command returns the original `201`, `Location` and body, with:
+
+```text
+Idempotency-Replayed: true
+```
+
+Changing `label`, `password` or any other functional field while keeping the key returns `409`.
+
+Conditional, idempotent deletion:
+
+```bash
+curl -i -X DELETE \
+  "https://teampass.example/api/index.php/item/delete?id=123&revision=456" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Idempotency-Key: 8fe52f47-6f72-4a1a-b0d8-68a01c884d41"
+```
+
+A stale `revision` returns `409` before the delete or any of its side effects. Omitting `revision`
+keeps the historical last-writer-wins behavior.

--- a/.claude/docs/architecture-item-revisions.md
+++ b/.claude/docs/architecture-item-revisions.md
@@ -1,6 +1,6 @@
 # Item Revisions & Offline Synchronization
 
-> Last updated: 2026-08-24 — target release 3.2.2
+> Last updated: 2026-08-25 — target release 3.2.2
 > Design study: `workReadmeFiles/item-revision-id-study.md`
 
 Gives every item a **monotonic revision ID** so an offline client (the mobile vault) can tell
@@ -92,9 +92,17 @@ five that exist today:
 ## API surface
 
 - `revision` and `revision_changed_at` returned by `item/get`, `item/inFolders`,
-  `item/findByUrl`, `item/create`, `item/update`
+  `item/findByUrl`, `item/create`, `item/update`, `item/delete`
 - `GET /api/v1/item/changes?since=&limit=` — the delta feed (see `api-reference.md`)
 - `PUT /api/v1/item/update` accepts an optional `revision` precondition → `409` on mismatch
+- `DELETE /api/v1/item/delete` accepts the same optional precondition. The row is locked and the
+  comparison runs immediately before soft deletion; a mismatch produces no audit, revision,
+  cache update or WebSocket event. A successful response carries the exact deletion
+  `revision`/`revision_changed_at` pair that the next delta scan uses for its tombstone.
+
+`POST /item/create` and `DELETE /item/delete` also accept an optional persistent idempotency key.
+The completion record is committed in the functional SQL transaction, so replay never allocates
+another journal row. See `architecture-api-idempotency.md`.
 
 `revision_changed_at` is a Unix UTC timestamp in seconds, or `NULL` when no reliable date exists.
 The delta feed takes the pair from the winning journal row after deduplication; tombstones cannot

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -221,6 +221,7 @@ a "retention": pruning it loses nothing, a client outside the window just does a
 ## API
 
 > Full reference: @.claude/docs/api-reference.md
+> Item mutation idempotency architecture: @.claude/docs/architecture-api-idempotency.md
 
 Controllers in `/api/Controller/Api/`. JWT auth via `Authorization: Bearer <token>`. Key endpoints: `/api/authorize`, `/api/item/get`, `/api/item/create`, `/api/item/getOtp`, `/api/folder/listFolders`.
 

--- a/app/api/Controller/Api/ItemController.php
+++ b/app/api/Controller/Api/ItemController.php
@@ -145,7 +145,7 @@ class ItemController extends BaseController
      */
     private function parseOptionalRevision(array $params): ?int
     {
-        if (array_key_exists('revision', $params) === false) {
+        if (array_key_exists('revision', $params) === false || $params['revision'] === '') {
             return null;
         }
 

--- a/app/api/Controller/Api/ItemController.php
+++ b/app/api/Controller/Api/ItemController.php
@@ -94,6 +94,82 @@ class ItemController extends BaseController
 
 
     /**
+     * Read and validate the optional Idempotency-Key request header.
+     *
+     * @param symfonyRequest $request Current request
+     * @return string|null Validated key, null when the header is absent
+     */
+    private function getIdempotencyKey(symfonyRequest $request): ?string
+    {
+        if ($request->headers->has('Idempotency-Key') === false) {
+            return null;
+        }
+
+        return ApiIdempotencyModel::validateKey((string) $request->headers->get('Idempotency-Key', ''));
+    }
+
+
+    /**
+     * Build the complete functional create intent used for request fingerprinting.
+     *
+     * @param array<string, mixed> $params Normalized item parameters
+     * @return array<string, mixed>
+     */
+    private function createIdempotencyIntent(array $params): array
+    {
+        return [
+            'folder_id' => (int) $params['folder_id'],
+            'label' => (string) $params['label'],
+            'login' => (string) $params['login'],
+            'password' => (string) $params['password'],
+            'email' => (string) $params['email'],
+            'url' => (string) $params['url'],
+            'description' => (string) $params['description'],
+            'tags' => (string) $params['tags'],
+            'totp' => (string) $params['totp'],
+            'totp_algorithm' => (string) $params['totp_algorithm'],
+            'totp_digits' => (int) $params['totp_digits'],
+            'totp_period' => (int) $params['totp_period'],
+            'fields' => $params['fields'],
+            'icon' => (string) $params['icon'],
+            'anyone_can_modify' => (int) $params['anyone_can_modify'],
+        ];
+    }
+
+
+    /**
+     * Parse the optional unsigned 32-bit item revision query parameter.
+     *
+     * @param array<string, mixed> $params Request parameters
+     * @return int|null Parsed revision, null when omitted
+     */
+    private function parseOptionalRevision(array $params): ?int
+    {
+        if (array_key_exists('revision', $params) === false) {
+            return null;
+        }
+
+        $rawRevision = $params['revision'];
+        if (is_int($rawRevision)) {
+            $revision = $rawRevision;
+        } elseif (is_string($rawRevision) && preg_match('/^(0|[1-9][0-9]*)$/D', $rawRevision) === 1) {
+            if (strlen($rawRevision) > 10) {
+                throw new InvalidArgumentException('Revision must be an unsigned 32-bit integer.');
+            }
+            $revision = (int) $rawRevision;
+        } else {
+            throw new InvalidArgumentException('Revision must be an unsigned 32-bit integer.');
+        }
+
+        if ($revision < 0 || $revision > 4294967295) {
+            throw new InvalidArgumentException('Revision must be an unsigned 32-bit integer.');
+        }
+
+        return $revision;
+    }
+
+
+    /**
      * Manage case inFolder - get items inside an array of folders
      *
      * @param array $userData
@@ -254,6 +330,8 @@ class ItemController extends BaseController
         $arrErrorHeaders = [];
         $arrSuccessHeaders = [];
         $intSuccessStatus = 200;
+        $idempotencyModel = null;
+        $idempotencyReservation = null;
 
         if (strtoupper($requestMethod) === 'POST') {
             // Is user allowed to create a folder
@@ -274,8 +352,16 @@ class ItemController extends BaseController
                 // get parameters
                 $arrQueryStringParams = $this->getQueryStringParams();
 
+                try {
+                    $idempotencyKey = $this->getIdempotencyKey($request);
+                } catch (InvalidArgumentException $exception) {
+                    $idempotencyKey = null;
+                    $strErrorDesc = $exception->getMessage();
+                    $strErrorHeader = 'HTTP/1.1 400 Bad Request';
+                }
+
                 // Check that the parameters are indeed an array before using them
-                if (is_array($arrQueryStringParams)) {
+                if (empty($strErrorDesc) === true && is_array($arrQueryStringParams)) {
                     // check parameters
                     $arrCheck = $this->checkNewItemData($arrQueryStringParams, $userData);
 
@@ -304,26 +390,72 @@ class ItemController extends BaseController
                             'fields' => $this->normalizeFields($arrQueryStringParams['fields'] ?? []),
                         ];
 
-                        // launch
-                        $itemModel = new ItemModel();
-                        $ret = $itemModel->addItem(
-                            $arrItemParams
-                        );
-                        if (($ret['error'] ?? false) === true) {
-                            $strErrorDesc = (string) ($ret['error_message'] ?? 'Item creation failed');
-                            $strErrorHeader = (string) ($ret['error_header'] ?? 'HTTP/1.1 422 Unprocessable Entity');
-                        } else {
-                            // 201 Created + Location of the new resource (path-absolute reference)
-                            $responseData = json_encode($ret);
-                            $intSuccessStatus = 201;
-                            $requestPath = (string) parse_url($request->getRequestUri(), PHP_URL_PATH);
-                            $arrSuccessHeaders[] = 'Location: '
-                                . preg_replace('/create$/', 'get', $requestPath)
-                                . '?id=' . (int) $ret['newId'];
+                        if ($idempotencyKey !== null) {
+                            try {
+                                $idempotencyModel = new ApiIdempotencyModel();
+                                $decision = $idempotencyModel->reserve(
+                                    (int) $userData['id'],
+                                    ApiIdempotencyModel::OPERATION_ITEM_CREATE,
+                                    $idempotencyKey,
+                                    $this->createIdempotencyIntent($arrItemParams)
+                                );
+
+                                if ($decision['state'] === 'replay') {
+                                    $responseData = json_encode($decision['response']);
+                                    $intSuccessStatus = (int) $decision['http_status'];
+                                    $arrSuccessHeaders[] = 'Idempotency-Replayed: true';
+                                    $requestPath = (string) parse_url($request->getRequestUri(), PHP_URL_PATH);
+                                    $arrSuccessHeaders[] = 'Location: '
+                                        . preg_replace('/create$/', 'get', $requestPath)
+                                        . '?id=' . (int) $decision['resource_id'];
+                                } elseif ($decision['state'] === 'conflict') {
+                                    $strErrorDesc = 'Idempotency-Key was already used with a different request.';
+                                    $strErrorHeader = 'HTTP/1.1 409 Conflict';
+                                } elseif ($decision['state'] === 'processing') {
+                                    $strErrorDesc = 'A request with this Idempotency-Key is still processing.';
+                                    $strErrorHeader = 'HTTP/1.1 409 Conflict';
+                                    $arrErrorHeaders[] = 'Retry-After: ' . (int) ($decision['retry_after'] ?? 1);
+                                } else {
+                                    $idempotencyReservation = $decision;
+                                }
+                            } catch (Throwable $exception) {
+                                error_log('[API] Unable to reserve item.create idempotency: ' . $exception->getMessage());
+                                $strErrorDesc = 'An internal error occurred while preparing the item creation.';
+                                $strErrorHeader = 'HTTP/1.1 500 Internal Server Error';
+                            }
+                        }
+
+                        if (empty($strErrorDesc) === true && $responseData === '') {
+                            // launch
+                            $itemModel = new ItemModel();
+                            $ret = $itemModel->addItem(
+                                $arrItemParams,
+                                $idempotencyModel,
+                                $idempotencyReservation
+                            );
+                            if (($ret['error'] ?? false) === true) {
+                                if ($idempotencyModel !== null && $idempotencyReservation !== null) {
+                                    try {
+                                        $idempotencyModel->releaseReservation($idempotencyReservation);
+                                    } catch (Throwable $exception) {
+                                        error_log('[API] Unable to release failed item.create idempotency: ' . $exception->getMessage());
+                                    }
+                                }
+                                $strErrorDesc = (string) ($ret['error_message'] ?? 'Item creation failed');
+                                $strErrorHeader = (string) ($ret['error_header'] ?? 'HTTP/1.1 422 Unprocessable Entity');
+                            } else {
+                                // 201 Created + Location of the new resource (path-absolute reference)
+                                $responseData = json_encode($ret);
+                                $intSuccessStatus = 201;
+                                $requestPath = (string) parse_url($request->getRequestUri(), PHP_URL_PATH);
+                                $arrSuccessHeaders[] = 'Location: '
+                                    . preg_replace('/create$/', 'get', $requestPath)
+                                    . '?id=' . (int) $ret['newId'];
+                            }
                         }
                     }
 
-                } else {
+                } elseif (empty($strErrorDesc) === true) {
                     $strErrorDesc = 'Data not consistent';
                     $strErrorHeader = 'HTTP/1.1 400 Bad Request';
                 }
@@ -1083,6 +1215,10 @@ class ItemController extends BaseController
         $request = symfonyRequest::createFromGlobals();
         $requestMethod = $request->getMethod();
         $strErrorDesc = $strErrorHeader = $responseData = '';
+        $arrErrorHeaders = [];
+        $arrSuccessHeaders = [];
+        $idempotencyModel = null;
+        $idempotencyReservation = null;
 
         if (strtoupper($requestMethod) === 'DELETE') {
             // Check if user is allowed to delete items
@@ -1092,16 +1228,28 @@ class ItemController extends BaseController
             } else {
                 // Get parameters
                 $arrQueryStringParams = $this->getQueryStringParams();
-                
+
                 // Check that the parameters are indeed an array before using them
                 if (is_array($arrQueryStringParams)) {
+                    try {
+                        $idempotencyKey = $this->getIdempotencyKey($request);
+                        $expectedRevision = $this->parseOptionalRevision($arrQueryStringParams);
+                    } catch (InvalidArgumentException $exception) {
+                        $idempotencyKey = null;
+                        $expectedRevision = null;
+                        $strErrorDesc = $exception->getMessage();
+                        $strErrorHeader = 'HTTP/1.1 400 Bad Request';
+                    }
+
                     // Check if item ID is provided
-                    if (!isset($arrQueryStringParams['id']) || empty($arrQueryStringParams['id'])) {
+                    if (empty($strErrorDesc) === true
+                        && (!isset($arrQueryStringParams['id']) || empty($arrQueryStringParams['id']))
+                    ) {
                         $strErrorDesc = 'Item ID is mandatory';
                         $strErrorHeader = 'HTTP/1.1 400 Bad Request';
-                    } else {
+                    } elseif (empty($strErrorDesc) === true) {
                         $itemId = (int) $arrQueryStringParams['id'];
-                        
+
                         try {
                             // Load item info to check access rights
                             $itemInfo = DB::queryFirstRow(
@@ -1128,22 +1276,67 @@ class ItemController extends BaseController
                                     $strErrorDesc = 'Access denied: you are not allowed to delete items in this folder';
                                     $strErrorHeader = 'HTTP/1.1 403 Forbidden';
                                 } else {
-                                    // delete the item
-                                    $itemModel = new ItemModel();
-                                    $ret = $itemModel->deleteItem(
-                                        $itemId,
-                                        $userData
-                                    );
+                                    if ($idempotencyKey !== null) {
+                                        try {
+                                            $idempotencyModel = new ApiIdempotencyModel();
+                                            $decision = $idempotencyModel->reserve(
+                                                (int) $userData['id'],
+                                                ApiIdempotencyModel::OPERATION_ITEM_DELETE,
+                                                $idempotencyKey,
+                                                [
+                                                    'item_id' => $itemId,
+                                                    'revision' => $expectedRevision,
+                                                ]
+                                            );
 
-                                    if ($ret['error'] === true) {
-                                        $strErrorDesc = $ret['error_message'];
-                                        $strErrorHeader = $ret['error_header'];
-                                    } else {
-                                        $responseData = json_encode($ret);
+                                            if ($decision['state'] === 'replay') {
+                                                $responseData = json_encode($decision['response']);
+                                                $arrSuccessHeaders[] = 'Idempotency-Replayed: true';
+                                            } elseif ($decision['state'] === 'conflict') {
+                                                $strErrorDesc = 'Idempotency-Key was already used with a different request.';
+                                                $strErrorHeader = 'HTTP/1.1 409 Conflict';
+                                            } elseif ($decision['state'] === 'processing') {
+                                                $strErrorDesc = 'A request with this Idempotency-Key is still processing.';
+                                                $strErrorHeader = 'HTTP/1.1 409 Conflict';
+                                                $arrErrorHeaders[] = 'Retry-After: ' . (int) ($decision['retry_after'] ?? 1);
+                                            } else {
+                                                $idempotencyReservation = $decision;
+                                            }
+                                        } catch (Throwable $exception) {
+                                            error_log('[API] Unable to reserve item.delete idempotency: ' . $exception->getMessage());
+                                            $strErrorDesc = 'An internal error occurred while preparing the item deletion.';
+                                            $strErrorHeader = 'HTTP/1.1 500 Internal Server Error';
+                                        }
+                                    }
+
+                                    if (empty($strErrorDesc) === true && $responseData === '') {
+                                        // delete the item
+                                        $itemModel = new ItemModel();
+                                        $ret = $itemModel->deleteItem(
+                                            $itemId,
+                                            $userData,
+                                            $expectedRevision,
+                                            $idempotencyModel,
+                                            $idempotencyReservation
+                                        );
+
+                                        if ($ret['error'] === true) {
+                                            if ($idempotencyModel !== null && $idempotencyReservation !== null) {
+                                                try {
+                                                    $idempotencyModel->releaseReservation($idempotencyReservation);
+                                                } catch (Throwable $exception) {
+                                                    error_log('[API] Unable to release failed item.delete idempotency: ' . $exception->getMessage());
+                                                }
+                                            }
+                                            $strErrorDesc = $ret['error_message'];
+                                            $strErrorHeader = $ret['error_header'];
+                                        } else {
+                                            $responseData = json_encode($ret);
+                                        }
                                     }
                                 }
                             }
-                        } catch (Error $e) {
+                        } catch (Throwable $e) {
                             error_log('[API] ItemController error: ' . $e->getMessage());
                             $strErrorDesc = 'An internal error occurred. Please contact support.';
                             $strErrorHeader = 'HTTP/1.1 500 Internal Server Error';
@@ -1164,10 +1357,10 @@ class ItemController extends BaseController
         if (empty($strErrorDesc) === true) {
             $this->sendOutput(
                 $responseData,
-                ['Content-Type: application/json', 'HTTP/1.1 200 OK']
+                array_merge(['Content-Type: application/json', 'HTTP/1.1 200 OK'], $arrSuccessHeaders)
             );
         } else {
-            $this->sendProblemFromHeader($strErrorHeader, $strErrorDesc, $arrErrorHeaders ?? []);
+            $this->sendProblemFromHeader($strErrorHeader, $strErrorDesc, $arrErrorHeaders);
         }
     }
     //end deleteAction()

--- a/app/api/Model/ApiIdempotencyModel.php
+++ b/app/api/Model/ApiIdempotencyModel.php
@@ -48,7 +48,7 @@ class ApiIdempotencyModel
         }
 
         $masterSecret = @file_get_contents(TEAMPASS_SECRETS . '/' . SECUREFILE);
-        if (is_string($masterSecret) === false || $masterSecret === '') {
+        if ($masterSecret === false || $masterSecret === '') {
             throw new RuntimeException('The server idempotency secret is unavailable.');
         }
 

--- a/app/api/Model/ApiIdempotencyModel.php
+++ b/app/api/Model/ApiIdempotencyModel.php
@@ -1,6 +1,8 @@
 <?php
 declare(strict_types=1);
 
+require_once __DIR__ . '/../../sources/api_idempotency_logic.php';
+
 /**
  * Teampass - a collaborative passwords manager.
  * ---
@@ -29,15 +31,22 @@ class ApiIdempotencyModel
     public const OPERATION_ITEM_DELETE = 'item.delete';
     public const MAX_KEY_LENGTH = 128;
     public const PROCESSING_LEASE_SECONDS = 300;
-    public const REPLAY_WINDOW_SECONDS = 7776000; // 90 days, aligned with the default offline sync window.
 
     private string $hmacSecret;
+    private int $replayWindowDays;
 
     /**
      * @param string|null $hmacSecret Test-only secret override; production derives it from SECUREFILE
+     * @param int|string|null $replayWindowDays Test override; production reads offline_sync_window_days
      */
-    public function __construct(?string $hmacSecret = null)
+    public function __construct(?string $hmacSecret = null, int|string|null $replayWindowDays = null)
     {
+        if ($replayWindowDays === null && $hmacSecret === null) {
+            $configManager = new \TeampassClasses\ConfigManager\ConfigManager();
+            $replayWindowDays = $configManager->getSetting('offline_sync_window_days');
+        }
+        $this->replayWindowDays = offlineSyncResolveWindowDays($replayWindowDays);
+
         if ($hmacSecret !== null) {
             $this->hmacSecret = $hmacSecret;
             return;
@@ -85,42 +94,13 @@ class ApiIdempotencyModel
      */
     public function fingerprint(array $intent): string
     {
-        $canonical = $this->canonicalize($intent);
+        $canonical = apiIdempotencyCanonicalize($intent);
         $encoded = json_encode(
             $canonical,
             JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_PRESERVE_ZERO_FRACTION | JSON_THROW_ON_ERROR
         );
 
         return hash_hmac('sha256', $encoded, $this->hmacSecret);
-    }
-
-    /**
-     * Classify an existing record before attempting a replay or stale takeover.
-     *
-     * @param array<string, mixed> $record Existing database row
-     * @param string $requestFingerprint HMAC of the current request intent
-     * @param int $now Current Unix timestamp
-     * @return array{state: string, retry_after?: int}
-     */
-    public function evaluateRecord(array $record, string $requestFingerprint, int $now): array
-    {
-        if (hash_equals((string) ($record['request_fingerprint'] ?? ''), $requestFingerprint) === false) {
-            return ['state' => 'conflict'];
-        }
-
-        if ((string) ($record['status'] ?? '') === 'completed') {
-            return ['state' => 'replay'];
-        }
-
-        $lockedUntil = (int) ($record['locked_until'] ?? 0);
-        if ($lockedUntil >= $now) {
-            return [
-                'state' => 'processing',
-                'retry_after' => max(1, $lockedUntil - $now),
-            ];
-        }
-
-        return ['state' => 'stale'];
     }
 
     /**
@@ -163,16 +143,15 @@ class ApiIdempotencyModel
                         'created_at' => $now,
                         'updated_at' => $now,
                         'locked_until' => $now + self::PROCESSING_LEASE_SECONDS,
-                        'expires_at' => $now + self::REPLAY_WINDOW_SECONDS,
+                        'expires_at' => apiIdempotencyReplayExpiry($now, $this->replayWindowDays),
                     ]
                 );
 
-                return [
-                    'state' => 'acquired',
-                    'id' => (int) DB::insertId(),
-                    'owner_token' => $ownerToken,
-                    'request_fingerprint' => $requestFingerprint,
-                ];
+                return apiIdempotencyAcquiredDecision(
+                    (int) DB::insertId(),
+                    $ownerToken,
+                    $requestFingerprint
+                );
             } catch (Throwable $exception) {
                 $record = $this->findRecord($userId, $operation, $keyHash);
                 if ($record === null) {
@@ -180,16 +159,8 @@ class ApiIdempotencyModel
                 }
             }
 
-            $decision = $this->evaluateRecord($record, $requestFingerprint, $now);
-            if ($decision['state'] === 'conflict') {
-                return $decision;
-            }
-
-            if ($decision['state'] === 'replay') {
-                return $this->buildReplayDecision($record);
-            }
-
-            if ($decision['state'] === 'processing') {
+            $decision = apiIdempotencyExistingRecordDecision($record, $requestFingerprint, $now);
+            if ($decision['state'] !== 'stale') {
                 return $decision;
             }
 
@@ -208,7 +179,7 @@ class ApiIdempotencyModel
                     'owner_token_hash' => $ownerTokenHash,
                     'updated_at' => $now,
                     'locked_until' => $now + self::PROCESSING_LEASE_SECONDS,
-                    'expires_at' => $now + self::REPLAY_WINDOW_SECONDS,
+                    'expires_at' => apiIdempotencyReplayExpiry($now, $this->replayWindowDays),
                 ],
                 'id = %i AND status = %s AND locked_until < %i AND request_fingerprint = %s',
                 (int) $record['id'],
@@ -217,13 +188,14 @@ class ApiIdempotencyModel
                 $requestFingerprint
             );
 
-            if (DB::affectedRows() === 1) {
-                return [
-                    'state' => 'acquired',
-                    'id' => (int) $record['id'],
-                    'owner_token' => $ownerToken,
-                    'request_fingerprint' => $requestFingerprint,
-                ];
+            $takeover = apiIdempotencyLeaseTakeoverDecision(
+                (int) DB::affectedRows(),
+                (int) $record['id'],
+                $ownerToken,
+                $requestFingerprint
+            );
+            if ($takeover !== null) {
+                return $takeover;
             }
         }
 
@@ -285,7 +257,7 @@ class ApiIdempotencyModel
                 'response_body' => $responseBody,
                 'updated_at' => $now,
                 'locked_until' => 0,
-                'expires_at' => $now + self::REPLAY_WINDOW_SECONDS,
+                'expires_at' => apiIdempotencyReplayExpiry($now, $this->replayWindowDays),
             ],
             'id = %i AND status = %s AND owner_token_hash = %s',
             (int) ($reservation['id'] ?? 0),
@@ -316,30 +288,6 @@ class ApiIdempotencyModel
     }
 
     /**
-     * Canonicalize associative arrays recursively while preserving list order.
-     *
-     * @param mixed $value Value to canonicalize
-     * @return mixed Canonicalized value
-     */
-    private function canonicalize($value)
-    {
-        if (is_array($value) === false) {
-            return $value;
-        }
-
-        if (array_is_list($value)) {
-            return array_map(fn ($entry) => $this->canonicalize($entry), $value);
-        }
-
-        ksort($value, SORT_STRING);
-        foreach ($value as $key => $entry) {
-            $value[$key] = $this->canonicalize($entry);
-        }
-
-        return $value;
-    }
-
-    /**
      * Find one idempotency record by its scoped identity.
      *
      * @return array<string, mixed>|null
@@ -357,27 +305,6 @@ class ApiIdempotencyModel
         );
 
         return is_array($record) ? $record : null;
-    }
-
-    /**
-     * Convert a completed database row to a replay decision.
-     *
-     * @param array<string, mixed> $record Completed row
-     * @return array<string, mixed>
-     */
-    private function buildReplayDecision(array $record): array
-    {
-        $response = json_decode((string) ($record['response_body'] ?? ''), true);
-        if (is_array($response) === false) {
-            throw new RuntimeException('The stored idempotency response is invalid.');
-        }
-
-        return [
-            'state' => 'replay',
-            'resource_id' => (int) ($record['resource_id'] ?? 0),
-            'http_status' => (int) ($record['http_status'] ?? 200),
-            'response' => $response,
-        ];
     }
 
     /**
@@ -420,7 +347,7 @@ class ApiIdempotencyModel
                 'response_body' => $responseBody,
                 'updated_at' => $now,
                 'locked_until' => 0,
-                'expires_at' => $now + self::REPLAY_WINDOW_SECONDS,
+                'expires_at' => apiIdempotencyReplayExpiry($now, $this->replayWindowDays),
             ],
             'id = %i AND status = %s AND locked_until < %i AND request_fingerprint = %s',
             (int) $record['id'],
@@ -433,11 +360,10 @@ class ApiIdempotencyModel
             return null;
         }
 
-        return [
-            'state' => 'replay',
+        return apiIdempotencyReplayDecision([
             'resource_id' => (int) $item['id'],
             'http_status' => 201,
-            'response' => $response,
-        ];
+            'response_body' => $responseBody,
+        ]);
     }
 }

--- a/app/api/Model/ApiIdempotencyModel.php
+++ b/app/api/Model/ApiIdempotencyModel.php
@@ -1,0 +1,443 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Teampass - a collaborative passwords manager.
+ * ---
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * ---
+ * @project   Teampass
+ * @version   API
+ * @file      ApiIdempotencyModel.php
+ * @copyright 2009-2026 Teampass.net
+ * @license   https://spdx.org/licenses/GPL-3.0-only.html#licenseText GPL-3.0
+ * @see       https://www.teampass.net
+ */
+
+/**
+ * Persistent idempotency records for mutating API operations.
+ *
+ * Only HMACs and replay-safe response metadata are stored. Request bodies,
+ * passwords, TOTP secrets, custom-field values and raw idempotency keys never
+ * reach the database through this model.
+ */
+class ApiIdempotencyModel
+{
+    public const OPERATION_ITEM_CREATE = 'item.create';
+    public const OPERATION_ITEM_DELETE = 'item.delete';
+    public const MAX_KEY_LENGTH = 128;
+    public const PROCESSING_LEASE_SECONDS = 300;
+    public const REPLAY_WINDOW_SECONDS = 7776000; // 90 days, aligned with the default offline sync window.
+
+    private string $hmacSecret;
+
+    /**
+     * @param string|null $hmacSecret Test-only secret override; production derives it from SECUREFILE
+     */
+    public function __construct(?string $hmacSecret = null)
+    {
+        if ($hmacSecret !== null) {
+            $this->hmacSecret = $hmacSecret;
+            return;
+        }
+
+        if (defined('TEAMPASS_SECRETS') === false || defined('SECUREFILE') === false) {
+            throw new RuntimeException('The server idempotency secret is unavailable.');
+        }
+
+        $masterSecret = @file_get_contents(TEAMPASS_SECRETS . '/' . SECUREFILE);
+        if (is_string($masterSecret) === false || $masterSecret === '') {
+            throw new RuntimeException('The server idempotency secret is unavailable.');
+        }
+
+        $this->hmacSecret = hash_hmac('sha256', 'teampass-api-idempotency-v1', $masterSecret, true);
+    }
+
+    /**
+     * Validate and return an opaque Idempotency-Key header value.
+     *
+     * @param string $key Raw header value
+     * @return string Validated key
+     */
+    public static function validateKey(string $key): string
+    {
+        if ($key === '' || strlen($key) > self::MAX_KEY_LENGTH) {
+            throw new InvalidArgumentException('Idempotency-Key must contain between 1 and 128 characters.');
+        }
+
+        if (preg_match('/^[\x21-\x7E]+$/D', $key) !== 1) {
+            throw new InvalidArgumentException('Idempotency-Key must contain visible ASCII characters without spaces.');
+        }
+
+        return $key;
+    }
+
+    /**
+     * Build a deterministic HMAC fingerprint for a functional request intent.
+     *
+     * Associative keys are sorted recursively, so JSON property order does not
+     * influence the result. List order is preserved because it may be functional.
+     *
+     * @param array<string, mixed> $intent Functional request fields
+     * @return string Lowercase hexadecimal HMAC
+     */
+    public function fingerprint(array $intent): string
+    {
+        $canonical = $this->canonicalize($intent);
+        $encoded = json_encode(
+            $canonical,
+            JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_PRESERVE_ZERO_FRACTION | JSON_THROW_ON_ERROR
+        );
+
+        return hash_hmac('sha256', $encoded, $this->hmacSecret);
+    }
+
+    /**
+     * Classify an existing record before attempting a replay or stale takeover.
+     *
+     * @param array<string, mixed> $record Existing database row
+     * @param string $requestFingerprint HMAC of the current request intent
+     * @param int $now Current Unix timestamp
+     * @return array{state: string, retry_after?: int}
+     */
+    public function evaluateRecord(array $record, string $requestFingerprint, int $now): array
+    {
+        if (hash_equals((string) ($record['request_fingerprint'] ?? ''), $requestFingerprint) === false) {
+            return ['state' => 'conflict'];
+        }
+
+        if ((string) ($record['status'] ?? '') === 'completed') {
+            return ['state' => 'replay'];
+        }
+
+        $lockedUntil = (int) ($record['locked_until'] ?? 0);
+        if ($lockedUntil >= $now) {
+            return [
+                'state' => 'processing',
+                'retry_after' => max(1, $lockedUntil - $now),
+            ];
+        }
+
+        return ['state' => 'stale'];
+    }
+
+    /**
+     * Reserve an idempotency identity or return the existing request outcome.
+     *
+     * @param int $userId Authenticated TeamPass user
+     * @param string $operation Operation scope
+     * @param string $key Validated raw Idempotency-Key
+     * @param array<string, mixed> $intent Functional request intent
+     * @return array<string, mixed> acquired, replay, conflict or processing decision
+     */
+    public function reserve(int $userId, string $operation, string $key, array $intent): array
+    {
+        if ($userId <= 0 || in_array($operation, [self::OPERATION_ITEM_CREATE, self::OPERATION_ITEM_DELETE], true) === false) {
+            throw new InvalidArgumentException('Invalid idempotency scope.');
+        }
+
+        $key = self::validateKey($key);
+        $keyHash = hash_hmac('sha256', $key, $this->hmacSecret);
+        $requestFingerprint = $this->fingerprint($intent);
+
+        for ($attempt = 0; $attempt < 3; $attempt++) {
+            $now = time();
+            $ownerToken = bin2hex(random_bytes(32));
+            $ownerTokenHash = hash('sha256', $ownerToken);
+
+            try {
+                DB::insert(
+                    prefixTable('api_idempotency'),
+                    [
+                        'user_id' => $userId,
+                        'operation' => $operation,
+                        'key_hash' => $keyHash,
+                        'request_fingerprint' => $requestFingerprint,
+                        'status' => 'processing',
+                        'owner_token_hash' => $ownerTokenHash,
+                        'resource_id' => null,
+                        'http_status' => null,
+                        'response_body' => null,
+                        'created_at' => $now,
+                        'updated_at' => $now,
+                        'locked_until' => $now + self::PROCESSING_LEASE_SECONDS,
+                        'expires_at' => $now + self::REPLAY_WINDOW_SECONDS,
+                    ]
+                );
+
+                return [
+                    'state' => 'acquired',
+                    'id' => (int) DB::insertId(),
+                    'owner_token' => $ownerToken,
+                    'request_fingerprint' => $requestFingerprint,
+                ];
+            } catch (Throwable $exception) {
+                $record = $this->findRecord($userId, $operation, $keyHash);
+                if ($record === null) {
+                    throw $exception;
+                }
+            }
+
+            $decision = $this->evaluateRecord($record, $requestFingerprint, $now);
+            if ($decision['state'] === 'conflict') {
+                return $decision;
+            }
+
+            if ($decision['state'] === 'replay') {
+                return $this->buildReplayDecision($record);
+            }
+
+            if ($decision['state'] === 'processing') {
+                return $decision;
+            }
+
+            // A committed create is linked back to its reservation. This defensive recovery
+            // path repairs an old/stale processing row without re-running any side effect.
+            if ($operation === self::OPERATION_ITEM_CREATE) {
+                $recovered = $this->recoverCommittedCreate($record, $requestFingerprint, $now);
+                if ($recovered !== null) {
+                    return $recovered;
+                }
+            }
+
+            DB::update(
+                prefixTable('api_idempotency'),
+                [
+                    'owner_token_hash' => $ownerTokenHash,
+                    'updated_at' => $now,
+                    'locked_until' => $now + self::PROCESSING_LEASE_SECONDS,
+                    'expires_at' => $now + self::REPLAY_WINDOW_SECONDS,
+                ],
+                'id = %i AND status = %s AND locked_until < %i AND request_fingerprint = %s',
+                (int) $record['id'],
+                'processing',
+                $now,
+                $requestFingerprint
+            );
+
+            if (DB::affectedRows() === 1) {
+                return [
+                    'state' => 'acquired',
+                    'id' => (int) $record['id'],
+                    'owner_token' => $ownerToken,
+                    'request_fingerprint' => $requestFingerprint,
+                ];
+            }
+        }
+
+        return ['state' => 'processing', 'retry_after' => 1];
+    }
+
+    /**
+     * Lock and verify a reservation inside the mutation transaction.
+     *
+     * @param array<string, mixed> $reservation Acquired reservation
+     * @return void
+     */
+    public function lockReservation(array $reservation): void
+    {
+        $record = DB::queryFirstRow(
+            'SELECT id, status, owner_token_hash
+             FROM ' . prefixTable('api_idempotency') . '
+             WHERE id = %i
+             FOR UPDATE',
+            (int) ($reservation['id'] ?? 0)
+        );
+
+        $expectedTokenHash = hash('sha256', (string) ($reservation['owner_token'] ?? ''));
+        if ($record === null
+            || (string) $record['status'] !== 'processing'
+            || hash_equals((string) $record['owner_token_hash'], $expectedTokenHash) === false
+        ) {
+            throw new RuntimeException('The idempotency reservation is no longer owned by this request.');
+        }
+    }
+
+    /**
+     * Complete a reservation in the same transaction as the functional mutation.
+     *
+     * @param array<string, mixed> $reservation Acquired reservation
+     * @param int $resourceId Created or deleted item id
+     * @param int $httpStatus Replay HTTP status
+     * @param array<string, mixed> $response Replay-safe response body
+     * @return void
+     */
+    public function completeReservation(
+        array $reservation,
+        int $resourceId,
+        int $httpStatus,
+        array $response
+    ): void {
+        $responseBody = json_encode(
+            $response,
+            JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR
+        );
+        $now = time();
+
+        DB::update(
+            prefixTable('api_idempotency'),
+            [
+                'status' => 'completed',
+                'resource_id' => $resourceId,
+                'http_status' => $httpStatus,
+                'response_body' => $responseBody,
+                'updated_at' => $now,
+                'locked_until' => 0,
+                'expires_at' => $now + self::REPLAY_WINDOW_SECONDS,
+            ],
+            'id = %i AND status = %s AND owner_token_hash = %s',
+            (int) ($reservation['id'] ?? 0),
+            'processing',
+            hash('sha256', (string) ($reservation['owner_token'] ?? ''))
+        );
+
+        if (DB::affectedRows() !== 1) {
+            throw new RuntimeException('Unable to finalize the idempotency reservation.');
+        }
+    }
+
+    /**
+     * Release an acquired reservation after validation or a rolled-back mutation failed.
+     *
+     * @param array<string, mixed> $reservation Acquired reservation
+     * @return void
+     */
+    public function releaseReservation(array $reservation): void
+    {
+        DB::delete(
+            prefixTable('api_idempotency'),
+            'id = %i AND status = %s AND owner_token_hash = %s',
+            (int) ($reservation['id'] ?? 0),
+            'processing',
+            hash('sha256', (string) ($reservation['owner_token'] ?? ''))
+        );
+    }
+
+    /**
+     * Canonicalize associative arrays recursively while preserving list order.
+     *
+     * @param mixed $value Value to canonicalize
+     * @return mixed Canonicalized value
+     */
+    private function canonicalize($value)
+    {
+        if (is_array($value) === false) {
+            return $value;
+        }
+
+        if (array_is_list($value)) {
+            return array_map(fn ($entry) => $this->canonicalize($entry), $value);
+        }
+
+        ksort($value, SORT_STRING);
+        foreach ($value as $key => $entry) {
+            $value[$key] = $this->canonicalize($entry);
+        }
+
+        return $value;
+    }
+
+    /**
+     * Find one idempotency record by its scoped identity.
+     *
+     * @return array<string, mixed>|null
+     */
+    private function findRecord(int $userId, string $operation, string $keyHash): ?array
+    {
+        $record = DB::queryFirstRow(
+            'SELECT id, user_id, operation, request_fingerprint, status, owner_token_hash,
+                    resource_id, http_status, response_body, locked_until, expires_at
+             FROM ' . prefixTable('api_idempotency') . '
+             WHERE user_id = %i AND operation = %s AND key_hash = %s',
+            $userId,
+            $operation,
+            $keyHash
+        );
+
+        return is_array($record) ? $record : null;
+    }
+
+    /**
+     * Convert a completed database row to a replay decision.
+     *
+     * @param array<string, mixed> $record Completed row
+     * @return array<string, mixed>
+     */
+    private function buildReplayDecision(array $record): array
+    {
+        $response = json_decode((string) ($record['response_body'] ?? ''), true);
+        if (is_array($response) === false) {
+            throw new RuntimeException('The stored idempotency response is invalid.');
+        }
+
+        return [
+            'state' => 'replay',
+            'resource_id' => (int) ($record['resource_id'] ?? 0),
+            'http_status' => (int) ($record['http_status'] ?? 200),
+            'response' => $response,
+        ];
+    }
+
+    /**
+     * Recover a committed create from the durable item-to-reservation link.
+     *
+     * @param array<string, mixed> $record Stale processing row
+     * @param string $requestFingerprint Current request fingerprint
+     * @param int $now Current Unix timestamp
+     * @return array<string, mixed>|null Replay decision when recovery succeeded
+     */
+    private function recoverCommittedCreate(array $record, string $requestFingerprint, int $now): ?array
+    {
+        $item = DB::queryFirstRow(
+            'SELECT id, revision, revision_changed_at
+             FROM ' . prefixTable('items') . '
+             WHERE api_idempotency_id = %i',
+            (int) $record['id']
+        );
+        if ($item === null) {
+            return null;
+        }
+
+        $response = [
+            'error' => false,
+            'message' => 'Item added successfully',
+            'newId' => (int) $item['id'],
+            'revision' => (int) ($item['revision'] ?? 0),
+            'revision_changed_at' => $item['revision_changed_at'] === null
+                ? null
+                : (int) $item['revision_changed_at'],
+        ];
+        $responseBody = json_encode($response, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR);
+
+        DB::update(
+            prefixTable('api_idempotency'),
+            [
+                'status' => 'completed',
+                'resource_id' => (int) $item['id'],
+                'http_status' => 201,
+                'response_body' => $responseBody,
+                'updated_at' => $now,
+                'locked_until' => 0,
+                'expires_at' => $now + self::REPLAY_WINDOW_SECONDS,
+            ],
+            'id = %i AND status = %s AND locked_until < %i AND request_fingerprint = %s',
+            (int) $record['id'],
+            'processing',
+            $now,
+            $requestFingerprint
+        );
+
+        if (DB::affectedRows() !== 1) {
+            return null;
+        }
+
+        return [
+            'state' => 'replay',
+            'resource_id' => (int) $item['id'],
+            'http_status' => 201,
+            'response' => $response,
+        ];
+    }
+}

--- a/app/api/Model/ItemModel.php
+++ b/app/api/Model/ItemModel.php
@@ -553,6 +553,7 @@ class ItemModel
                 $newID,
                 $itemInfos,
                 $folderId,
+                $passwordKey,
                 $userId,
                 $username,
                 $tags,
@@ -1099,6 +1100,7 @@ class ItemModel
      * @param int $newID - The ID of the newly created item
      * @param array $itemInfos - Folder-specific settings
      * @param int $folderId - Folder ID of the item
+     * @param string $passwordKey - The encryption key for the item
      * @param int $userId - ID of the user creating the item
      * @param string $username - Username of the creator
      * @param string $tags - Tags to be associated with the item
@@ -1111,6 +1113,7 @@ class ItemModel
         int $newID,
         array $itemInfos,
         int $folderId,
+        string $passwordKey,
         int $userId,
         string $username,
         string $tags,

--- a/app/api/Model/ItemModel.php
+++ b/app/api/Model/ItemModel.php
@@ -2281,7 +2281,6 @@ class ItemModel
                 (int) $userData['id']
             ) === false) {
                 DB::rollback();
-                $transactionStarted = false;
                 return [
                     'error' => true,
                     'error_message' => 'Access denied: you are not allowed to delete this item',
@@ -2291,7 +2290,6 @@ class ItemModel
 
             if ($expectedRevision !== null && $expectedRevision !== (int) ($currentItem['revision'] ?? 0)) {
                 DB::rollback();
-                $transactionStarted = false;
                 return [
                     'error' => true,
                     'error_message' => 'The item was modified since revision ' . $expectedRevision . '.',
@@ -2305,7 +2303,6 @@ class ItemModel
                 || (bool) ($laprRelation['is_credential'] ?? false) === true
             ) {
                 DB::rollback();
-                $transactionStarted = false;
                 return [
                     'error' => true,
                     'error_message' => 'This item is linked to LAPR. Remove the managed account or linked endpoint first.',

--- a/app/api/Model/ItemModel.php
+++ b/app/api/Model/ItemModel.php
@@ -2264,7 +2264,6 @@ class ItemModel
 
             if (DB::count() === 0) {
                 DB::rollback();
-                $transactionStarted = false;
                 return [
                     'error' => true,
                     'error_message' => 'Item not found',

--- a/app/api/Model/ItemModel.php
+++ b/app/api/Model/ItemModel.php
@@ -453,11 +453,19 @@ class ItemModel
      * Main function to add a new item to the database.
      * It handles data preparation, validation, password checks, folder settings,
      * item creation, and post-insertion tasks (like logging, sharing, and tagging).
+     *
+     * @param array<string, mixed> $arrItemParams Item fields and authenticated user context
+     * @param ApiIdempotencyModel|null $idempotencyModel Persistent idempotency coordinator
+     * @param array<string, mixed>|null $idempotencyReservation Acquired reservation
+     * @return array<string, mixed> Success or error response
      */
     public function addItem(
-        array $arrItemParams
+        array $arrItemParams,
+        ?ApiIdempotencyModel $idempotencyModel = null,
+        ?array $idempotencyReservation = null
     ) : array
     {
+        $transactionStarted = false;
         try {
             include_once API_ROOT_PATH . '/../sources/main.functions.php';
 
@@ -522,11 +530,38 @@ class ItemModel
                 $data['favicon_url'] = $this->getFaviconUrl($data['url']);
             }
 
+            // Keep the complete persistent mutation atomic, including the replay result. External
+            // favicon resolution and all validation deliberately happened before this transaction.
+            DB::startTransaction();
+            $transactionStarted = true;
+            if ($idempotencyModel !== null && $idempotencyReservation !== null) {
+                $idempotencyModel->lockReservation($idempotencyReservation);
+            }
+
             // Step 8: Insert the new item into the database
-            $newID = $this->insertNewItem($data, $password, $itemInfos, $complexityLevel, $passwordIv);
+            $newID = $this->insertNewItem(
+                $data,
+                $password,
+                $itemInfos,
+                $complexityLevel,
+                $passwordIv,
+                $idempotencyReservation === null ? null : (int) $idempotencyReservation['id']
+            );
 
             // Step 9: Handle post-insert tasks (logging, sharing, tagging, custom fields)
-            $this->handlePostInsertTasks($newID, $itemInfos, $folderId, $passwordKey, $userId, $username, $tags, $fields, $data, $SETTINGS);
+            $this->handlePostInsertTasks(
+                $newID,
+                $itemInfos,
+                $folderId,
+                $passwordKey,
+                $userId,
+                $username,
+                $tags,
+                $fields,
+                $data,
+                $SETTINGS,
+                false
+            );
 
             updateCacheTable('add_value', $newID, $userId);
 
@@ -538,9 +573,12 @@ class ItemModel
             refreshItemHealthAfterSave((int) $newID, $userId, (string) $plaintextPasswordForHealth, $SETTINGS);
 
             $revisionMetadata = getItemRevisionMetadata((int) $newID);
+            if ($revisionMetadata['revision'] <= 0 || $revisionMetadata['revision_changed_at'] === null) {
+                throw new RuntimeException('The item creation revision could not be persisted.');
+            }
 
             // Success response
-            return [
+            $response = [
                 'error' => false,
                 'message' => 'Item added successfully',
                 'newId' => $newID,
@@ -548,12 +586,45 @@ class ItemModel
                 'revision_changed_at' => $revisionMetadata['revision_changed_at'],
             ];
 
-        } catch (Exception $e) {
-            // Error response
+            if ($idempotencyModel !== null && $idempotencyReservation !== null) {
+                $idempotencyModel->completeReservation($idempotencyReservation, $newID, 201, $response);
+            }
+
+            DB::commit();
+            $transactionStarted = false;
+
+            // Syslog is an external UDP side effect. Emit it only after the SQL outcome and
+            // replay result are durable; an idempotent replay never reaches this point.
+            emitItemSyslog($SETTINGS, $newID, $label, 'at_creation', $username);
+
+            return $response;
+        } catch (InvalidArgumentException | UnexpectedValueException $e) {
+            if ($transactionStarted === true) {
+                DB::rollback();
+                resetItemRevisionMemo();
+            }
+
             return [
                 'error' => true,
                 'error_header' => 'HTTP/1.1 422 Unprocessable Entity',
                 'error_message' => $e->getMessage(),
+            ];
+        } catch (Throwable $e) {
+            if ($transactionStarted === true) {
+                DB::rollback();
+                resetItemRevisionMemo();
+            }
+
+            error_log(
+                '[API] ItemModel::addItem failed for user '
+                . (int) ($arrItemParams['id'] ?? 0)
+                . ' [' . get_class($e) . ':' . (int) $e->getCode() . ']'
+            );
+
+            return [
+                'error' => true,
+                'error_header' => 'HTTP/1.1 500 Internal Server Error',
+                'error_message' => 'An internal error occurred while creating the item.',
             ];
         }
     }
@@ -696,11 +767,11 @@ class ItemModel
     private function validatePassword(string $password, array $SETTINGS) : void
     {
         if ($this->isPasswordEmptyAllowed($password, $SETTINGS['create_item_without_password'])) {
-            throw new Exception('Empty password is not allowed');
+            throw new InvalidArgumentException('Empty password is not allowed');
         }
 
         if (strlen($password) > $SETTINGS['pwd_maximum_length']) {
-            throw new Exception('Password is too long (max allowed is ' . $SETTINGS['pwd_maximum_length'] . ' characters)');
+            throw new InvalidArgumentException('Password is too long (max allowed is ' . $SETTINGS['pwd_maximum_length'] . ' characters)');
         }
     }
 
@@ -862,7 +933,7 @@ class ItemModel
     {
         // Check existence first
         if (isset($itemInfos['folderId']) === false) {
-            throw new Exception('Folder ID is missing');
+            throw new InvalidArgumentException('Folder ID is missing');
         }
 
         // Cast to integer for strict validation
@@ -870,7 +941,7 @@ class ItemModel
 
         // Validate value
         if ($folderId <= 0) {
-            throw new Exception('Invalid folder ID for complexity check');
+            throw new InvalidArgumentException('Invalid folder ID for complexity check');
         }
 
         $folderComplexity = DB::queryFirstRow(
@@ -892,7 +963,7 @@ class ItemModel
         $passwordStrengthScore = convertPasswordStrength((int) $passwordStrength['score']);
 
         if ($passwordStrengthScore < $requested_folder_complexity && (int) $itemInfos['no_complex_check_on_creation'] === 0) {
-            throw new Exception('Password strength is too low');
+            throw new InvalidArgumentException('Password strength is too low');
         }
 
         return $passwordStrengthScore;
@@ -919,7 +990,7 @@ class ItemModel
 	     (isset($SETTINGS['duplicate_item']) && (int) $SETTINGS['duplicate_item'] === 0)
 	     && (int) $itemInfos['personal_folder'] === 0)
         ) {
-            throw new Exception('Similar item already exists. Duplicates are not allowed.');
+            throw new InvalidArgumentException('Similar item already exists. Duplicates are not allowed.');
         }
     }
 
@@ -946,35 +1017,48 @@ class ItemModel
      * @param array $itemInfos - Folder-specific settings
      * @param int $complexityLevel - Complexity level computed from the plaintext password by checkPasswordComplexity()
      * @param string $passwordIv - v2 metadata (pw_iv) returned by encryptPassword(); empty for legacy data
+     * @param int|null $idempotencyId Durable create reservation identifier
      * @return int - Returns the ID of the newly created item
      */
-    private function insertNewItem(array $data, string $password, array $itemInfos, int $complexityLevel, string $passwordIv = '') : int
+    private function insertNewItem(
+        array $data,
+        string $password,
+        array $itemInfos,
+        int $complexityLevel,
+        string $passwordIv = '',
+        ?int $idempotencyId = null
+    ) : int
     {
         include_once API_ROOT_PATH . '/../sources/main.functions.php';
 
+        $itemData = [
+            'label' => $data['label'],
+            'description' => $data['description'],
+            'pw' => $password,
+            'pw_iv' => $passwordIv,
+            'pw_len' => strlen($data['password']),
+            'email' => $data['email'],
+            'url' => $data['url'],
+            'id_tree' => $data['folderId'],
+            'login' => $data['login'],
+            'inactif' => 0,
+            'restricted_to' => '',
+            'perso' => $itemInfos['personal_folder'],
+            'anyone_can_modify' => $data['anyoneCanModify'],
+            'complexity_level' => $complexityLevel,
+            'encryption_type' => 'teampass_aes',
+            'fa_icon' => $data['icon'],
+            'item_key' => uniqidReal(50),
+            'created_at' => time(),
+            'favicon_url' => $data['favicon_url'],
+        ];
+        if ($idempotencyId !== null) {
+            $itemData['api_idempotency_id'] = $idempotencyId;
+        }
+
         DB::insert(
             prefixTable('items'),
-            [
-                'label' => $data['label'],
-                'description' => $data['description'],
-                'pw' => $password,
-                'pw_iv' => $passwordIv,
-                'pw_len' => strlen($data['password']),
-                'email' => $data['email'],
-                'url' => $data['url'],
-                'id_tree' => $data['folderId'],
-                'login' => $data['login'],
-                'inactif' => 0,
-                'restricted_to' => '',
-                'perso' => $itemInfos['personal_folder'],
-                'anyone_can_modify' => $data['anyoneCanModify'],
-                'complexity_level' => $complexityLevel,
-                'encryption_type' => 'teampass_aes',
-                'fa_icon' => $data['icon'],
-                'item_key' => uniqidReal(50),
-                'created_at' => time(),
-                'favicon_url' => $data['favicon_url'],
-            ]
+            $itemData
         );
 
         $newItemId = DB::insertId();
@@ -1020,6 +1104,7 @@ class ItemModel
      * @param string $tags - Tags to be associated with the item
      * @param array $data - The original data used to create the item (including the label)
      * @param array $SETTINGS - System settings for logging and task creation
+     * @param bool $emitSyslog - Whether logItems() may emit the external syslog datagram
      */
     private function handlePostInsertTasks(
         int $newID,
@@ -1031,7 +1116,8 @@ class ItemModel
         string $tags,
         array $fields,
         array $data,
-        array $SETTINGS
+        array $SETTINGS,
+        bool $emitSyslog = true
     ) : void {
         // Create share keys for the creator
         storeUsersShareKey(
@@ -1047,7 +1133,20 @@ class ItemModel
         );
 
         // Log the item creation
-        logItems($SETTINGS, $newID, $data['label'], $userId, 'at_creation', $username);
+        logItems(
+            $SETTINGS,
+            $newID,
+            $data['label'],
+            $userId,
+            'at_creation',
+            $username,
+            null,
+            null,
+            null,
+            null,
+            $emitSyslog,
+            true
+        );
 
         // Add tags to the item
         $this->addTags($newID, $tags);
@@ -2132,13 +2231,20 @@ class ItemModel
      *
      * @param int $itemId The ID of the item to delete
      * @param array $userData User data from JWT token
+     * @param int|null $expectedRevision Optional optimistic-concurrency precondition
+     * @param ApiIdempotencyModel|null $idempotencyModel Persistent idempotency coordinator
+     * @param array<string, mixed>|null $idempotencyReservation Acquired reservation
      * @return array Returns success or error response
      */
     public function deleteItem(
         int $itemId,
-        array $userData
+        array $userData,
+        ?int $expectedRevision = null,
+        ?ApiIdempotencyModel $idempotencyModel = null,
+        ?array $idempotencyReservation = null
     ): array
     {
+        $transactionStarted = false;
         try {
             include_once API_ROOT_PATH . '/../sources/main.functions.php';
             include_once API_ROOT_PATH . '/../sources/lapr.functions.php';
@@ -2147,17 +2253,53 @@ class ItemModel
             $configManager = new ConfigManager();
             $SETTINGS = $configManager->getAllSettings();
 
-            // Load current item data
+            DB::startTransaction();
+            $transactionStarted = true;
+            if ($idempotencyModel !== null && $idempotencyReservation !== null) {
+                $idempotencyModel->lockReservation($idempotencyReservation);
+            }
+
+            // Lock the item row and perform the revision check immediately before mutation.
             $currentItem = DB::queryFirstRow(
-                'SELECT * FROM ' . prefixTable('items') . ' WHERE id = %i',
+                'SELECT * FROM ' . prefixTable('items') . ' WHERE id = %i FOR UPDATE',
                 $itemId
             );
 
             if (DB::count() === 0) {
+                DB::rollback();
+                $transactionStarted = false;
                 return [
                     'error' => true,
                     'error_message' => 'Item not found',
                     'error_header' => 'HTTP/1.1 404 Not Found',
+                ];
+            }
+
+            $folderAccessModel = new FolderAccessModel();
+            if ($folderAccessModel->canAccessItemInFolder(
+                $userData,
+                (int) $currentItem['id_tree'],
+                $itemId
+            ) === false || $folderAccessModel->canDeleteInFolder(
+                (int) $currentItem['id_tree'],
+                (int) $userData['id']
+            ) === false) {
+                DB::rollback();
+                $transactionStarted = false;
+                return [
+                    'error' => true,
+                    'error_message' => 'Access denied: you are not allowed to delete this item',
+                    'error_header' => 'HTTP/1.1 403 Forbidden',
+                ];
+            }
+
+            if ($expectedRevision !== null && $expectedRevision !== (int) ($currentItem['revision'] ?? 0)) {
+                DB::rollback();
+                $transactionStarted = false;
+                return [
+                    'error' => true,
+                    'error_message' => 'The item was modified since revision ' . $expectedRevision . '.',
+                    'error_header' => 'HTTP/1.1 409 Conflict',
                 ];
             }
 
@@ -2166,6 +2308,8 @@ class ItemModel
             if ((bool) ($laprRelation['is_managed'] ?? false) === true
                 || (bool) ($laprRelation['is_credential'] ?? false) === true
             ) {
+                DB::rollback();
+                $transactionStarted = false;
                 return [
                     'error' => true,
                     'error_message' => 'This item is linked to LAPR. Remove the managed account or linked endpoint first.',
@@ -2184,23 +2328,80 @@ class ItemModel
                 $itemId
             );
 
-            logItems($SETTINGS, $itemId, $currentItem['label'], $userData['id'], 'at_delete', $userData['username']);
+            logItems(
+                $SETTINGS,
+                $itemId,
+                $currentItem['label'],
+                $userData['id'],
+                'at_delete',
+                $userData['username'],
+                null,
+                null,
+                null,
+                null,
+                false,
+                true
+            );
 
             updateCacheTable('delete_value', $itemId);
 
-            // Success response
-            return [
+            emitItemEvent(
+                'deleted',
+                $itemId,
+                (int) $currentItem['id_tree'],
+                (string) $currentItem['label'],
+                (string) $userData['username'],
+                (int) $userData['id']
+            );
+
+            $revisionMetadata = getItemRevisionMetadata($itemId);
+            if ($revisionMetadata['revision'] <= (int) ($currentItem['revision'] ?? 0)
+                || $revisionMetadata['revision_changed_at'] === null
+            ) {
+                throw new RuntimeException('The item deletion revision could not be persisted.');
+            }
+            $response = [
                 'error' => false,
                 'message' => 'Item deleted successfully',
                 'item_id' => $itemId,
+                'revision' => $revisionMetadata['revision'],
+                'revision_changed_at' => $revisionMetadata['revision_changed_at'],
             ];
 
-        } catch (Exception $e) {
-            // Error response
+            if ($idempotencyModel !== null && $idempotencyReservation !== null) {
+                $idempotencyModel->completeReservation($idempotencyReservation, $itemId, 200, $response);
+            }
+
+            DB::commit();
+            $transactionStarted = false;
+
+            // Keep the external syslog datagram outside the SQL transaction. Replays return
+            // the stored response above the model and therefore never emit it again.
+            emitItemSyslog(
+                $SETTINGS,
+                $itemId,
+                (string) $currentItem['label'],
+                'at_delete',
+                (string) $userData['username']
+            );
+
+            return $response;
+        } catch (Throwable $e) {
+            if ($transactionStarted === true) {
+                DB::rollback();
+                resetItemRevisionMemo();
+            }
+
+            error_log(
+                '[API] ItemModel::deleteItem failed for item '
+                . $itemId
+                . ' [' . get_class($e) . ':' . (int) $e->getCode() . ']'
+            );
+
             return [
                 'error' => true,
                 'error_header' => 'HTTP/1.1 500 Internal Server Error',
-                'error_message' => $e->getMessage(),
+                'error_message' => 'An internal error occurred while deleting the item.',
             ];
         }
     }

--- a/app/api/Model/ItemModel.php
+++ b/app/api/Model/ItemModel.php
@@ -598,21 +598,18 @@ class ItemModel
             emitItemSyslog($SETTINGS, $newID, $label, 'at_creation', $username);
 
             return $response;
-        } catch (InvalidArgumentException | UnexpectedValueException $e) {
+        } catch (Throwable $e) {
             if ($transactionStarted === true) {
                 DB::rollback();
                 resetItemRevisionMemo();
             }
 
-            return [
-                'error' => true,
-                'error_header' => 'HTTP/1.1 422 Unprocessable Entity',
-                'error_message' => $e->getMessage(),
-            ];
-        } catch (Throwable $e) {
-            if ($transactionStarted === true) {
-                DB::rollback();
-                resetItemRevisionMemo();
+            if ($e instanceof InvalidArgumentException || $e instanceof UnexpectedValueException) {
+                return [
+                    'error' => true,
+                    'error_header' => 'HTTP/1.1 422 Unprocessable Entity',
+                    'error_message' => $e->getMessage(),
+                ];
             }
 
             error_log(

--- a/app/api/Model/ItemModel.php
+++ b/app/api/Model/ItemModel.php
@@ -549,11 +549,10 @@ class ItemModel
             );
 
             // Step 9: Handle post-insert tasks (logging, sharing, tagging, custom fields)
-            $this->handlePostInsertTasks(
+            $fieldsForTasks = $this->handlePostInsertTasks(
                 $newID,
                 $itemInfos,
                 $folderId,
-                $passwordKey,
                 $userId,
                 $username,
                 $tags,
@@ -567,10 +566,6 @@ class ItemModel
 
             // Notify WebSocket subscribers so other users viewing this folder see the new item
             emitItemEvent('created', $newID, $folderId, $label, $username, $userId);
-
-            // Refresh the caller's security posture so a reused/weak password is flagged without
-            // waiting for a manual dashboard scan (no-op when the dashboard is disabled).
-            refreshItemHealthAfterSave((int) $newID, $userId, (string) $plaintextPasswordForHealth, $SETTINGS);
 
             $revisionMetadata = getItemRevisionMetadata((int) $newID);
             if ($revisionMetadata['revision'] <= 0 || $revisionMetadata['revision_changed_at'] === null) {
@@ -593,8 +588,15 @@ class ItemModel
             DB::commit();
             $transactionStarted = false;
 
-            // Syslog is an external UDP side effect. Emit it only after the SQL outcome and
-            // replay result are durable; an idempotent replay never reaches this point.
+            // The detached handler uses another database connection, so enqueue and launch it
+            // only after the item and its idempotency replay result are visible.
+            if ((int) $itemInfos['personal_folder'] === 0) {
+                storeTask('new_item', $userId, 0, $folderId, $newID, $passwordKey, $fieldsForTasks, []);
+            }
+
+            // Cache refreshes and external side effects stay outside the SQL transaction. An
+            // idempotent replay returns before the model and therefore never repeats them.
+            refreshItemHealthAfterSave((int) $newID, $userId, (string) $plaintextPasswordForHealth, $SETTINGS);
             emitItemSyslog($SETTINGS, $newID, $label, 'at_creation', $username);
 
             return $response;
@@ -616,6 +618,8 @@ class ItemModel
                 '[API] ItemModel::addItem failed for user '
                 . (int) ($arrItemParams['id'] ?? 0)
                 . ' [' . get_class($e) . ':' . (int) $e->getCode() . ']'
+                . ' ' . $e->getMessage()
+                . ' in ' . $e->getFile() . ':' . $e->getLine()
             );
 
             return [
@@ -1090,24 +1094,23 @@ class ItemModel
      * Handles tasks that need to be performed after the item is inserted:
      * 1. Stores sharing keys
      * 2. Logs the item creation
-     * 3. Adds a task if the folder is not personal
-     * 4. Adds tags to the item
+     * 3. Adds tags to the item
+     * 4. Stores custom fields and returns their keys for the post-commit fan-out task
      * @param int $newID - The ID of the newly created item
      * @param array $itemInfos - Folder-specific settings
      * @param int $folderId - Folder ID of the item
-     * @param string $passwordKey - The encryption key for the item
      * @param int $userId - ID of the user creating the item
      * @param string $username - Username of the creator
      * @param string $tags - Tags to be associated with the item
      * @param array $data - The original data used to create the item (including the label)
      * @param array $SETTINGS - System settings for logging and task creation
      * @param bool $emitSyslog - Whether logItems() may emit the external syslog datagram
+     * @return array<int, array<string, mixed>> Field keys for the background fan-out task
      */
     private function handlePostInsertTasks(
         int $newID,
         array $itemInfos,
         int $folderId,
-        string $passwordKey,
         int $userId,
         string $username,
         string $tags,
@@ -1115,7 +1118,7 @@ class ItemModel
         array $data,
         array $SETTINGS,
         bool $emitSyslog = true
-    ) : void {
+    ) : array {
         // Create share keys for the creator
         storeUsersShareKey(
             'sharekeys_items',
@@ -1148,13 +1151,10 @@ class ItemModel
         // Add tags to the item
         $this->addTags($newID, $tags);
 
-        // Store custom fields — returns the field object keys for the background task
+        // Store custom fields and return their object keys to the post-commit caller.
         $fieldsForTasks = $this->handleCustomFieldsOnCreate($newID, $folderId, $fields, $userId, $itemInfos, $SETTINGS);
 
-        // Create a task if the folder is not personal (generates pwd/fields sharekeys for the other users)
-        if ((int) $itemInfos['personal_folder'] === 0) {
-            storeTask('new_item', $userId, 0, $folderId, $newID, $passwordKey, $fieldsForTasks, []);
-        }
+        return $fieldsForTasks;
     }
 
 
@@ -2271,6 +2271,8 @@ class ItemModel
                 ];
             }
 
+            // The controller checks authorization before reserving the idempotency key. Repeat
+            // it under the item row lock so a concurrent move cannot invalidate that decision.
             $folderAccessModel = new FolderAccessModel();
             if ($folderAccessModel->canAccessItemInFolder(
                 $userData,
@@ -2389,6 +2391,8 @@ class ItemModel
                 '[API] ItemModel::deleteItem failed for item '
                 . $itemId
                 . ' [' . get_class($e) . ':' . (int) $e->getCode() . ']'
+                . ' ' . $e->getMessage()
+                . ' in ' . $e->getFile() . ':' . $e->getLine()
             );
 
             return [

--- a/app/api/inc/bootstrap.php
+++ b/app/api/inc/bootstrap.php
@@ -46,6 +46,7 @@ require API_ROOT_PATH . "/Controller/Api/BaseController.php";
 
 // include the use model file
 require API_ROOT_PATH . "/Model/UserModel.php";
+require API_ROOT_PATH . "/Model/ApiIdempotencyModel.php";
 require API_ROOT_PATH . "/Model/ItemModel.php";
 require API_ROOT_PATH . "/Model/FolderModel.php";
 require API_ROOT_PATH . "/Model/FolderAccessModel.php";

--- a/app/api/index.php
+++ b/app/api/index.php
@@ -63,8 +63,8 @@ if ($corsOriginsRaw === '') {
 header('Content-Type: application/json; charset=UTF-8');
 header('Access-Control-Allow-Methods: POST, GET, PUT, DELETE');
 header('Access-Control-Max-Age: 3600');
-header('Access-Control-Allow-Headers: Content-Type, Access-Control-Allow-Headers, Authorization, X-Requested-With');
-header('Access-Control-Expose-Headers: X-Api-Version, X-Total-Count, Location, Allow');
+header('Access-Control-Allow-Headers: Content-Type, Access-Control-Allow-Headers, Authorization, X-Requested-With, Idempotency-Key');
+header('Access-Control-Expose-Headers: X-Api-Version, X-Total-Count, Location, Allow, Idempotency-Replayed, Retry-After');
 header('X-Content-Type-Options: nosniff');
 header('X-Frame-Options: DENY');
 header('Referrer-Policy: no-referrer');

--- a/app/api/openapi.json
+++ b/app/api/openapi.json
@@ -628,7 +628,7 @@
             "post": {
                 "operationId": "itemCreate",
                 "summary": "Create a new item",
-                "description": "All listed fields must be present, even if empty. Idempotency-Key is optional; within its 90-day replay window the same user, key and canonical creation intent return the original 201 response without repeating side effects.",
+                "description": "All listed fields must be present, even if empty. Idempotency-Key is optional; within the configured offline synchronization window (90 days by default, 0 for no limit) the same user, key and canonical creation intent return the original 201 response without repeating side effects.",
                 "parameters": [
                     {
                         "$ref": "#/components/parameters/IdempotencyKey"
@@ -775,7 +775,7 @@
             "delete": {
                 "operationId": "itemDelete",
                 "summary": "Soft-delete an item",
-                "description": "The optional revision is an optimistic-concurrency precondition. Idempotency-Key makes a successful deletion replayable for 90 days without allocating another revision or repeating side effects.",
+                "description": "The optional revision is an optimistic-concurrency precondition. Idempotency-Key makes a successful deletion replayable for the configured offline synchronization window (90 days by default, 0 for no limit) without allocating another revision or repeating side effects.",
                 "parameters": [
                     {
                         "$ref": "#/components/parameters/IdempotencyKey"
@@ -793,7 +793,8 @@
                         "name": "revision",
                         "in": "query",
                         "required": false,
-                        "description": "Current item revision expected by the caller. A mismatch returns 409 before any mutation.",
+                        "allowEmptyValue": true,
+                        "description": "Current item revision expected by the caller. A mismatch returns 409 before any mutation; an empty value is treated as omitted.",
                         "schema": {
                             "type": "integer",
                             "minimum": 0,

--- a/app/api/openapi.json
+++ b/app/api/openapi.json
@@ -628,7 +628,12 @@
             "post": {
                 "operationId": "itemCreate",
                 "summary": "Create a new item",
-                "description": "All listed fields must be present, even if empty.",
+                "description": "All listed fields must be present, even if empty. Idempotency-Key is optional; within its 90-day replay window the same user, key and canonical creation intent return the original 201 response without repeating side effects.",
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/IdempotencyKey"
+                    }
+                ],
                 "requestBody": {
                     "required": true,
                     "content": {
@@ -648,6 +653,9 @@
                                 "schema": {
                                     "type": "string"
                                 }
+                            },
+                            "Idempotency-Replayed": {
+                                "$ref": "#/components/headers/Idempotency-Replayed"
                             }
                         },
                         "content": {
@@ -669,6 +677,9 @@
                     },
                     "405": {
                         "$ref": "#/components/responses/MethodNotAllowed"
+                    },
+                    "409": {
+                        "$ref": "#/components/responses/Conflict"
                     },
                     "422": {
                         "$ref": "#/components/responses/UnprocessableEntity"
@@ -764,23 +775,66 @@
             "delete": {
                 "operationId": "itemDelete",
                 "summary": "Soft-delete an item",
+                "description": "The optional revision is an optimistic-concurrency precondition. Idempotency-Key makes a successful deletion replayable for 90 days without allocating another revision or repeating side effects.",
                 "parameters": [
+                    {
+                        "$ref": "#/components/parameters/IdempotencyKey"
+                    },
                     {
                         "name": "id",
                         "in": "query",
                         "required": true,
                         "schema": {
-                            "type": "integer"
+                            "type": "integer",
+                            "minimum": 1
+                        }
+                    },
+                    {
+                        "name": "revision",
+                        "in": "query",
+                        "required": false,
+                        "description": "Current item revision expected by the caller. A mismatch returns 409 before any mutation.",
+                        "schema": {
+                            "type": "integer",
+                            "minimum": 0,
+                            "maximum": 4294967295
                         }
                     }
                 ],
                 "responses": {
                     "200": {
                         "description": "Item deleted",
+                        "headers": {
+                            "Idempotency-Replayed": {
+                                "$ref": "#/components/headers/Idempotency-Replayed"
+                            }
+                        },
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "type": "object"
+                                    "type": "object",
+                                    "properties": {
+                                        "error": {
+                                            "type": "boolean"
+                                        },
+                                        "message": {
+                                            "type": "string"
+                                        },
+                                        "item_id": {
+                                            "type": "integer"
+                                        },
+                                        "revision": {
+                                            "type": "integer",
+                                            "description": "Deletion revision exposed by item/changes"
+                                        },
+                                        "revision_changed_at": {
+                                            "type": [
+                                                "integer",
+                                                "null"
+                                            ],
+                                            "description": "Unix UTC timestamp paired with the deletion revision"
+                                        }
+                                    }
                                 }
                             }
                         }
@@ -796,6 +850,9 @@
                     },
                     "405": {
                         "$ref": "#/components/responses/MethodNotAllowed"
+                    },
+                    "409": {
+                        "$ref": "#/components/responses/Conflict"
                     },
                     "500": {
                         "$ref": "#/components/responses/InternalError"
@@ -1157,6 +1214,18 @@
                     "type": "integer",
                     "minimum": 0
                 }
+            },
+            "IdempotencyKey": {
+                "name": "Idempotency-Key",
+                "in": "header",
+                "required": false,
+                "description": "Opaque 1-128 character visible-ASCII key, scoped to the authenticated user and API operation. Raw keys are never persisted.",
+                "schema": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 128,
+                    "pattern": "^[!-~]+$"
+                }
             }
         },
         "headers": {
@@ -1164,6 +1233,15 @@
                 "description": "Total number of matching entries before pagination",
                 "schema": {
                     "type": "integer"
+                }
+            },
+            "Idempotency-Replayed": {
+                "description": "Present with value true when the stored response was replayed without executing the mutation.",
+                "schema": {
+                    "type": "string",
+                    "enum": [
+                        "true"
+                    ]
                 }
             }
         },

--- a/app/scripts/task_maintenance_clean_orphan_objects.php
+++ b/app/scripts/task_maintenance_clean_orphan_objects.php
@@ -64,14 +64,16 @@ $integritySummary = cleanOrphanObjectsAndScanIntegrity();
 $prunedRevisions = pruneItemRevisionsJournal(
     offlineSyncResolveWindowDays($SETTINGS['offline_sync_window_days'] ?? null)
 );
+$prunedIdempotencyRecords = pruneApiIdempotencyRecords();
 
 // log end
 doLog('completed', '', 1, $logID);
 
 echo sprintf(
-    'Items integrity scan completed: %d active corrupted item(s). %d journal entry(ies) pruned.',
+    'Items integrity scan completed: %d active corrupted item(s). %d journal entry(ies) pruned. %d API idempotency record(s) pruned.',
     (int) ($integritySummary['count'] ?? 0),
-    $prunedRevisions
+    $prunedRevisions,
+    $prunedIdempotencyRecords
 );
 
 /**

--- a/app/sources/api_idempotency_logic.php
+++ b/app/sources/api_idempotency_logic.php
@@ -1,0 +1,192 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Teampass - a collaborative passwords manager.
+ * ---
+ * This file is part of the TeamPass project.
+ *
+ * TeamPass is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * TeamPass is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Certain components of this file may be under different licenses. For
+ * details, see the `licenses` directory or individual file headers.
+ * ---
+ * DB-free decisions used by the persistent API idempotency adapter.
+ *
+ * @file      api_idempotency_logic.php
+ * @author    Nils Laumaillé (nils@teampass.net)
+ * @copyright 2009-2026 Teampass.net
+ * @license   GPL-3.0
+ * @see       https://www.teampass.net
+ */
+
+require_once __DIR__ . '/item_revisions_logic.php';
+
+/**
+ * Canonicalize a request value before hashing its functional intent.
+ *
+ * Associative keys are sorted recursively. List order remains significant.
+ *
+ * @param mixed $value Value to canonicalize
+ * @return mixed Canonical value
+ */
+function apiIdempotencyCanonicalize($value)
+{
+    if (is_array($value) === false) {
+        return $value;
+    }
+
+    if (array_is_list($value)) {
+        return array_map('apiIdempotencyCanonicalize', $value);
+    }
+
+    ksort($value, SORT_STRING);
+    foreach ($value as $key => $entry) {
+        $value[$key] = apiIdempotencyCanonicalize($entry);
+    }
+
+    return $value;
+}
+
+/**
+ * Compute the replay expiry aligned with the configured offline-sync window.
+ *
+ * Zero means that neither the revision journal nor idempotency replays expire.
+ * The overflow guard also makes unexpectedly large administrator values safe.
+ *
+ * @param int   $now           Current Unix timestamp
+ * @param mixed $rawWindowDays Configured offline-sync window in days
+ * @return int Expiry timestamp, 0 when the window is unlimited
+ */
+function apiIdempotencyReplayExpiry(int $now, $rawWindowDays): int
+{
+    if ($now < 0) {
+        throw new InvalidArgumentException('Current timestamp must not be negative.');
+    }
+
+    $windowDays = offlineSyncResolveWindowDays($rawWindowDays);
+    if ($windowDays === 0) {
+        return 0;
+    }
+
+    $secondsPerDay = 86400;
+    if ($windowDays > intdiv(PHP_INT_MAX - $now, $secondsPerDay)) {
+        return PHP_INT_MAX;
+    }
+
+    return $now + ($windowDays * $secondsPerDay);
+}
+
+/**
+ * Build the reservation returned after an insert or successful lease takeover.
+ *
+ * @param int    $recordId          Idempotency record identifier
+ * @param string $ownerToken        Raw request-local owner token
+ * @param string $requestFingerprint HMAC of the functional request intent
+ * @return array{state:string,id:int,owner_token:string,request_fingerprint:string}
+ */
+function apiIdempotencyAcquiredDecision(
+    int $recordId,
+    string $ownerToken,
+    string $requestFingerprint
+): array {
+    if ($recordId <= 0 || $ownerToken === '' || $requestFingerprint === '') {
+        throw new InvalidArgumentException('An acquired idempotency reservation must be complete.');
+    }
+
+    return [
+        'state' => 'acquired',
+        'id' => $recordId,
+        'owner_token' => $ownerToken,
+        'request_fingerprint' => $requestFingerprint,
+    ];
+}
+
+/**
+ * Convert a completed persistence row into the replay returned to the caller.
+ *
+ * @param array<string, mixed> $record Completed database row
+ * @return array{state:string,resource_id:int,http_status:int,response:array<mixed>}
+ */
+function apiIdempotencyReplayDecision(array $record): array
+{
+    $response = json_decode((string) ($record['response_body'] ?? ''), true);
+    if (is_array($response) === false) {
+        throw new RuntimeException('The stored idempotency response is invalid.');
+    }
+
+    return [
+        'state' => 'replay',
+        'resource_id' => (int) ($record['resource_id'] ?? 0),
+        'http_status' => (int) ($record['http_status'] ?? 200),
+        'response' => $response,
+    ];
+}
+
+/**
+ * Decide how an existing idempotency record must be handled.
+ *
+ * A stale result authorizes the persistence adapter to attempt one compare-and-swap
+ * lease takeover. It does not mean that ownership has already been acquired.
+ *
+ * @param array<string, mixed> $record Existing database row
+ * @param string $requestFingerprint HMAC of the current request intent
+ * @param int    $now Current Unix timestamp
+ * @return array<string, mixed> conflict, replay, processing or stale decision
+ */
+function apiIdempotencyExistingRecordDecision(
+    array $record,
+    string $requestFingerprint,
+    int $now
+): array {
+    if (hash_equals((string) ($record['request_fingerprint'] ?? ''), $requestFingerprint) === false) {
+        return ['state' => 'conflict'];
+    }
+
+    if ((string) ($record['status'] ?? '') === 'completed') {
+        return apiIdempotencyReplayDecision($record);
+    }
+
+    $lockedUntil = (int) ($record['locked_until'] ?? 0);
+    if ($lockedUntil >= $now) {
+        return [
+            'state' => 'processing',
+            'retry_after' => max(1, $lockedUntil - $now),
+        ];
+    }
+
+    return ['state' => 'stale'];
+}
+
+/**
+ * Convert a compare-and-swap result into an acquired lease when it won.
+ *
+ * @param int    $affectedRows       Rows changed by the guarded lease update
+ * @param int    $recordId          Idempotency record identifier
+ * @param string $ownerToken        Raw request-local owner token
+ * @param string $requestFingerprint HMAC of the functional request intent
+ * @return array<string, mixed>|null Acquired decision, or null when another request won
+ */
+function apiIdempotencyLeaseTakeoverDecision(
+    int $affectedRows,
+    int $recordId,
+    string $ownerToken,
+    string $requestFingerprint
+): ?array {
+    if ($affectedRows !== 1) {
+        return null;
+    }
+
+    return apiIdempotencyAcquiredDecision($recordId, $ownerToken, $requestFingerprint);
+}

--- a/app/sources/main.functions.php
+++ b/app/sources/main.functions.php
@@ -3455,7 +3455,6 @@ function pruneApiIdempotencyRecords(): int
         $removed = (int) DB::affectedRows();
 
         DB::commit();
-        $transactionStarted = false;
 
         return $removed;
     } catch (Throwable $exception) {

--- a/app/sources/main.functions.php
+++ b/app/sources/main.functions.php
@@ -3415,9 +3415,9 @@ function pruneItemRevisionsJournal(int $windowDays): int
 /**
  * Remove expired API idempotency metadata without touching an active processing lease.
  *
- * The replay window is deliberately finite (90 days). A stale processing row is eligible
- * only after both its lease and replay window expired, so an in-flight request is never removed.
- * Item links are cleared first to avoid leaving technical dangling identifiers.
+ * Each row carries the expiry derived from the configured offline-sync window. A stale processing
+ * row is eligible only after both its lease and replay window expired, so an in-flight request is
+ * never removed. Reservations are locked before item rows to match mutation lock ordering.
  *
  * @return int Number of idempotency records removed
  */
@@ -3431,26 +3431,40 @@ function pruneApiIdempotencyRecords(): int
         DB::startTransaction();
         $transactionStarted = true;
 
-        DB::query(
-            'UPDATE ' . prefixTable('items') . ' AS i
-             INNER JOIN ' . prefixTable('api_idempotency') . ' AS a
-                ON a.id = i.api_idempotency_id
-             SET i.api_idempotency_id = NULL
-             WHERE a.expires_at < %i
-               AND (a.status = %s OR (a.status = %s AND a.locked_until < %i))',
+        $expiredRecords = DB::query(
+            'SELECT id
+             FROM ' . prefixTable('api_idempotency') . '
+             WHERE expires_at > 0
+               AND expires_at < %i
+               AND (status = %s OR (status = %s AND locked_until < %i))
+             ORDER BY id
+             FOR UPDATE',
             $now,
             'completed',
             'processing',
             $now
         );
+        $expiredIds = array_values(array_filter(array_map(
+            static fn (array $record): int => (int) ($record['id'] ?? 0),
+            $expiredRecords
+        )));
+
+        if (count($expiredIds) === 0) {
+            DB::commit();
+            return 0;
+        }
+
+        DB::update(
+            prefixTable('items'),
+            ['api_idempotency_id' => null],
+            'api_idempotency_id IN %li',
+            $expiredIds
+        );
 
         DB::delete(
             prefixTable('api_idempotency'),
-            'expires_at < %i AND (status = %s OR (status = %s AND locked_until < %i))',
-            $now,
-            'completed',
-            'processing',
-            $now
+            'id IN %li',
+            $expiredIds
         );
         $removed = (int) DB::affectedRows();
 

--- a/app/sources/main.functions.php
+++ b/app/sources/main.functions.php
@@ -3061,8 +3061,11 @@ function logEvents(
  * @param string $encryption_type Encryption on
  * @param string $time Encryption Time
  * @param string $old_value       Old value
+ * @param bool   $emitSyslog      Emit the external syslog datagram immediately
+ * @param bool   $failOnDatabaseError Re-throw audit/revision failures for transactional callers
  * 
  * @return void
+ * @throws Throwable When strict database-error handling is requested
  */
 function logItems(
     array $SETTINGS,
@@ -3074,7 +3077,9 @@ function logItems(
     ?string $raison = null,
     ?string $encryption_type = null,
     ?string $time = null,
-    ?string $old_value = null
+    ?string $old_value = null,
+    bool $emitSyslog = true,
+    bool $failOnDatabaseError = false
 ): void {
     // Load class DB
     loadClasses('DB');
@@ -3140,6 +3145,9 @@ function logItems(
             ]
         );
     } catch (\Throwable $e) {
+        if ($failOnDatabaseError === true) {
+            throw $e;
+        }
         // Logging must never break API or UI flows
         return;
     }
@@ -3158,6 +3166,9 @@ function logItems(
                 'last_item_change'
             );
         } catch (\Throwable $e) {
+            if ($failOnDatabaseError === true) {
+                throw $e;
+            }
             // ignore logging-related DB errors
         }
     }
@@ -3166,11 +3177,14 @@ function logItems(
     // point every content change already goes through, satellites included: custom fields,
     // tags, attachments and OTP all log at_modification with a dedicated reason.
     if (itemRevisionShouldBump($action) === true) {
-        bumpItemRevision(
+        $revision = bumpItemRevision(
             $item_id,
             itemRevisionJournalAction($action, $raison),
             $id_user
         );
+        if ($failOnDatabaseError === true && $revision <= 0) {
+            throw new RuntimeException('Unable to allocate the item revision.');
+        }
     }
 
     // Prepare reason for syslog: remove internal source marker if present
@@ -3180,39 +3194,63 @@ function logItems(
         $raisonForSyslog = $parsedReason['reason'] === '' ? null : $parsedReason['reason'];
     }
 
-    // SYSLOG
-    if (isset($SETTINGS['syslog_enable']) === true && (int) $SETTINGS['syslog_enable'] === 1) {
-        // Extract reason
-        $attribute = is_null($raisonForSyslog) === true ? [''] : explode(' : ', $raisonForSyslog);
-        // Get item info if not known
-        if (empty($item_label) === true) {
-            try {
-                $dataItem = DB::queryFirstRow(
-                    'SELECT id, id_tree, label
-                    FROM ' . prefixTable('items') . '
-                    WHERE id = %i',
-                    $item_id
-                );
-                $item_label = $dataItem['label'];
-            } catch (\Throwable $e) {
-                // ignore logging-related DB errors
-            }
+    if ($emitSyslog === true) {
+        emitItemSyslog($SETTINGS, $item_id, $item_label, $action, $login, $raisonForSyslog);
+    }
+
+    // send notification if enabled
+    //notifyOnChange($item_id, $action, $SETTINGS);
+}
+
+/**
+ * Emit the external syslog representation of an item audit event.
+ *
+ * Kept separate from the database audit so transactional API mutations can commit first. A
+ * failed datagram must never turn an already committed item mutation into an HTTP failure.
+ *
+ * @param array<string, mixed> $SETTINGS TeamPass settings
+ * @param int $itemId Item identifier
+ * @param string $itemLabel Item label, resolved from the database when empty
+ * @param string $action Audit action
+ * @param string|null $login Actor login
+ * @param string|null $reason Audit reason without the API source marker
+ * @return void
+ */
+function emitItemSyslog(
+    array $SETTINGS,
+    int $itemId,
+    string $itemLabel,
+    string $action,
+    ?string $login = null,
+    ?string $reason = null
+): void {
+    if (isset($SETTINGS['syslog_enable']) === false || (int) $SETTINGS['syslog_enable'] !== 1) {
+        return;
+    }
+
+    try {
+        $attribute = $reason === null ? [''] : explode(' : ', $reason);
+        if ($itemLabel === '') {
+            $dataItem = DB::queryFirstRow(
+                'SELECT label FROM ' . prefixTable('items') . ' WHERE id = %i',
+                $itemId
+            );
+            $itemLabel = is_array($dataItem) ? (string) ($dataItem['label'] ?? '') : '';
         }
 
         send_syslog(
             'action=' . str_replace('at_', '', $action) .
                 ' attribute=' . str_replace('at_', '', $attribute[0]) .
-                ' itemno=' . $item_id .
-                ' user=' . (is_null($login) === true ? '' : addslashes((string) $login)) .
-                ' itemname="' . addslashes($item_label) . '"',
+                ' itemno=' . $itemId .
+                ' user=' . ($login === null ? '' : addslashes($login)) .
+                ' itemname="' . addslashes($itemLabel) . '"',
             $SETTINGS['syslog_host'],
             $SETTINGS['syslog_port'],
             'teampass'
         );
+    } catch (\Throwable $exception) {
+        error_log('[API] Unable to emit item syslog event: ' . $exception->getMessage());
     }
-
-    // send notification if enabled
-    //notifyOnChange($item_id, $action, $SETTINGS);
 }
 
 /**
@@ -3370,6 +3408,61 @@ function pruneItemRevisionsJournal(int $windowDays): int
 
         return (int) DB::affectedRows();
     } catch (\Throwable $e) {
+        return 0;
+    }
+}
+
+/**
+ * Remove expired API idempotency metadata without touching an active processing lease.
+ *
+ * The replay window is deliberately finite (90 days). A stale processing row is eligible
+ * only after both its lease and replay window expired, so an in-flight request is never removed.
+ * Item links are cleared first to avoid leaving technical dangling identifiers.
+ *
+ * @return int Number of idempotency records removed
+ */
+function pruneApiIdempotencyRecords(): int
+{
+    $now = time();
+    $transactionStarted = false;
+
+    try {
+        loadClasses('DB');
+        DB::startTransaction();
+        $transactionStarted = true;
+
+        DB::query(
+            'UPDATE ' . prefixTable('items') . ' AS i
+             INNER JOIN ' . prefixTable('api_idempotency') . ' AS a
+                ON a.id = i.api_idempotency_id
+             SET i.api_idempotency_id = NULL
+             WHERE a.expires_at < %i
+               AND (a.status = %s OR (a.status = %s AND a.locked_until < %i))',
+            $now,
+            'completed',
+            'processing',
+            $now
+        );
+
+        DB::delete(
+            prefixTable('api_idempotency'),
+            'expires_at < %i AND (status = %s OR (status = %s AND locked_until < %i))',
+            $now,
+            'completed',
+            'processing',
+            $now
+        );
+        $removed = (int) DB::affectedRows();
+
+        DB::commit();
+        $transactionStarted = false;
+
+        return $removed;
+    } catch (Throwable $exception) {
+        if ($transactionStarted === true) {
+            DB::rollback();
+        }
+
         return 0;
     }
 }

--- a/docs/api/api-basic.md
+++ b/docs/api/api-basic.md
@@ -553,7 +553,13 @@ curl -X GET "https://your-teampass.com/api/index.php/item/getOtp?id=123" \
 | **Method** | POST |
 | **URL** | `<Teampass URL>/api/index.php/item/create` |
 | **Content-Type** | `application/json` |
-| **Headers** | `Authorization: Bearer <token>` |
+| **Headers** | `Authorization: Bearer <token>`; optional `Idempotency-Key: <opaque-key>` |
+
+`Idempotency-Key` accepts 1–128 visible ASCII characters without spaces. It is scoped to the
+authenticated user and this operation. TeamPass keeps the completed result for 90 days: retrying
+the same functional request returns the original `201`, `Location` and body without creating
+anything again, and adds `Idempotency-Replayed: true`. Reusing the key with a changed payload
+returns `409`. A duplicate request still processing returns `409` and `Retry-After`.
 
 **Request Body (JSON):**
 ```json
@@ -607,10 +613,12 @@ curl -X GET "https://your-teampass.com/api/index.php/item/getOtp?id=123" \
 
 | Code | Description |
 | ---- | ----------- |
-| 200 | Item created successfully |
-| 400 | Missing or invalid parameters |
+| 201 | Item created successfully (including an idempotent replay) |
+| 400 | Missing/invalid parameters or invalid `Idempotency-Key` |
 | 401 | Invalid token or expired session |
 | 403 | Create permission denied or access denied to folder |
+| 409 | Key already used with another payload, or an identical request is still processing |
+| 422 | Item validation failed |
 | 500 | Server error |
 
 **Example:**
@@ -618,6 +626,7 @@ curl -X GET "https://your-teampass.com/api/index.php/item/getOtp?id=123" \
 curl -X POST "https://your-teampass.com/api/index.php/item/create" \
   -H "Authorization: Bearer YOUR_JWT_TOKEN" \
   -H "Content-Type: application/json" \
+  -H "Idempotency-Key: 550e8400-e29b-41d4-a716-446655440000" \
   -d '{
     "label": "My new item",
     "folder_id": 5,
@@ -631,6 +640,11 @@ curl -X POST "https://your-teampass.com/api/index.php/item/create" \
     "icon": "fa-solid fa-key"
   }'
 ```
+
+Run the same command again to replay its result. Keeping the key but changing, for example,
+`label` or `password` demonstrates the `409` key/payload conflict. TeamPass stores only
+server-secret HMACs of the key and functional payload, never the raw key, body, password, TOTP
+secret or custom-field values.
 
 ---
 
@@ -754,51 +768,52 @@ curl -X PUT "https://your-teampass.com/api/index.php/item/update" \
 | ---- | ----------- |
 | **Endpoint** | `item/delete` |
 | **Method** | DELETE |
-| **URL** | `<Teampass URL>/api/index.php/item/delete` |
-| **Content-Type** | `application/json` |
-| **Headers** | `Authorization: Bearer <token>` |
+| **URL** | `<Teampass URL>/api/index.php/item/delete?id=<id>&revision=<revision>` |
+| **Content-Type** | Not required (parameters are in the query string) |
+| **Headers** | `Authorization: Bearer <token>`; optional `Idempotency-Key: <opaque-key>` |
 
-**Request Body (JSON):**
-```json
-{
-  "id": 123
-}
-```
-
-**Body Parameters:**
+**Query Parameters:**
 
 | Field | Type | Required | Description |
 | ----- | ---- | -------- | ----------- |
 | `id` | integer | ✅ | Item ID to delete |
+| `revision` | integer | ❌ | Current unsigned item revision. A mismatch returns `409` before any mutation. Omitting it retains the historical last-writer-wins behavior. |
+
+The optional idempotency key uses the same syntax, user/operation scope and 90-day window as
+create. Its fingerprint includes both `id` and the optional `revision`. A replay returns the
+original success body plus `Idempotency-Replayed: true` without a second delete, audit, revision,
+cache update or WebSocket event. It therefore cannot delete an item again after a later restore.
 
 **Response (success):**
 ```json
 {
   "error": false,
   "message": "Item deleted successfully",
-  "item_id": "123"
+  "item_id": 123,
+  "revision": 4128,
+  "revision_changed_at": 1787563490
 }
 ```
+
+The revision/date pair is the delete tombstone subsequently returned by `GET /item/changes`.
 
 **Response Codes:**
 
 | Code | Description |
 | ---- | ----------- |
 | 200 | Item deleted successfully |
-| 400 | Missing ID or inconsistent data |
+| 400 | Missing ID, invalid revision or invalid idempotency key |
 | 403 | Delete permission denied or access denied — including a folder granted as `R`, `ND` or `NDNE` (check `can_delete` on [`folder/writableFolders`](#writable-folders)) |
 | 404 | Item not found |
-| 422 | HTTP method not supported (must be DELETE) |
+| 405 | HTTP method not supported (must be DELETE) |
+| 409 | Stale revision, LAPR protection, key/request conflict, or identical request still processing |
 | 500 | Server error |
 
 **Example:**
 ```bash
-curl -X DELETE "https://your-teampass.com/api/index.php/item/delete" \
+curl -X DELETE "https://your-teampass.com/api/index.php/item/delete?id=123&revision=4127" \
   -H "Authorization: Bearer YOUR_JWT_TOKEN" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "id": 123
-  }'
+  -H "Idempotency-Key: 8fe52f47-6f72-4a1a-b0d8-68a01c884d41"
 ```
 
 ---

--- a/docs/api/api-basic.md
+++ b/docs/api/api-basic.md
@@ -556,10 +556,11 @@ curl -X GET "https://your-teampass.com/api/index.php/item/getOtp?id=123" \
 | **Headers** | `Authorization: Bearer <token>`; optional `Idempotency-Key: <opaque-key>` |
 
 `Idempotency-Key` accepts 1–128 visible ASCII characters without spaces. It is scoped to the
-authenticated user and this operation. TeamPass keeps the completed result for 90 days: retrying
-the same functional request returns the original `201`, `Location` and body without creating
-anything again, and adds `Idempotency-Replayed: true`. Reusing the key with a changed payload
-returns `409`. A duplicate request still processing returns `409` and `Retry-After`.
+authenticated user and this operation. TeamPass keeps the completed result for the configured
+offline synchronization window (`offline_sync_window_days`, 90 days by default, `0` for no limit):
+retrying the same functional request returns the original `201`, `Location` and body without
+creating anything again, and adds `Idempotency-Replayed: true`. Reusing the key with a changed
+payload returns `409`. A duplicate request still processing returns `409` and `Retry-After`.
 
 **Request Body (JSON):**
 ```json
@@ -777,9 +778,9 @@ curl -X PUT "https://your-teampass.com/api/index.php/item/update" \
 | Field | Type | Required | Description |
 | ----- | ---- | -------- | ----------- |
 | `id` | integer | ✅ | Item ID to delete |
-| `revision` | integer | ❌ | Current unsigned item revision. A mismatch returns `409` before any mutation. Omitting it retains the historical last-writer-wins behavior. |
+| `revision` | integer | ❌ | Current unsigned item revision. A mismatch returns `409` before any mutation. Omitting it or sending an empty value retains the historical last-writer-wins behavior. |
 
-The optional idempotency key uses the same syntax, user/operation scope and 90-day window as
+The optional idempotency key uses the same syntax, user/operation scope and configured window as
 create. Its fingerprint includes both `id` and the optional `revision`. A replay returns the
 original success body plus `Idempotency-Replayed: true` without a second delete, audit, revision,
 cache update or WebSocket event. It therefore cannot delete an item again after a later restore.

--- a/public/install/install-steps/install.js
+++ b/public/install/install-steps/install.js
@@ -324,7 +324,8 @@ function performStep5() {
         { id: 'check76', action: 'lapr_policies' },
         { id: 'check77', action: 'lapr_audit_log' },
         { id: 'check78', action: 'lapr_rate_limit' },
-        { id: 'check79', action: 'items_revisions' }
+        { id: 'check79', action: 'items_revisions' },
+        { id: 'check80', action: 'api_idempotency' }
     ];
     
     let errorOccurred = false; // Variable to track errors

--- a/public/install/install-steps/run.step5.php
+++ b/public/install/install-steps/run.step5.php
@@ -434,10 +434,12 @@ class DatabaseInstaller
             `hibp_checked_at` varchar(30) NULL DEFAULT NULL,
             `revision` INT UNSIGNED NOT NULL DEFAULT '0',
             `revision_changed_at` BIGINT UNSIGNED NULL DEFAULT NULL,
+            `api_idempotency_id` BIGINT UNSIGNED NULL DEFAULT NULL,
             PRIMARY KEY (`id`),
             KEY `restricted_inactif_idx` (`restricted_to`,`inactif`),
             INDEX items_perso_id_idx (`perso`, `id`),
-            INDEX idx_items_tree_inactif_deleted (`id_tree`, `inactif`, `deleted_at`)
+            INDEX idx_items_tree_inactif_deleted (`id_tree`, `inactif`, `deleted_at`),
+            UNIQUE KEY `uq_items_api_idempotency` (`api_idempotency_id`)
             ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;"
         );
     }
@@ -2393,6 +2395,34 @@ class DatabaseInstaller
         KEY `idx_items_revisions_changed_at` (`changed_at`)
     ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
     COMMENT='Item change journal feeding the offline synchronization delta feed'"
+        );
+    }
+
+    // Create table api_idempotency
+    private function api_idempotency()
+    {
+        DB::query(
+            'CREATE TABLE IF NOT EXISTS `' . $this->inputData['tablePrefix'] . "api_idempotency` (
+        `id` BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+        `user_id` INT UNSIGNED NOT NULL,
+        `operation` VARCHAR(50) NOT NULL,
+        `key_hash` CHAR(64) NOT NULL,
+        `request_fingerprint` CHAR(64) NOT NULL,
+        `status` ENUM('processing', 'completed') NOT NULL DEFAULT 'processing',
+        `owner_token_hash` CHAR(64) NOT NULL,
+        `resource_id` INT UNSIGNED NULL DEFAULT NULL,
+        `http_status` SMALLINT UNSIGNED NULL DEFAULT NULL,
+        `response_body` TEXT NULL DEFAULT NULL,
+        `created_at` BIGINT UNSIGNED NOT NULL,
+        `updated_at` BIGINT UNSIGNED NOT NULL,
+        `locked_until` BIGINT UNSIGNED NOT NULL DEFAULT '0',
+        `expires_at` BIGINT UNSIGNED NOT NULL,
+        PRIMARY KEY (`id`),
+        UNIQUE KEY `uq_api_idempotency_identity` (`user_id`, `operation`, `key_hash`),
+        KEY `idx_api_idempotency_cleanup` (`status`, `expires_at`, `locked_until`),
+        KEY `idx_api_idempotency_resource` (`operation`, `resource_id`)
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+    COMMENT='Replay-safe metadata for idempotent API mutations'"
         );
     }
 

--- a/public/install/upgrade_run_3.2.2.php
+++ b/public/install/upgrade_run_3.2.2.php
@@ -390,15 +390,41 @@ if ($res === false) {
 
 // Durable link between an idempotent create reservation and the item it produced.
 // NULL keeps every historical and non-idempotent creation unchanged.
-$res = addColumnIfNotExist(
-    $pre . 'items',
-    'api_idempotency_id',
-    'BIGINT UNSIGNED NULL DEFAULT NULL'
-);
-if ($res === false) {
-    echo '[{"finish":"1", "msg":"", "error":"Error adding api_idempotency_id to items table: ' . addslashes(mysqli_error($db_link)) . '"}]';
-    mysqli_close($db_link);
-    exit();
+$idempotencyColumnExists = columnExists($db_link, $pre . 'items', 'api_idempotency_id');
+$idempotencyIndexExists = mysqli_fetch_array(mysqli_query(
+    $db_link,
+    "SELECT COUNT(*) FROM INFORMATION_SCHEMA.STATISTICS
+     WHERE TABLE_SCHEMA = DATABASE()
+       AND TABLE_NAME = '" . $pre . "items'
+       AND INDEX_NAME = 'uq_items_api_idempotency'"
+));
+
+// The normal upgrade path adds the column and its unique key in one table rebuild. The
+// separate branches keep a retry safe after an interrupted or partially applied upgrade.
+if ($idempotencyColumnExists === false) {
+    $indexDefinition = empty($idempotencyIndexExists[0])
+        ? ', ADD UNIQUE KEY `uq_items_api_idempotency` (`api_idempotency_id`)'
+        : '';
+    $res = mysqli_query(
+        $db_link,
+        'ALTER TABLE `' . $pre . 'items` ADD `api_idempotency_id` BIGINT UNSIGNED NULL DEFAULT NULL'
+            . $indexDefinition
+    );
+    if ($res === false) {
+        echo '[{"finish":"1", "msg":"", "error":"Error adding items idempotency schema: ' . addslashes(mysqli_error($db_link)) . '"}]';
+        mysqli_close($db_link);
+        exit();
+    }
+} elseif (empty($idempotencyIndexExists[0])) {
+    $res = mysqli_query(
+        $db_link,
+        'ALTER TABLE `' . $pre . 'items` ADD UNIQUE KEY `uq_items_api_idempotency` (`api_idempotency_id`)'
+    );
+    if ($res === false) {
+        echo '[{"finish":"1", "msg":"", "error":"Error adding items idempotency index: ' . addslashes(mysqli_error($db_link)) . '"}]';
+        mysqli_close($db_link);
+        exit();
+    }
 }
 
 // Item change journal. Its AUTO_INCREMENT primary key is the globally monotonic
@@ -456,26 +482,6 @@ if ($res === false) {
     echo '[{"finish":"1", "msg":"", "error":"Error creating api_idempotency table: ' . addslashes(mysqli_error($db_link)) . '"}]';
     mysqli_close($db_link);
     exit();
-}
-
-// Add the nullable one-to-one create link idempotently on upgraded databases.
-$indexExists = mysqli_fetch_array(mysqli_query(
-    $db_link,
-    "SELECT COUNT(*) FROM INFORMATION_SCHEMA.STATISTICS
-     WHERE TABLE_SCHEMA = DATABASE()
-       AND TABLE_NAME = '" . $pre . "items'
-       AND INDEX_NAME = 'uq_items_api_idempotency'"
-));
-if (empty($indexExists[0])) {
-    $res = mysqli_query(
-        $db_link,
-        'ALTER TABLE `' . $pre . 'items` ADD UNIQUE KEY `uq_items_api_idempotency` (`api_idempotency_id`)'
-    );
-    if ($res === false) {
-        echo '[{"finish":"1", "msg":"", "error":"Error adding items idempotency index: ' . addslashes(mysqli_error($db_link)) . '"}]';
-        mysqli_close($db_link);
-        exit();
-    }
 }
 
 // Backfill only when the current item revision still has its exact journal row. Older

--- a/public/install/upgrade_run_3.2.2.php
+++ b/public/install/upgrade_run_3.2.2.php
@@ -388,6 +388,19 @@ if ($res === false) {
     exit();
 }
 
+// Durable link between an idempotent create reservation and the item it produced.
+// NULL keeps every historical and non-idempotent creation unchanged.
+$res = addColumnIfNotExist(
+    $pre . 'items',
+    'api_idempotency_id',
+    'BIGINT UNSIGNED NULL DEFAULT NULL'
+);
+if ($res === false) {
+    echo '[{"finish":"1", "msg":"", "error":"Error adding api_idempotency_id to items table: ' . addslashes(mysqli_error($db_link)) . '"}]';
+    mysqli_close($db_link);
+    exit();
+}
+
 // Item change journal. Its AUTO_INCREMENT primary key is the globally monotonic
 // revision sequence, and its rows are the only tombstone left once an item row is
 // hard deleted or leaves the caller's visible folders.
@@ -411,6 +424,58 @@ if ($res === false) {
     echo '[{"finish":"1", "msg":"", "error":"Error creating items_revisions table: ' . addslashes(mysqli_error($db_link)) . '"}]';
     mysqli_close($db_link);
     exit();
+}
+
+// Persistent API idempotency state. Only HMACs and replay-safe response metadata are stored;
+// request bodies, raw keys and credential values never enter this table.
+$res = mysqli_query(
+    $db_link,
+    'CREATE TABLE IF NOT EXISTS `' . $pre . "api_idempotency` (
+        `id` BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+        `user_id` INT UNSIGNED NOT NULL,
+        `operation` VARCHAR(50) NOT NULL,
+        `key_hash` CHAR(64) NOT NULL,
+        `request_fingerprint` CHAR(64) NOT NULL,
+        `status` ENUM('processing', 'completed') NOT NULL DEFAULT 'processing',
+        `owner_token_hash` CHAR(64) NOT NULL,
+        `resource_id` INT UNSIGNED NULL DEFAULT NULL,
+        `http_status` SMALLINT UNSIGNED NULL DEFAULT NULL,
+        `response_body` TEXT NULL DEFAULT NULL,
+        `created_at` BIGINT UNSIGNED NOT NULL,
+        `updated_at` BIGINT UNSIGNED NOT NULL,
+        `locked_until` BIGINT UNSIGNED NOT NULL DEFAULT '0',
+        `expires_at` BIGINT UNSIGNED NOT NULL,
+        PRIMARY KEY (`id`),
+        UNIQUE KEY `uq_api_idempotency_identity` (`user_id`, `operation`, `key_hash`),
+        KEY `idx_api_idempotency_cleanup` (`status`, `expires_at`, `locked_until`),
+        KEY `idx_api_idempotency_resource` (`operation`, `resource_id`)
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+    COMMENT='Replay-safe metadata for idempotent API mutations'"
+);
+if ($res === false) {
+    echo '[{"finish":"1", "msg":"", "error":"Error creating api_idempotency table: ' . addslashes(mysqli_error($db_link)) . '"}]';
+    mysqli_close($db_link);
+    exit();
+}
+
+// Add the nullable one-to-one create link idempotently on upgraded databases.
+$indexExists = mysqli_fetch_array(mysqli_query(
+    $db_link,
+    "SELECT COUNT(*) FROM INFORMATION_SCHEMA.STATISTICS
+     WHERE TABLE_SCHEMA = DATABASE()
+       AND TABLE_NAME = '" . $pre . "items'
+       AND INDEX_NAME = 'uq_items_api_idempotency'"
+));
+if (empty($indexExists[0])) {
+    $res = mysqli_query(
+        $db_link,
+        'ALTER TABLE `' . $pre . 'items` ADD UNIQUE KEY `uq_items_api_idempotency` (`api_idempotency_id`)'
+    );
+    if ($res === false) {
+        echo '[{"finish":"1", "msg":"", "error":"Error adding items idempotency index: ' . addslashes(mysqli_error($db_link)) . '"}]';
+        mysqli_close($db_link);
+        exit();
+    }
 }
 
 // Backfill only when the current item revision still has its exact journal row. Older

--- a/tests/Unit/Api/ApiItemIdempotencyTest.php
+++ b/tests/Unit/Api/ApiItemIdempotencyTest.php
@@ -194,7 +194,10 @@ class ApiItemIdempotencyTest extends TestCase
         self::assertLessThan(strpos($create, '$this->insertNewItem('), strpos($create, 'DB::startTransaction();'));
         self::assertLessThan(strpos($create, 'DB::commit();'), strpos($create, 'completeReservation('));
         self::assertGreaterThan(strpos($create, 'DB::commit();'), strrpos($create, 'emitItemSyslog('));
-        self::assertStringNotContainsString('$e->getMessage()', $create);
+        $createLogStart = strrpos($create, 'error_log(');
+        $createLogEnd = strpos($create, ');', (int) $createLogStart);
+        $createLog = substr($create, (int) $createLogStart, (int) $createLogEnd - (int) $createLogStart);
+        self::assertStringNotContainsString('$e->getMessage()', $createLog);
 
         $deleteStart = strpos($model, 'public function deleteItem(');
         $delete = substr($model, (int) $deleteStart);
@@ -202,7 +205,10 @@ class ApiItemIdempotencyTest extends TestCase
         self::assertLessThan(strpos($delete, "'inactif' => '1'"), strpos($delete, '$expectedRevision !== null'));
         self::assertLessThan(strpos($delete, 'DB::commit();'), strpos($delete, 'completeReservation('));
         self::assertGreaterThan(strpos($delete, 'DB::commit();'), strrpos($delete, 'emitItemSyslog('));
-        self::assertStringNotContainsString('$e->getMessage()', $delete);
+        $deleteLogStart = strrpos($delete, 'error_log(');
+        $deleteLogEnd = strpos($delete, ');', (int) $deleteLogStart);
+        $deleteLog = substr($delete, (int) $deleteLogStart, (int) $deleteLogEnd - (int) $deleteLogStart);
+        self::assertStringNotContainsString('$e->getMessage()', $deleteLog);
     }
 
     public function testControllerKeepsKeysOptionalAndShortCircuitsCompletedReplays(): void

--- a/tests/Unit/Api/ApiItemIdempotencyTest.php
+++ b/tests/Unit/Api/ApiItemIdempotencyTest.php
@@ -1,0 +1,269 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../../app/api/Model/ApiIdempotencyModel.php';
+require_once __DIR__ . '/../../../app/api/Controller/Api/BaseController.php';
+require_once __DIR__ . '/../../../app/api/Controller/Api/ItemController.php';
+
+/**
+ * Behavioural and persistence-contract tests for idempotent item mutations.
+ */
+class ApiItemIdempotencyTest extends TestCase
+{
+    private ApiIdempotencyModel $model;
+
+    protected function setUp(): void
+    {
+        $this->model = new ApiIdempotencyModel('unit-test-idempotency-secret');
+    }
+
+    public function testKeyValidationAcceptsOpaqueVisibleAscii(): void
+    {
+        $key = '550e8400-e29b-41d4-a716-446655440000';
+
+        self::assertSame($key, ApiIdempotencyModel::validateKey($key));
+    }
+
+    /**
+     * @dataProvider invalidKeyProvider
+     */
+    public function testKeyValidationRejectsEmptyMalformedAndOversizedValues(string $key): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        ApiIdempotencyModel::validateKey($key);
+    }
+
+    /**
+     * @return array<string, array{string}>
+     */
+    public static function invalidKeyProvider(): array
+    {
+        return [
+            'empty' => [''],
+            'space' => ['not opaque'],
+            'control' => ["bad\nkey"],
+            'non-ascii' => ['clé'],
+            'too long' => [str_repeat('a', ApiIdempotencyModel::MAX_KEY_LENGTH + 1)],
+        ];
+    }
+
+    public function testFingerprintIgnoresObjectPropertyOrderButCoversSecrets(): void
+    {
+        $first = [
+            'label' => 'Database',
+            'password' => 'First-secret',
+            'fields' => [['id' => 4, 'value' => 'Sensitive field']],
+            'totp' => 'JBSWY3DPEHPK3PXP',
+        ];
+        $reordered = [
+            'totp' => 'JBSWY3DPEHPK3PXP',
+            'fields' => [['value' => 'Sensitive field', 'id' => 4]],
+            'password' => 'First-secret',
+            'label' => 'Database',
+        ];
+
+        $fingerprint = $this->model->fingerprint($first);
+        self::assertSame($fingerprint, $this->model->fingerprint($reordered));
+        self::assertNotSame($fingerprint, $this->model->fingerprint(array_replace($first, ['password' => 'Other-secret'])));
+        self::assertMatchesRegularExpression('/^[a-f0-9]{64}$/', $fingerprint);
+        self::assertStringNotContainsString('First-secret', $fingerprint);
+        self::assertStringNotContainsString('JBSWY3DPEHPK3PXP', $fingerprint);
+        self::assertNotSame(
+            $fingerprint,
+            (new ApiIdempotencyModel('another-server-secret'))->fingerprint($first)
+        );
+    }
+
+    public function testDeleteFingerprintCoversItemAndExpectedRevision(): void
+    {
+        $original = $this->model->fingerprint(['item_id' => 7, 'revision' => 12]);
+
+        self::assertNotSame($original, $this->model->fingerprint(['item_id' => 8, 'revision' => 12]));
+        self::assertNotSame($original, $this->model->fingerprint(['item_id' => 7, 'revision' => 13]));
+        self::assertNotSame($original, $this->model->fingerprint(['item_id' => 7, 'revision' => null]));
+    }
+
+    public function testExistingRecordStateMachineDistinguishesReplayConflictAndProcessing(): void
+    {
+        $fingerprint = $this->model->fingerprint(['item_id' => 7, 'revision' => 12]);
+        $now = 1_800_000_000;
+
+        self::assertSame(
+            ['state' => 'replay'],
+            $this->model->evaluateRecord([
+                'request_fingerprint' => $fingerprint,
+                'status' => 'completed',
+                'locked_until' => 0,
+            ], $fingerprint, $now)
+        );
+        self::assertSame(
+            ['state' => 'conflict'],
+            $this->model->evaluateRecord([
+                'request_fingerprint' => str_repeat('0', 64),
+                'status' => 'completed',
+                'locked_until' => 0,
+            ], $fingerprint, $now)
+        );
+        self::assertSame(
+            ['state' => 'processing', 'retry_after' => 20],
+            $this->model->evaluateRecord([
+                'request_fingerprint' => $fingerprint,
+                'status' => 'processing',
+                'locked_until' => $now + 20,
+            ], $fingerprint, $now)
+        );
+        self::assertSame(
+            ['state' => 'stale'],
+            $this->model->evaluateRecord([
+                'request_fingerprint' => $fingerprint,
+                'status' => 'processing',
+                'locked_until' => $now - 1,
+            ], $fingerprint, $now)
+        );
+    }
+
+    public function testDeleteRevisionParserAcceptsOmissionAndUnsignedRange(): void
+    {
+        $controller = new ItemController();
+        $method = new ReflectionMethod($controller, 'parseOptionalRevision');
+        $method->setAccessible(true);
+
+        self::assertNull($method->invoke($controller, ['id' => 1]));
+        self::assertSame(0, $method->invoke($controller, ['revision' => '0']));
+        self::assertSame(4294967295, $method->invoke($controller, ['revision' => '4294967295']));
+    }
+
+    /**
+     * @dataProvider invalidRevisionProvider
+     */
+    public function testDeleteRevisionParserRejectsMalformedValues($revision): void
+    {
+        $controller = new ItemController();
+        $method = new ReflectionMethod($controller, 'parseOptionalRevision');
+        $method->setAccessible(true);
+
+        $this->expectException(InvalidArgumentException::class);
+        $method->invoke($controller, ['revision' => $revision]);
+    }
+
+    /**
+     * @return array<string, array{mixed}>
+     */
+    public static function invalidRevisionProvider(): array
+    {
+        return [
+            'empty' => [''],
+            'negative' => ['-1'],
+            'decimal' => ['1.5'],
+            'scientific' => ['1e2'],
+            'overflow' => ['4294967296'],
+            'float' => [1.0],
+        ];
+    }
+
+    public function testSchemaScopesKeysPerUserAndOperationWithoutSecretColumns(): void
+    {
+        $install = (string) file_get_contents(__DIR__ . '/../../../public/install/install-steps/run.step5.php');
+        $upgrade = (string) file_get_contents(__DIR__ . '/../../../public/install/upgrade_run_3.2.2.php');
+
+        foreach ([$install, $upgrade] as $schema) {
+            $tableStart = strpos($schema, 'api_idempotency` (');
+            self::assertNotFalse($tableStart);
+            $tableDefinition = substr($schema, (int) $tableStart, 1800);
+
+            self::assertStringContainsString('api_idempotency', $schema);
+            self::assertStringContainsString('`user_id`, `operation`, `key_hash`', $schema);
+            self::assertStringContainsString('`request_fingerprint` CHAR(64)', $schema);
+            self::assertStringNotContainsString('`raw_key`', $tableDefinition);
+            self::assertStringNotContainsString('`request_body`', $tableDefinition);
+            self::assertStringNotContainsString('`password`', $tableDefinition);
+            self::assertStringNotContainsString('`totp_secret`', $tableDefinition);
+        }
+    }
+
+    public function testCreateAndDeleteFinalizeReplayMetadataInsideTheirMutationTransactions(): void
+    {
+        $model = (string) file_get_contents(__DIR__ . '/../../../app/api/Model/ItemModel.php');
+
+        $createStart = strpos($model, 'public function addItem(');
+        $createEnd = strpos($model, 'private function getFaviconUrl', (int) $createStart);
+        $create = substr($model, (int) $createStart, (int) $createEnd - (int) $createStart);
+        self::assertLessThan(strpos($create, '$this->insertNewItem('), strpos($create, 'DB::startTransaction();'));
+        self::assertLessThan(strpos($create, 'DB::commit();'), strpos($create, 'completeReservation('));
+        self::assertGreaterThan(strpos($create, 'DB::commit();'), strrpos($create, 'emitItemSyslog('));
+        self::assertStringNotContainsString('$e->getMessage()', $create);
+
+        $deleteStart = strpos($model, 'public function deleteItem(');
+        $delete = substr($model, (int) $deleteStart);
+        self::assertLessThan(strpos($delete, "'inactif' => '1'"), strpos($delete, 'FOR UPDATE'));
+        self::assertLessThan(strpos($delete, "'inactif' => '1'"), strpos($delete, '$expectedRevision !== null'));
+        self::assertLessThan(strpos($delete, 'DB::commit();'), strpos($delete, 'completeReservation('));
+        self::assertGreaterThan(strpos($delete, 'DB::commit();'), strrpos($delete, 'emitItemSyslog('));
+        self::assertStringNotContainsString('$e->getMessage()', $delete);
+    }
+
+    public function testControllerKeepsKeysOptionalAndShortCircuitsCompletedReplays(): void
+    {
+        $controller = (string) file_get_contents(
+            __DIR__ . '/../../../app/api/Controller/Api/ItemController.php'
+        );
+
+        $createStart = strpos($controller, 'public function createAction(');
+        $createEnd = strpos($controller, 'public function getAction(', (int) $createStart);
+        $create = substr($controller, (int) $createStart, (int) $createEnd - (int) $createStart);
+        self::assertStringContainsString('$idempotencyModel = null;', $create);
+        self::assertLessThan(strpos($create, '->reserve('), strpos($create, 'checkNewItemData('));
+        self::assertLessThan(strpos($create, '$itemModel->addItem('), strpos($create, "['state'] === 'replay'"));
+        self::assertStringContainsString('Idempotency-Replayed: true', $create);
+        self::assertStringContainsString('releaseReservation(', $create);
+
+        $deleteStart = strpos($controller, 'public function deleteAction(');
+        $delete = substr($controller, (int) $deleteStart);
+        self::assertStringContainsString('$idempotencyModel = null;', $delete);
+        self::assertLessThan(strpos($delete, '->reserve('), strpos($delete, 'canDeleteInFolder('));
+        self::assertLessThan(strpos($delete, '$itemModel->deleteItem('), strpos($delete, "['state'] === 'replay'"));
+        self::assertStringContainsString('Idempotency-Replayed: true', $delete);
+        self::assertStringContainsString('releaseReservation(', $delete);
+    }
+
+    public function testMaintenanceKeepsActiveProcessingLeases(): void
+    {
+        $maintenance = (string) file_get_contents(__DIR__ . '/../../../app/sources/main.functions.php');
+        $start = strpos($maintenance, 'function pruneApiIdempotencyRecords()');
+        self::assertNotFalse($start);
+        $block = substr($maintenance, (int) $start, 2200);
+
+        self::assertStringContainsString('expires_at < %i', $block);
+        self::assertStringContainsString('locked_until < %i', $block);
+        self::assertStringNotContainsString('locked_until > %i', $block);
+    }
+
+    public function testOpenApiDocumentsCreateAndDeleteIdempotencyAndDeleteRevision(): void
+    {
+        $spec = json_decode(
+            (string) file_get_contents(__DIR__ . '/../../../app/api/openapi.json'),
+            true,
+            512,
+            JSON_THROW_ON_ERROR
+        );
+
+        self::assertSame(
+            '#/components/parameters/IdempotencyKey',
+            $spec['paths']['/item/create']['post']['parameters'][0]['$ref']
+        );
+        self::assertSame(
+            '#/components/parameters/IdempotencyKey',
+            $spec['paths']['/item/delete']['delete']['parameters'][0]['$ref']
+        );
+        self::assertSame('revision', $spec['paths']['/item/delete']['delete']['parameters'][2]['name']);
+        self::assertArrayHasKey('409', $spec['paths']['/item/create']['post']['responses']);
+        self::assertArrayHasKey('409', $spec['paths']['/item/delete']['delete']['responses']);
+        self::assertArrayHasKey(
+            'revision_changed_at',
+            $spec['paths']['/item/delete']['delete']['responses']['200']['content']['application/json']['schema']['properties']
+        );
+    }
+}

--- a/tests/Unit/Api/ApiItemIdempotencyTest.php
+++ b/tests/Unit/Api/ApiItemIdempotencyTest.php
@@ -86,45 +86,6 @@ class ApiItemIdempotencyTest extends TestCase
         self::assertNotSame($original, $this->model->fingerprint(['item_id' => 7, 'revision' => null]));
     }
 
-    public function testExistingRecordStateMachineDistinguishesReplayConflictAndProcessing(): void
-    {
-        $fingerprint = $this->model->fingerprint(['item_id' => 7, 'revision' => 12]);
-        $now = 1_800_000_000;
-
-        self::assertSame(
-            ['state' => 'replay'],
-            $this->model->evaluateRecord([
-                'request_fingerprint' => $fingerprint,
-                'status' => 'completed',
-                'locked_until' => 0,
-            ], $fingerprint, $now)
-        );
-        self::assertSame(
-            ['state' => 'conflict'],
-            $this->model->evaluateRecord([
-                'request_fingerprint' => str_repeat('0', 64),
-                'status' => 'completed',
-                'locked_until' => 0,
-            ], $fingerprint, $now)
-        );
-        self::assertSame(
-            ['state' => 'processing', 'retry_after' => 20],
-            $this->model->evaluateRecord([
-                'request_fingerprint' => $fingerprint,
-                'status' => 'processing',
-                'locked_until' => $now + 20,
-            ], $fingerprint, $now)
-        );
-        self::assertSame(
-            ['state' => 'stale'],
-            $this->model->evaluateRecord([
-                'request_fingerprint' => $fingerprint,
-                'status' => 'processing',
-                'locked_until' => $now - 1,
-            ], $fingerprint, $now)
-        );
-    }
-
     public function testDeleteRevisionParserAcceptsOmissionAndUnsignedRange(): void
     {
         $controller = new ItemController();
@@ -132,6 +93,7 @@ class ApiItemIdempotencyTest extends TestCase
         $method->setAccessible(true);
 
         self::assertNull($method->invoke($controller, ['id' => 1]));
+        self::assertNull($method->invoke($controller, ['revision' => '']));
         self::assertSame(0, $method->invoke($controller, ['revision' => '0']));
         self::assertSame(4294967295, $method->invoke($controller, ['revision' => '4294967295']));
     }
@@ -155,7 +117,6 @@ class ApiItemIdempotencyTest extends TestCase
     public static function invalidRevisionProvider(): array
     {
         return [
-            'empty' => [''],
             'negative' => ['-1'],
             'decimal' => ['1.5'],
             'scientific' => ['1e2'],
@@ -182,6 +143,18 @@ class ApiItemIdempotencyTest extends TestCase
             self::assertStringNotContainsString('`password`', $tableDefinition);
             self::assertStringNotContainsString('`totp_secret`', $tableDefinition);
         }
+
+        $upgradeSchemaStart = strpos($upgrade, '$idempotencyColumnExists =');
+        self::assertNotFalse($upgradeSchemaStart);
+        $upgradeSchema = substr($upgrade, (int) $upgradeSchemaStart, 2400);
+        $columnAlter = strpos($upgradeSchema, 'ADD `api_idempotency_id` BIGINT UNSIGNED NULL DEFAULT NULL');
+        $combinedIndex = strpos($upgradeSchema, '. $indexDefinition', (int) $columnAlter);
+        self::assertNotFalse($columnAlter);
+        self::assertNotFalse($combinedIndex);
+        self::assertStringContainsString(
+            ', ADD UNIQUE KEY `uq_items_api_idempotency` (`api_idempotency_id`)',
+            $upgradeSchema
+        );
     }
 
     public function testCreateAndDeleteFinalizeReplayMetadataInsideTheirMutationTransactions(): void
@@ -193,11 +166,15 @@ class ApiItemIdempotencyTest extends TestCase
         $create = substr($model, (int) $createStart, (int) $createEnd - (int) $createStart);
         self::assertLessThan(strpos($create, '$this->insertNewItem('), strpos($create, 'DB::startTransaction();'));
         self::assertLessThan(strpos($create, 'DB::commit();'), strpos($create, 'completeReservation('));
+        self::assertGreaterThan(strpos($create, 'DB::commit();'), strpos($create, "storeTask('new_item'"));
+        self::assertGreaterThan(strpos($create, 'DB::commit();'), strpos($create, 'refreshItemHealthAfterSave('));
         self::assertGreaterThan(strpos($create, 'DB::commit();'), strrpos($create, 'emitItemSyslog('));
         $createLogStart = strrpos($create, 'error_log(');
         $createLogEnd = strpos($create, ');', (int) $createLogStart);
         $createLog = substr($create, (int) $createLogStart, (int) $createLogEnd - (int) $createLogStart);
-        self::assertStringNotContainsString('$e->getMessage()', $createLog);
+        self::assertStringContainsString('$e->getMessage()', $createLog);
+        self::assertStringContainsString('$e->getFile()', $createLog);
+        self::assertStringContainsString('$e->getLine()', $createLog);
 
         $deleteStart = strpos($model, 'public function deleteItem(');
         $delete = substr($model, (int) $deleteStart);
@@ -208,7 +185,9 @@ class ApiItemIdempotencyTest extends TestCase
         $deleteLogStart = strrpos($delete, 'error_log(');
         $deleteLogEnd = strpos($delete, ');', (int) $deleteLogStart);
         $deleteLog = substr($delete, (int) $deleteLogStart, (int) $deleteLogEnd - (int) $deleteLogStart);
-        self::assertStringNotContainsString('$e->getMessage()', $deleteLog);
+        self::assertStringContainsString('$e->getMessage()', $deleteLog);
+        self::assertStringContainsString('$e->getFile()', $deleteLog);
+        self::assertStringContainsString('$e->getLine()', $deleteLog);
     }
 
     public function testControllerKeepsKeysOptionalAndShortCircuitsCompletedReplays(): void
@@ -240,11 +219,18 @@ class ApiItemIdempotencyTest extends TestCase
         $maintenance = (string) file_get_contents(__DIR__ . '/../../../app/sources/main.functions.php');
         $start = strpos($maintenance, 'function pruneApiIdempotencyRecords()');
         self::assertNotFalse($start);
-        $block = substr($maintenance, (int) $start, 2200);
+        $block = substr($maintenance, (int) $start, 3200);
 
+        self::assertStringContainsString('expires_at > 0', $block);
         self::assertStringContainsString('expires_at < %i', $block);
         self::assertStringContainsString('locked_until < %i', $block);
         self::assertStringNotContainsString('locked_until > %i', $block);
+        $reservationLock = strpos($block, "FROM ' . prefixTable('api_idempotency')");
+        $itemUpdate = strpos($block, "prefixTable('items'),");
+        self::assertNotFalse($reservationLock);
+        self::assertNotFalse($itemUpdate);
+        self::assertStringContainsString('FOR UPDATE', $block);
+        self::assertLessThan($itemUpdate, $reservationLock);
     }
 
     public function testOpenApiDocumentsCreateAndDeleteIdempotencyAndDeleteRevision(): void
@@ -265,6 +251,7 @@ class ApiItemIdempotencyTest extends TestCase
             $spec['paths']['/item/delete']['delete']['parameters'][0]['$ref']
         );
         self::assertSame('revision', $spec['paths']['/item/delete']['delete']['parameters'][2]['name']);
+        self::assertTrue($spec['paths']['/item/delete']['delete']['parameters'][2]['allowEmptyValue']);
         self::assertArrayHasKey('409', $spec['paths']['/item/create']['post']['responses']);
         self::assertArrayHasKey('409', $spec['paths']['/item/delete']['delete']['responses']);
         self::assertArrayHasKey(

--- a/tests/Unit/ApiIdempotencyLogicTest.php
+++ b/tests/Unit/ApiIdempotencyLogicTest.php
@@ -1,0 +1,143 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../app/sources/api_idempotency_logic.php';
+
+/**
+ * Behavioural tests for the DB-free API idempotency state machine.
+ */
+class ApiIdempotencyLogicTest extends TestCase
+{
+    public function testCanonicalizationSortsObjectsAndPreservesListOrder(): void
+    {
+        self::assertSame(
+            [
+                'a' => ['x' => 1, 'y' => 2],
+                'z' => [['b' => 2, 'c' => 3], ['a' => 1]],
+            ],
+            apiIdempotencyCanonicalize([
+                'z' => [['c' => 3, 'b' => 2], ['a' => 1]],
+                'a' => ['y' => 2, 'x' => 1],
+            ])
+        );
+    }
+
+    public function testNewReservationReturnsAnAcquiredDecision(): void
+    {
+        self::assertSame(
+            [
+                'state' => 'acquired',
+                'id' => 42,
+                'owner_token' => 'owner-token',
+                'request_fingerprint' => 'request-fingerprint',
+            ],
+            apiIdempotencyAcquiredDecision(42, 'owner-token', 'request-fingerprint')
+        );
+    }
+
+    public function testCompletedRecordReturnsItsReplaySafeResponse(): void
+    {
+        self::assertSame(
+            [
+                'state' => 'replay',
+                'resource_id' => 73,
+                'http_status' => 201,
+                'response' => ['error' => false, 'newId' => 73],
+            ],
+            apiIdempotencyExistingRecordDecision(
+                [
+                    'request_fingerprint' => 'same-request',
+                    'status' => 'completed',
+                    'resource_id' => 73,
+                    'http_status' => 201,
+                    'response_body' => '{"error":false,"newId":73}',
+                    'locked_until' => 0,
+                ],
+                'same-request',
+                1_800_000_000
+            )
+        );
+    }
+
+    public function testExistingRecordRejectsAnotherFunctionalIntent(): void
+    {
+        self::assertSame(
+            ['state' => 'conflict'],
+            apiIdempotencyExistingRecordDecision(
+                [
+                    'request_fingerprint' => 'first-request',
+                    'status' => 'completed',
+                    'response_body' => '{}',
+                ],
+                'different-request',
+                1_800_000_000
+            )
+        );
+    }
+
+    public function testLiveLeaseReturnsTheRemainingRetryDelay(): void
+    {
+        self::assertSame(
+            ['state' => 'processing', 'retry_after' => 20],
+            apiIdempotencyExistingRecordDecision(
+                [
+                    'request_fingerprint' => 'same-request',
+                    'status' => 'processing',
+                    'locked_until' => 1_800_000_020,
+                ],
+                'same-request',
+                1_800_000_000
+            )
+        );
+    }
+
+    public function testExpiredLeaseRequestsAnAtomicTakeover(): void
+    {
+        self::assertSame(
+            ['state' => 'stale'],
+            apiIdempotencyExistingRecordDecision(
+                [
+                    'request_fingerprint' => 'same-request',
+                    'status' => 'processing',
+                    'locked_until' => 1_799_999_999,
+                ],
+                'same-request',
+                1_800_000_000
+            )
+        );
+    }
+
+    public function testLeaseTakeoverOnlySucceedsForOneChangedRow(): void
+    {
+        self::assertSame(
+            [
+                'state' => 'acquired',
+                'id' => 42,
+                'owner_token' => 'new-owner',
+                'request_fingerprint' => 'same-request',
+            ],
+            apiIdempotencyLeaseTakeoverDecision(1, 42, 'new-owner', 'same-request')
+        );
+        self::assertNull(apiIdempotencyLeaseTakeoverDecision(0, 42, 'new-owner', 'same-request'));
+        self::assertNull(apiIdempotencyLeaseTakeoverDecision(2, 42, 'new-owner', 'same-request'));
+    }
+
+    public function testReplayExpiryUsesTheConfiguredOfflineSyncWindow(): void
+    {
+        $now = 1_800_000_000;
+
+        self::assertSame($now + (90 * 86400), apiIdempotencyReplayExpiry($now, null));
+        self::assertSame($now + (7 * 86400), apiIdempotencyReplayExpiry($now, '7'));
+        self::assertSame(0, apiIdempotencyReplayExpiry($now, 0));
+        self::assertSame(PHP_INT_MAX, apiIdempotencyReplayExpiry($now, PHP_INT_MAX));
+    }
+
+    public function testMalformedStoredReplayIsRejected(): void
+    {
+        $this->expectException(RuntimeException::class);
+        apiIdempotencyReplayDecision(['response_body' => '{invalid']);
+    }
+}


### PR DESCRIPTION
## Context

This is the second, deliberately isolated follow-up from #5343. The first part (API password history and durable revision timestamps) was integrated through #5348.

This PR adds the remaining "idempotent create/delete and conditional delete" scope for future bidirectional offline synchronization. It does not change mobile or browser-extension code.

## API contract

- `POST /item/create` accepts an optional `Idempotency-Key` containing 1-128 visible ASCII characters without spaces.
- The first keyed create keeps the normal `201`, `Location`, `newId`, `revision` and `revision_changed_at` response.
- Replaying the same user/key/canonical intent returns the stored response with `Idempotency-Replayed: true`, without repeating database writes or side effects.
- Reusing a key with a different intent returns `409`; an identical request with an active processing lease returns `409` and `Retry-After`.
- `DELETE /item/delete` accepts an optional unsigned `revision` precondition. A stale revision returns `409` before mutation; omitting it preserves the existing last-writer-wins behavior.
- Successful deletes return the exact deletion `revision` and `revision_changed_at` pair exposed by `GET /item/changes`.
- Delete supports the same optional idempotency header. Replaying a completed delete never performs the deletion again, including after a later restore.

Requests without `Idempotency-Key`, and deletes without `revision`, remain backward compatible.

## Persistence and security

- Adds the prefixed `api_idempotency` table, scoped by the unique tuple `(user_id, operation, key_hash)`.
- Adds nullable unique `items.api_idempotency_id` so a stale create reservation can recover an already committed item without repeating its side effects.
- Raw keys, request bodies, passwords, TOTP secrets and custom-field values are never persisted in idempotency metadata.
- Key hashes and canonical request fingerprints use HMAC-SHA-256 with a domain-separated key derived from the TeamPass instance secret.
- Create fingerprints cover every functional field, recursively sort associative keys and preserve list order.
- Completed records have a 90-day replay window. Maintenance clears expired links and records without deleting an active processing lease.

## Atomicity and crash behavior

- A five-minute processing lease is acquired before mutation.
- Validation and favicon/DNS work complete before the functional create transaction.
- Item, sharekey, TOTP, tag, custom-field, audit/revision, cache/health/task, queued WebSocket and idempotency-completion rows commit together.
- Audit/revision handling is strict for these transactional create/delete paths, and the returned revision pair is verified before commit.
- Delete locks the item row and evaluates the optional revision immediately before mutation.
- External UDP syslog emission occurs only after commit and is never repeated by a replay.
- A lost HTTP response can be replayed. An uncommitted crashed request rolls back, and its expired lease can be taken over.

The remaining external-effect limitation is explicit: a process crash immediately after SQL commit but before the UDP call can omit that syslog datagram. The durable TeamPass audit row is still committed.

## Install, upgrade and documentation

- Fresh-install schema and `public/install/upgrade_run_3.2.2.php` both include the new nullable item link, table and indexes.
- The upgrade remains idempotent.
- CORS, OpenAPI 3.1, the basic API guide, API reference and architecture documentation are updated.
- `ApiItemIdempotencyTest` covers key validation, canonical fingerprints, replay/conflict/lease decisions, delete revision parsing, schema security, transaction ordering, cleanup safety and OpenAPI contracts.

## Local validation

Completed successfully:

- verified that all 22 supplied PR5343 files match the original PR head;
- isolated the final three part-2 commits and confirmed them with `git range-diff`;
- parsed `app/api/openapi.json`;
- ran structural assertions over replay short-circuits, transaction ordering, row locking, revision checks, post-commit syslog and install/upgrade schemas;
- ran an equivalent of the table-prefix guard over all 81 known table names;
- verified the committed Composer autoloader remains production-only;
- ran `git diff --check` and checked for conflict markers and forbidden debug calls.

Not executed locally because this Windows workspace has no PHP CLI, Docker runtime, WSL installation or disposable TeamPass database:

- PHP syntax checks;
- PHPUnit;
- PHPStan;
- fresh-install/upgrade and runtime role/folder matrices.

The GitHub Quality and CodeQL workflows are expected to provide the PHP 8.2/8.3, PHPStan level 4 and security validation.

## Checklist

- [x] Every new public function has a docblock
- [x] Variable names and comments are in English
- [x] No `var_dump()` or `console.log()` introduced
- [x] No hard-coded TeamPass table prefix introduced
- [x] Fresh-install and upgrade paths are both updated
- [x] No `teampassclasses` dual-location class is changed
- [x] `app/vendor/composer/` remains in production form
- [x] PHPUnit passes on PHP 8.2 and 8.3 (CI)
- [x] PHPStan level 4 passes (CI)
- [ ] Database-backed install/upgrade scenarios are exercised

## Screenshots

Not applicable. This PR changes API, database-schema and backend behavior without changing the web UI.