### PR TITLE
Add dynamic user search to LDAP synchronization

### DIFF
--- a/app/pages/users.js.php
+++ b/app/pages/users.js.php
@@ -151,7 +151,7 @@ if ($checkUserAccess->checkSession() === false || $checkUserAccess->userAccessPa
         )
     }
 
-    $(document).on('input keyup search', '#ldap-users-search', filterLdapUsersTable)
+    $(document).on('input keyup', '#ldap-users-search', filterLdapUsersTable)
 
     $(document).on('click', '#ldap-users-search-clear', () => {
         $('#ldap-users-search').val('').trigger('input').focus()

--- a/app/pages/users.js.php
+++ b/app/pages/users.js.php
@@ -123,6 +123,40 @@ if ($checkUserAccess->checkSession() === false || $checkUserAccess->userAccessPa
         }
     }
 
+    /**
+     * Filter the LDAP synchronization table using the identity fields already loaded.
+     *
+     * @return void
+     */
+    function filterLdapUsersTable() {
+        const searchValue = ($('#ldap-users-search').val() || '').toString()
+        const criteria = searchValue.trim().toLowerCase()
+        const $rows = $('#row-ldap-body .ldap-user-row')
+        let visibleRows = 0
+
+        $rows.each((index, row) => {
+            const searchableIdentity = ($(row).attr('data-search') || '').toLowerCase()
+            const isVisible = criteria === '' || searchableIdentity.indexOf(criteria) !== -1
+
+            $(row).toggleClass('hidden', isVisible === false)
+            if (isVisible === true) {
+                visibleRows++
+            }
+        })
+
+        $('#ldap-users-search-clear').prop('disabled', searchValue === '')
+        $('#ldap-users-search-no-results').toggleClass(
+            'hidden',
+            criteria === '' || visibleRows > 0 || $rows.length === 0
+        )
+    }
+
+    $(document).on('input keyup search', '#ldap-users-search', filterLdapUsersTable)
+
+    $(document).on('click', '#ldap-users-search-clear', () => {
+        $('#ldap-users-search').val('').trigger('input').focus()
+    })
+
     //Launch the datatables pluggin
     var oTable = $('#table-users').DataTable({
         'paging': true,
@@ -3244,6 +3278,7 @@ function refreshListInactiveUsers(filterValue) {
         $('#row-ldap-body')
             .addClass('overlay')
             .html('');
+        $('#ldap-users-search-no-results').addClass('hidden')
 
         $.post(
             "sources/users.queries.php", {
@@ -3276,6 +3311,14 @@ function refreshListInactiveUsers(filterValue) {
                         userLogin = entry[store.get('teampassSettings').ldap_user_attribute] !== undefined ? entry[store.get('teampassSettings').ldap_user_attribute][0] : '';
                         // CHeck if not empty
                         if (userLogin !== '') {
+                            const searchText = [
+                                userLogin,
+                                entry.displayname !== undefined ? entry.displayname[0] : '',
+                                entry.givenname !== undefined ? entry.givenname[0] : '',
+                                entry.sn !== undefined ? entry.sn[0] : '',
+                                entry.mail !== undefined ? entry.mail[0] : ''
+                            ].join(' ')
+
                             // LDAP/AD account status indicators
                             var ldapStatusIcons = '';
                             if (entry.ldapAccountDisabled !== undefined && parseInt(entry.ldapAccountDisabled) === 1) {
@@ -3291,7 +3334,7 @@ function refreshListInactiveUsers(filterValue) {
                             }
                             // Directory-supplied values: purifyData() drops tags but keeps quotes,
                             // which alone breaks out of the attributes below. Encode each one.
-                            html += '<tr>' +
+                            html += '<tr class="ldap-user-row" data-search="' + htmlEncode(searchText) + '">' +
                                 '<td>' + htmlEncode(userLogin) +
                                 '</td>' +
                                 '<td class="text-center text-nowrap" style="min-width: 85px;">' +
@@ -3343,6 +3386,8 @@ function refreshListInactiveUsers(filterValue) {
                     });
 
                     $('#row-ldap-body').html(html);
+
+                    filterLdapUsersTable()
 
                     $('#row-ldap-body').removeClass('overlay');
 

--- a/app/pages/users.js.php
+++ b/app/pages/users.js.php
@@ -1941,6 +1941,7 @@ if ($checkUserAccess->checkSession() === false || $checkUserAccess->userAccessPa
             //
         } else if ($(this).data('action') === 'close-ldap-new-role') {
             $('#ldap-new-role').addClass('hidden');
+            $('#ldap-users-search-wrapper').removeClass('hidden')
             $('#ldap-users-table').removeClass('hidden');
 
             //
@@ -1953,6 +1954,7 @@ if ($checkUserAccess->checkSession() === false || $checkUserAccess->userAccessPa
             // --- END
             //
         } else if ($(this).data('action') === 'ldap-add-role') {
+            $('#ldap-users-search-wrapper').addClass('hidden')
             $('#ldap-users-table').addClass('hidden');
             $('#ldap-new-role').removeClass('hidden');
 
@@ -2014,6 +2016,7 @@ if ($checkUserAccess->checkSession() === false || $checkUserAccess->userAccessPa
                             );
                         } else {
                             $('#ldap-new-role-selection').val('');
+                            $('#ldap-users-search-wrapper').removeClass('hidden')
                             $('#ldap-users-table').removeClass('hidden');
                             $('#row-ldap-body').html('');
                             $('#ldap-new-role').addClass('hidden');

--- a/app/pages/users.js.php
+++ b/app/pages/users.js.php
@@ -151,7 +151,7 @@ if ($checkUserAccess->checkSession() === false || $checkUserAccess->userAccessPa
         )
     }
 
-    $(document).on('input keyup', '#ldap-users-search', filterLdapUsersTable)
+    $(document).on('input', '#ldap-users-search', filterLdapUsersTable)
 
     $(document).on('click', '#ldap-users-search-clear', () => {
         $('#ldap-users-search').val('').trigger('input').focus()
@@ -3319,7 +3319,8 @@ function refreshListInactiveUsers(filterValue) {
                                 entry.displayname !== undefined ? entry.displayname[0] : '',
                                 entry.givenname !== undefined ? entry.givenname[0] : '',
                                 entry.sn !== undefined ? entry.sn[0] : '',
-                                entry.mail !== undefined ? entry.mail[0] : ''
+                                entry.mail !== undefined ? entry.mail[0] : '',
+                                (entry.ldap_user_groups || []).join(' ')
                             ].join(' ')
 
                             // LDAP/AD account status indicators

--- a/app/pages/users.php
+++ b/app/pages/users.php
@@ -363,6 +363,23 @@ $emailNotConfigured = $canAccessInactiveAndDeletedUsers === true
                                 </div>
                             </div>
                             <div class="card-body table-responsive p-0" id="ldap-users-table">
+                                <div class="row mx-0 mb-3">
+                                    <div class="col-12 col-lg-6 px-0">
+                                        <div class="input-group input-group-sm">
+                                            <div class="input-group-prepend">
+                                                <div class="input-group-text">
+                                                    <i class="fas fa-search" aria-hidden="true"></i>
+                                                </div>
+                                            </div>
+                                            <input type="search" class="form-control" placeholder="<?php echo $lang->get('find'); ?>" aria-label="<?php echo $lang->get('find'); ?>" id="ldap-users-search">
+                                            <div class="input-group-append">
+                                                <button type="button" class="btn btn-default" title="<?php echo $lang->get('reset'); ?>" aria-label="<?php echo $lang->get('reset'); ?>" id="ldap-users-search-clear" disabled>
+                                                    <i class="fas fa-times" aria-hidden="true"></i>
+                                                </button>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
                                 <table class="table table-hover table-responsive">
                                     <thead>
                                         <tr>
@@ -376,6 +393,9 @@ $emailNotConfigured = $canAccessInactiveAndDeletedUsers === true
                                     <tbody id="row-ldap-body">
                                     </tbody>
                                 </table>
+                                <div class="mt-2 hidden" id="ldap-users-search-no-results" role="status">
+                                    <i class="fas fa-info mr-2 text-warning" aria-hidden="true"></i><?php echo $lang->get('no_item_to_display'); ?>
+                                </div>
                             </div>
                         </div>
                     </div>

--- a/app/pages/users.php
+++ b/app/pages/users.php
@@ -330,7 +330,7 @@ $emailNotConfigured = $canAccessInactiveAndDeletedUsers === true
                                     <i class="fas fa-search" aria-hidden="true"></i>
                                 </div>
                             </div>
-                            <input type="search" class="form-control" placeholder="<?php echo $lang->get('find'); ?>" aria-label="<?php echo $lang->get('find'); ?>" id="ldap-users-search">
+                            <input type="text" role="searchbox" class="form-control" placeholder="<?php echo $lang->get('find'); ?>" aria-label="<?php echo $lang->get('find'); ?>" id="ldap-users-search">
                             <div class="input-group-append">
                                 <button type="button" class="btn btn-default" title="<?php echo $lang->get('reset'); ?>" aria-label="<?php echo $lang->get('reset'); ?>" id="ldap-users-search-clear" disabled>
                                     <i class="fas fa-times" aria-hidden="true"></i>

--- a/app/pages/users.php
+++ b/app/pages/users.php
@@ -323,11 +323,24 @@ $emailNotConfigured = $canAccessInactiveAndDeletedUsers === true
                 <!-- /.card-header -->
                 <!-- table start -->
                 <div class="card-body">
-                    <div class="row col-12">
-                        <button type="button" class="btn btn-secondary btn-sm tp-action mr-2" data-action="ldap-existing-users">
-                            <i class="fa-solid fa-sync-alt mr-2"></i><?php echo $lang->get('list_users'); ?>
+                    <div class="d-flex flex-wrap align-items-center mb-3" id="ldap-users-toolbar">
+                        <div class="input-group input-group-sm mr-2 mb-2" style="width: 260px; max-width: 100%;" id="ldap-users-search-wrapper">
+                            <div class="input-group-prepend">
+                                <div class="input-group-text">
+                                    <i class="fas fa-search" aria-hidden="true"></i>
+                                </div>
+                            </div>
+                            <input type="search" class="form-control" placeholder="<?php echo $lang->get('find'); ?>" aria-label="<?php echo $lang->get('find'); ?>" id="ldap-users-search">
+                            <div class="input-group-append">
+                                <button type="button" class="btn btn-default" title="<?php echo $lang->get('reset'); ?>" aria-label="<?php echo $lang->get('reset'); ?>" id="ldap-users-search-clear" disabled>
+                                    <i class="fas fa-times" aria-hidden="true"></i>
+                                </button>
+                            </div>
+                        </div>
+                        <button type="button" class="btn btn-secondary btn-sm tp-action mr-2 mb-2" data-action="ldap-existing-users">
+                            <i class="fa-solid fa-sync-alt mr-2"></i><?php echo $lang->get('refresh'); ?>
                         </button>
-                        <button type="button" class="btn btn-secondary btn-sm tp-action mr-2" data-action="ldap-add-role">
+                        <button type="button" class="btn btn-secondary btn-sm tp-action mr-2 mb-2" data-action="ldap-add-role">
                             <i class="fa-solid fa-graduation-cap mr-2"></i><?php echo $lang->get('add_role_tip'); ?>
                         </button>
                     </div>
@@ -363,23 +376,6 @@ $emailNotConfigured = $canAccessInactiveAndDeletedUsers === true
                                 </div>
                             </div>
                             <div class="card-body table-responsive p-0" id="ldap-users-table">
-                                <div class="row mx-0 mb-3">
-                                    <div class="col-12 col-lg-6 px-0">
-                                        <div class="input-group input-group-sm">
-                                            <div class="input-group-prepend">
-                                                <div class="input-group-text">
-                                                    <i class="fas fa-search" aria-hidden="true"></i>
-                                                </div>
-                                            </div>
-                                            <input type="search" class="form-control" placeholder="<?php echo $lang->get('find'); ?>" aria-label="<?php echo $lang->get('find'); ?>" id="ldap-users-search">
-                                            <div class="input-group-append">
-                                                <button type="button" class="btn btn-default" title="<?php echo $lang->get('reset'); ?>" aria-label="<?php echo $lang->get('reset'); ?>" id="ldap-users-search-clear" disabled>
-                                                    <i class="fas fa-times" aria-hidden="true"></i>
-                                                </button>
-                                            </div>
-                                        </div>
-                                    </div>
-                                </div>
                                 <table class="table table-hover table-responsive">
                                     <thead>
                                         <tr>

--- a/app/pages/users.php
+++ b/app/pages/users.php
@@ -324,21 +324,21 @@ $emailNotConfigured = $canAccessInactiveAndDeletedUsers === true
                 <!-- table start -->
                 <div class="card-body">
                     <div class="d-flex flex-wrap align-items-center mb-3" id="ldap-users-toolbar">
-                        <div class="input-group input-group-sm mr-2 mb-2" style="width: 260px; max-width: 100%;" id="ldap-users-search-wrapper">
+                        <div class="input-group input-group-sm mr-2 mb-2" id="ldap-users-search-wrapper">
                             <div class="input-group-prepend">
                                 <div class="input-group-text">
-                                    <i class="fas fa-search" aria-hidden="true"></i>
+                                    <i class="fa-solid fa-magnifying-glass" aria-hidden="true"></i>
                                 </div>
                             </div>
                             <input type="text" role="searchbox" class="form-control" placeholder="<?php echo $lang->get('find'); ?>" aria-label="<?php echo $lang->get('find'); ?>" id="ldap-users-search">
                             <div class="input-group-append">
                                 <button type="button" class="btn btn-default" title="<?php echo $lang->get('reset'); ?>" aria-label="<?php echo $lang->get('reset'); ?>" id="ldap-users-search-clear" disabled>
-                                    <i class="fas fa-times" aria-hidden="true"></i>
+                                    <i class="fa-solid fa-xmark" aria-hidden="true"></i>
                                 </button>
                             </div>
                         </div>
                         <button type="button" class="btn btn-secondary btn-sm tp-action mr-2 mb-2" data-action="ldap-existing-users">
-                            <i class="fa-solid fa-sync-alt mr-2"></i><?php echo $lang->get('refresh'); ?>
+                            <i class="fa-solid fa-sync-alt mr-2"></i><?php echo $lang->get('list_users'); ?>
                         </button>
                         <button type="button" class="btn btn-secondary btn-sm tp-action mr-2 mb-2" data-action="ldap-add-role">
                             <i class="fa-solid fa-graduation-cap mr-2"></i><?php echo $lang->get('add_role_tip'); ?>
@@ -389,8 +389,8 @@ $emailNotConfigured = $canAccessInactiveAndDeletedUsers === true
                                     <tbody id="row-ldap-body">
                                     </tbody>
                                 </table>
-                                <div class="mt-2 hidden" id="ldap-users-search-no-results" role="status">
-                                    <i class="fas fa-info mr-2 text-warning" aria-hidden="true"></i><?php echo $lang->get('no_item_to_display'); ?>
+                                <div class="mt-2 px-3 hidden" id="ldap-users-search-no-results" role="status">
+                                    <i class="fa-solid fa-info mr-2 text-warning" aria-hidden="true"></i><?php echo $lang->get('no_item_to_display'); ?>
                                 </div>
                             </div>
                         </div>

--- a/public/assets/css/teampass.css
+++ b/public/assets/css/teampass.css
@@ -67,6 +67,11 @@
   text-overflow: ellipsis;
 }
 
+#ldap-users-search-wrapper {
+    width: 260px;
+    max-width: 100%;
+}
+
 .list-item-description {
     position: relative;
     height: 50px;

--- a/tests/Unit/LdapSynchronizationSearchTest.php
+++ b/tests/Unit/LdapSynchronizationSearchTest.php
@@ -21,6 +21,8 @@ class LdapSynchronizationSearchTest extends TestCase
     {
         $view = self::source('app/pages/users.php');
 
+        self::assertStringContainsString('id="ldap-users-toolbar"', $view);
+        self::assertStringContainsString('style="width: 260px; max-width: 100%;" id="ldap-users-search-wrapper"', $view);
         self::assertStringContainsString('id="ldap-users-search"', $view);
         self::assertMatchesRegularExpression(
             '/<input(?=[^\r\n]*id="ldap-users-search")(?=[^\r\n]*aria-label=)[^\r\n]*>/s',
@@ -31,6 +33,28 @@ class LdapSynchronizationSearchTest extends TestCase
             $view
         );
         self::assertStringContainsString('id="ldap-users-search-no-results" role="status"', $view);
+    }
+
+    public function testToolbarOrdersSearchBeforeRefreshAndRoleActions(): void
+    {
+        $view = self::source('app/pages/users.php');
+        $toolbarStart = strpos($view, 'id="ldap-users-toolbar"');
+        $tableStart = strpos($view, 'id="ldap-users-table"', (int) $toolbarStart);
+
+        self::assertIsInt($toolbarStart);
+        self::assertIsInt($tableStart);
+
+        $toolbar = substr($view, $toolbarStart, $tableStart - $toolbarStart);
+        $searchPosition = strpos($toolbar, 'id="ldap-users-search"');
+        $refreshPosition = strpos($toolbar, 'data-action="ldap-existing-users"');
+        $rolePosition = strpos($toolbar, 'data-action="ldap-add-role"');
+
+        self::assertIsInt($searchPosition);
+        self::assertIsInt($refreshPosition);
+        self::assertIsInt($rolePosition);
+        self::assertLessThan($refreshPosition, $searchPosition);
+        self::assertLessThan($rolePosition, $refreshPosition);
+        self::assertStringContainsString('$lang->get(\'refresh\')', $toolbar);
     }
 
     public function testSearchFiltersIdentityFieldsAndCanBeCleared(): void

--- a/tests/Unit/LdapSynchronizationSearchTest.php
+++ b/tests/Unit/LdapSynchronizationSearchTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Regression guards for the LDAP synchronization user search.
+ */
+class LdapSynchronizationSearchTest extends TestCase
+{
+    private static function source(string $relativePath): string
+    {
+        $content = file_get_contents(__DIR__ . '/../../' . $relativePath);
+        self::assertNotFalse($content, $relativePath . ' must be readable');
+
+        return (string) $content;
+    }
+
+    public function testSearchControlsArePresentAndAccessible(): void
+    {
+        $view = self::source('app/pages/users.php');
+
+        self::assertStringContainsString('id="ldap-users-search"', $view);
+        self::assertMatchesRegularExpression(
+            '/<input(?=[^\r\n]*id="ldap-users-search")(?=[^\r\n]*aria-label=)[^\r\n]*>/s',
+            $view
+        );
+        self::assertMatchesRegularExpression(
+            '/<button(?=[^\r\n]*id="ldap-users-search-clear")(?=[^\r\n]*aria-label=)(?=[^\r\n]*disabled)[^\r\n]*>/s',
+            $view
+        );
+        self::assertStringContainsString('id="ldap-users-search-no-results" role="status"', $view);
+    }
+
+    public function testSearchFiltersIdentityFieldsAndCanBeCleared(): void
+    {
+        $script = self::source('app/pages/users.js.php');
+
+        self::assertStringContainsString('function filterLdapUsersTable()', $script);
+        self::assertStringContainsString("$(document).on('input keyup search', '#ldap-users-search', filterLdapUsersTable)", $script);
+        self::assertStringContainsString("$('#ldap-users-search').val('').trigger('input').focus()", $script);
+        self::assertStringContainsString('entry.displayname', $script);
+        self::assertStringContainsString('entry.givenname', $script);
+        self::assertStringContainsString('entry.sn', $script);
+        self::assertStringContainsString('entry.mail', $script);
+        self::assertStringContainsString('data-search="\' + htmlEncode(searchText) + \'"', $script);
+    }
+
+    public function testFilterIsReappliedAfterAjaxRendering(): void
+    {
+        $script = self::source('app/pages/users.js.php');
+        $renderPosition = strpos($script, "$('#row-ldap-body').html(html)");
+        $filterPosition = strpos($script, 'filterLdapUsersTable()', (int) $renderPosition);
+
+        self::assertIsInt($renderPosition);
+        self::assertIsInt($filterPosition);
+        self::assertGreaterThan($renderPosition, $filterPosition);
+    }
+}

--- a/tests/Unit/LdapSynchronizationSearchTest.php
+++ b/tests/Unit/LdapSynchronizationSearchTest.php
@@ -25,7 +25,7 @@ class LdapSynchronizationSearchTest extends TestCase
         self::assertStringContainsString('style="width: 260px; max-width: 100%;" id="ldap-users-search-wrapper"', $view);
         self::assertStringContainsString('id="ldap-users-search"', $view);
         self::assertMatchesRegularExpression(
-            '/<input(?=[^\r\n]*id="ldap-users-search")(?=[^\r\n]*aria-label=)[^\r\n]*>/s',
+            '/<input(?=[^\r\n]*type="text")(?=[^\r\n]*role="searchbox")(?=[^\r\n]*id="ldap-users-search")(?=[^\r\n]*aria-label=)[^\r\n]*>/s',
             $view
         );
         self::assertMatchesRegularExpression(
@@ -62,7 +62,7 @@ class LdapSynchronizationSearchTest extends TestCase
         $script = self::source('app/pages/users.js.php');
 
         self::assertStringContainsString('function filterLdapUsersTable()', $script);
-        self::assertStringContainsString("$(document).on('input keyup search', '#ldap-users-search', filterLdapUsersTable)", $script);
+        self::assertStringContainsString("$(document).on('input keyup', '#ldap-users-search', filterLdapUsersTable)", $script);
         self::assertStringContainsString("$('#ldap-users-search').val('').trigger('input').focus()", $script);
         self::assertStringContainsString('entry.displayname', $script);
         self::assertStringContainsString('entry.givenname', $script);

--- a/tests/Unit/LdapSynchronizationSearchTest.php
+++ b/tests/Unit/LdapSynchronizationSearchTest.php
@@ -22,7 +22,7 @@ class LdapSynchronizationSearchTest extends TestCase
         $view = self::source('app/pages/users.php');
 
         self::assertStringContainsString('id="ldap-users-toolbar"', $view);
-        self::assertStringContainsString('style="width: 260px; max-width: 100%;" id="ldap-users-search-wrapper"', $view);
+        self::assertStringContainsString('id="ldap-users-search-wrapper"', $view);
         self::assertStringContainsString('id="ldap-users-search"', $view);
         self::assertMatchesRegularExpression(
             '/<input(?=[^\r\n]*type="text")(?=[^\r\n]*role="searchbox")(?=[^\r\n]*id="ldap-users-search")(?=[^\r\n]*aria-label=)[^\r\n]*>/s',
@@ -35,26 +35,26 @@ class LdapSynchronizationSearchTest extends TestCase
         self::assertStringContainsString('id="ldap-users-search-no-results" role="status"', $view);
     }
 
-    public function testToolbarOrdersSearchBeforeRefreshAndRoleActions(): void
+    public function testToolbarOrdersSearchBeforeListAndRoleActions(): void
     {
         $view = self::source('app/pages/users.php');
         $toolbarStart = strpos($view, 'id="ldap-users-toolbar"');
-        $tableStart = strpos($view, 'id="ldap-users-table"', (int) $toolbarStart);
-
         self::assertIsInt($toolbarStart);
+
+        $tableStart = strpos($view, 'id="ldap-users-table"', $toolbarStart);
         self::assertIsInt($tableStart);
 
         $toolbar = substr($view, $toolbarStart, $tableStart - $toolbarStart);
         $searchPosition = strpos($toolbar, 'id="ldap-users-search"');
-        $refreshPosition = strpos($toolbar, 'data-action="ldap-existing-users"');
+        $listPosition = strpos($toolbar, 'data-action="ldap-existing-users"');
         $rolePosition = strpos($toolbar, 'data-action="ldap-add-role"');
 
         self::assertIsInt($searchPosition);
-        self::assertIsInt($refreshPosition);
+        self::assertIsInt($listPosition);
         self::assertIsInt($rolePosition);
-        self::assertLessThan($refreshPosition, $searchPosition);
-        self::assertLessThan($rolePosition, $refreshPosition);
-        self::assertStringContainsString('$lang->get(\'refresh\')', $toolbar);
+        self::assertLessThan($listPosition, $searchPosition);
+        self::assertLessThan($rolePosition, $listPosition);
+        self::assertStringContainsString('$lang->get(\'list_users\')', $toolbar);
     }
 
     public function testSearchFiltersIdentityFieldsAndCanBeCleared(): void
@@ -62,12 +62,13 @@ class LdapSynchronizationSearchTest extends TestCase
         $script = self::source('app/pages/users.js.php');
 
         self::assertStringContainsString('function filterLdapUsersTable()', $script);
-        self::assertStringContainsString("$(document).on('input keyup', '#ldap-users-search', filterLdapUsersTable)", $script);
+        self::assertStringContainsString("$(document).on('input', '#ldap-users-search', filterLdapUsersTable)", $script);
         self::assertStringContainsString("$('#ldap-users-search').val('').trigger('input').focus()", $script);
         self::assertStringContainsString('entry.displayname', $script);
         self::assertStringContainsString('entry.givenname', $script);
         self::assertStringContainsString('entry.sn', $script);
         self::assertStringContainsString('entry.mail', $script);
+        self::assertStringContainsString("(entry.ldap_user_groups || []).join(' ')", $script);
         self::assertStringContainsString('data-search="\' + htmlEncode(searchText) + \'"', $script);
     }
 
@@ -75,9 +76,9 @@ class LdapSynchronizationSearchTest extends TestCase
     {
         $script = self::source('app/pages/users.js.php');
         $renderPosition = strpos($script, "$('#row-ldap-body').html(html)");
-        $filterPosition = strpos($script, 'filterLdapUsersTable()', (int) $renderPosition);
-
         self::assertIsInt($renderPosition);
+
+        $filterPosition = strpos($script, 'filterLdapUsersTable()', $renderPosition);
         self::assertIsInt($filterPosition);
         self::assertGreaterThan($renderPosition, $filterPosition);
     }


### PR DESCRIPTION
## Description

Adds a dynamic client-side search to the LDAP synchronization user list.

- Places a compact search field before the Refresh and Add role actions in a responsive toolbar.
- Filters the already-loaded rows by login, display name, first name, last name, and email address.
- Provides one explicit, accessible clear button that behaves consistently across browsers and is disabled while the field is empty.
- Displays a translated empty-result state when no LDAP user matches.
- Preserves and reapplies the active filter after each AJAX refresh.
- Escapes directory-provided search values with `htmlEncode()` before inserting them into the DOM.
- Adds a focused PHPUnit regression test for the controls, toolbar ordering, accessibility, and JavaScript wiring.

No LDAP query, database schema, translation, or AJAX endpoint is changed.

## Related issue

None.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (existing behaviour changes)
- [ ] Documentation
- [ ] Translation
- [ ] Refactor / maintenance

## How has this been tested?

- GitHub Actions passes on PHP 8.2 and PHP 8.3.
- PHPStan level 4 passes.
- CodeQL reports no new alerts in code changed by this pull request.
- JavaScript/TypeScript analysis, table-prefix validation, and the production-autoloader check pass.
- Scrutinizer reports no new issues and passing tests.
- `git diff --check` passes locally.
- Targeted static checks confirm the compact toolbar ordering, accessible controls, escaped search index, clear action, empty-result state, and filter reapplication after AJAX rendering.
- Added `tests/Unit/LdapSynchronizationSearchTest.php` for regression coverage.
- Manual LDAP and user-role testing was not available in this environment.

## Checklist

- [x] PHPStan level 4 passes (`php app/vendor/bin/phpstan analyse --memory-limit=2G`)
- [x] The test suite passes (`php _tools/phpunit.phar` — see CONTRIBUTING.md for the one-time setup)
- [x] Every new public function has a docblock
- [x] Variable names and comments are in English
- [x] No `var_dump()` or `console.log()` was added by this change
- [x] New `app/sources/*.queries.php` files have a matching `public/sources/` proxy shim (not applicable: no handler was added)
- [x] Changes to `teampassclasses` were applied to **both** copies (`app/includes/libraries/` and `app/vendor/`) (not applicable: no class was changed)
- [x] `app/vendor/composer/` is in its production form (`git checkout -- app/vendor/composer/`)

## Impact on install / upgrade

- [x] No schema change
- [ ] Schema change — an `install/upgrade_run_X.X.X.php` script is included and the fresh install path was tested

## Screenshots

Not available in this environment because there is no local PHP/LDAP runtime.