### PR TITLE
Fix scheduled backup admin notice

### DIFF
--- a/app/sources/admin_notices.functions.php
+++ b/app/sources/admin_notices.functions.php
@@ -244,7 +244,15 @@ function adminNoticesCollectChecklist(array $SETTINGS, Language $lang): array
     $notices = [];
 
     // No scheduled backup means no recovery path after an incident.
-    if ((int) ($SETTINGS['bck_scheduled_enabled'] ?? 0) !== 1) {
+    // Backup settings use their own misc namespace and are not loaded by ConfigManager.
+    $scheduledBackupEnabled = DB::queryFirstField(
+        'SELECT valeur FROM ' . prefixTable('misc') . '
+        WHERE type = %s AND intitule = %s
+        LIMIT 1',
+        'settings',
+        'bck_scheduled_enabled'
+    );
+    if ((int) $scheduledBackupEnabled !== 1) {
         $notices[] = adminNoticeBuild([
             'id' => 'checklist_backup',
             'severity' => 'info',

--- a/tests/Unit/AdminNoticesConfigurationTest.php
+++ b/tests/Unit/AdminNoticesConfigurationTest.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Static integration guards for the admin dashboard configuration sources.
+ */
+class AdminNoticesConfigurationTest extends TestCase
+{
+    public function testScheduledBackupNoticeReadsTheOperationalSettingsNamespace(): void
+    {
+        $source = file_get_contents(__DIR__ . '/../../app/sources/admin_notices.functions.php');
+        self::assertIsString($source);
+
+        self::assertMatchesRegularExpression(
+            '/\$scheduledBackupEnabled\s*=\s*DB::queryFirstField\(.*?'
+                . "prefixTable\('misc'\).*?'settings'.*?'bck_scheduled_enabled'/s",
+            $source
+        );
+        self::assertStringNotContainsString("\$SETTINGS['bck_scheduled_enabled']", $source);
+    }
+}


### PR DESCRIPTION
## Description

The admin dashboard read `bck_scheduled_enabled` from the `ConfigManager` settings array. That array only contains `misc.type = admin`, while scheduled backup configuration is stored under `misc.type = settings`. As a result, an enabled local scheduled backup was always reported as missing.

Read the flag from its operational `settings` namespace using a parameterized MeekroDB query and the configured table prefix. Add a static integration guard to prevent the dashboard from falling back to the wrong configuration source.

## Related issue

None — reproduced on a TeamPass 3.2.2.3 lab.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (existing behaviour changes)
- [ ] Documentation
- [ ] Translation
- [ ] Refactor / maintenance

## How has this been tested?

- Manually verified as an administrator on a TeamPass 3.2.2.3 lab: an enabled scheduled backup no longer raises the false dashboard recommendation.
- Added `AdminNoticesConfigurationTest` to guard the `settings` namespace lookup, dynamic table prefix, and removal of the stale `$SETTINGS` lookup.
- `git diff --check` passes.
- PHPStan and PHPUnit could not be run on the Windows workstation because no PHP runtime is installed; GitHub CI passes PHPStan level 4 and PHPUnit on PHP 8.2 and 8.3.
- Manager, standard and read-only roles: not applicable; the affected page is administrator-only.
- Personal folders: not applicable.

## Checklist

- [x] PHPStan level 4 passes (`php app/vendor/bin/phpstan analyse --memory-limit=2G`)
- [x] The test suite passes (`php _tools/phpunit.phar` — see CONTRIBUTING.md for the one-time setup)
- [x] Every new public function has a docblock
- [x] Variable names and comments are in English
- [x] No `var_dump()` or `console.log()` left in the code
- [x] New `app/sources/*.queries.php` files have a matching `public/sources/` proxy shim
- [x] Changes to `teampassclasses` were applied to **both** copies (`app/includes/libraries/` and `app/vendor/`)
- [x] `app/vendor/composer/` is in its production form (`git checkout -- app/vendor/composer/`)

## Impact on install / upgrade

- [x] No schema change
- [ ] Schema change — an `install/upgrade_run_X.X.X.php` script is included and the fresh install path was tested

## Screenshots

No visual change. The existing recommendation now follows the persisted scheduled-backup setting.