### PR TITLE
Fix command palette item search

### DIFF
--- a/app/sources/palette.queries.php
+++ b/app/sources/palette.queries.php
@@ -165,7 +165,7 @@ switch ($post_type) {
                 $restrictionSql = searchItemRestrictionSql(
                     (int) $session->get('user-id'),
                     $userRoleIds,
-                    'c',
+                    'i',
                     prefixTable('restriction_to_roles')
                 );
 

--- a/tests/Unit/SearchFolderScopeTest.php
+++ b/tests/Unit/SearchFolderScopeTest.php
@@ -123,6 +123,20 @@ class SearchFolderScopeTest extends TestCase
         $this->assertStringContainsString('c.perso = 0 OR CAST(c.author AS UNSIGNED)', $source);
     }
 
+    public function testPaletteBuildsItemRestrictionFromTheCanonicalItemsRow(): void
+    {
+        // Empty item restrictions are normalized to "0" in the search cache,
+        // while the items table retains the canonical empty value expected by
+        // searchItemRestrictionSql(). The palette already joins it as alias i.
+        $source = file_get_contents(__DIR__ . '/../../app/sources/palette.queries.php');
+
+        $this->assertIsString($source);
+        $this->assertMatchesRegularExpression(
+            '/searchItemRestrictionSql\(\s*\(int\) \$session->get\(\'user-id\'\),\s*\$userRoleIds,\s*\'i\',/s',
+            $source
+        );
+    }
+
     public function testLegacyPersonalFolderDepthHeuristicIsNotUsed(): void
     {
         foreach (['find.queries.php', 'palette.queries.php'] as $handler) {


### PR DESCRIPTION
## Description

Fix the command palette item search regression introduced by the item-level ACL filter.

The palette passed the search-cache alias to `searchItemRestrictionSql()`. The cache normalizes an empty `restricted_to` value to `'0'`, while the ACL helper expects the canonical `NULL` or empty value stored in the `items` table. As a result, ordinary unrestricted personal and shared items were filtered out.

Use the already joined `items` alias for the ACL predicate and add a regression test that locks this invariant.

## Related issue

Follow-up regression found after #5355.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (existing behaviour changes)
- [ ] Documentation
- [ ] Translation
- [ ] Refactor / maintenance

## How has this been tested?

- `git diff --check upstream/develop...HEAD`
- Static review of the generated ACL predicate and the cache/item `restricted_to` representations
- Added a PHPUnit regression test ensuring the palette builds the restriction predicate from the canonical `items` row
- PHPUnit and PHPStan could not be run locally because no PHP runtime or container runtime is available; both are delegated to CI
- Manual verification recommended with unrestricted shared and personal items, plus allowed/denied user and role restrictions

## Checklist

- [x] PHPStan level 4 passes (`php app/vendor/bin/phpstan analyse --memory-limit=2G`) — CI passed
- [x] The test suite passes (`php _tools/phpunit.phar` — see CONTRIBUTING.md for the one-time setup) — CI passed on PHP 8.2 and PHP 8.3
- [x] Every new public function has a docblock (no public function added)
- [x] Variable names and comments are in English
- [x] No `var_dump()` or `console.log()` left in the code
- [x] New `app/sources/*.queries.php` files have a matching `public/sources/` proxy shim (no new handler)
- [x] Changes to `teampassclasses` were applied to **both** copies (no class change)
- [x] `app/vendor/composer/` is in its production form (unchanged)

## Impact on install / upgrade

- [x] No schema change
- [ ] Schema change — an `install/upgrade_run_X.X.X.php` script is included and the fresh install path was tested

## Screenshots

Not applicable: no UI change.