### PR TITLE
Protect task logs and keep the background-task lock persistent

### DIFF
--- a/app/scripts/backgroundTaskLock.php
+++ b/app/scripts/backgroundTaskLock.php
@@ -1,0 +1,119 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Teampass - a collaborative passwords manager.
+ * ---
+ * This file is part of the TeamPass project.
+ *
+ * TeamPass is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * TeamPass is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Certain components of this file may be under different licenses. For
+ * details, see the `licenses` directory or individual file headers.
+ * ---
+ * @file      backgroundTaskLock.php
+ * @author    Nils Laumaillé (nils@teampass.net)
+ * @copyright 2009-2026 Teampass.net
+ * @license   GPL-3.0
+ * @see       https://www.teampass.net
+ */
+
+require_once __DIR__ . '/../sources/runtime_files.functions.php';
+
+/**
+ * Own the handler's advisory lock on a trusted local runtime file.
+ *
+ * File presence and an old PID do not indicate activity: only flock does.
+ * Validate the inode after locking and unlink it before unlocking on release.
+ * A contender holding an orphaned descriptor must never start background work.
+ */
+final class BackgroundTaskLock
+{
+    /** @var resource|null */
+    private $handle = null;
+
+    /** @param string $path Trusted configured local path to the handler lock. */
+    public function __construct(private string $path)
+    {
+    }
+
+    /** Acquire exclusively without waiting or changing another owner's PID. */
+    public function acquire(): bool
+    {
+        if (is_resource($this->handle)) {
+            return true;
+        }
+
+        $handle = tpOpenRuntimeFile($this->path);
+        if ($handle === false) {
+            error_log(
+                'Teampass Background Tasks: cannot open a valid lock file "' . $this->path
+                . '" - check that the web server user can write to this directory.'
+            );
+            return false;
+        }
+        return $this->acquireHandle($handle);
+    }
+
+    /**
+     * Take ownership of an opened descriptor, closing it on any failed attempt.
+     *
+     * @param resource $handle The descriptor opened for this acquisition.
+     */
+    private function acquireHandle($handle): bool
+    {
+        if (@flock($handle, LOCK_EX | LOCK_NB) === false) {
+            fclose($handle);
+            return false;
+        }
+
+        // A finishing handler may have unlinked this inode after our open.
+        $stat = @fstat($handle);
+        if ($stat === false || tpRuntimeFileMatchesPath($this->path, $stat) === false) {
+            fclose($handle);
+            return false;
+        }
+
+        $pid = (string) getmypid();
+        if (@ftruncate($handle, 0) === false || @fwrite($handle, $pid) !== strlen($pid) || @fflush($handle) === false) {
+            fclose($handle);
+            error_log('Teampass Background Tasks: cannot write lock file "' . $this->path . '".');
+            return false;
+        }
+        $this->handle = $handle;
+        return true;
+    }
+
+    /** Remove only our own inode while locked, then release the descriptor. */
+    public function release(): void
+    {
+        if (is_resource($this->handle)) {
+            $stat = @fstat($this->handle);
+            if ($stat !== false && tpRuntimeFileMatchesPath($this->path, $stat)) {
+                unlink($this->path);
+            }
+            // Keep explicit unlocking even if a child inherited the descriptor.
+            // Closing is also the fallback if the explicit unlock fails.
+            flock($this->handle, LOCK_UN);
+            fclose($this->handle);
+        }
+        $this->handle = null;
+    }
+
+    /** Also release when the owner goes out of scope; abrupt exit is handled by the OS. */
+    public function __destruct()
+    {
+        $this->release();
+    }
+}

--- a/app/scripts/background_tasks___handler.php
+++ b/app/scripts/background_tasks___handler.php
@@ -35,6 +35,7 @@ require_once __DIR__.'/../sources/main.functions.php';
 require_once __DIR__ . '/../sources/backup.functions.php';
 require_once __DIR__ . '/../sources/lapr.functions.php';
 require_once __DIR__ . '/taskLogger.php';
+require_once __DIR__ . '/backgroundTaskLock.php';
 
 class BackgroundTasksHandler {
     private array $settings;
@@ -43,7 +44,7 @@ class BackgroundTasksHandler {
     private int $maxExecutionTime;
     private int $batchSize;
     private int $maxTimeBeforeRemoval;
-    private mixed $lockFileHandle = null;
+    private ?BackgroundTaskLock $processLock = null;
     /** @var array<int, array{process: Process, task: array<string, mixed>, resourceKey: ?string}> Running process pool */
     private array $pool = [];
     private string $triggerFile;
@@ -951,70 +952,15 @@ class BackgroundTasksHandler {
     private function acquireProcessLock(): bool {
         $lockFile = !empty(TASKS_LOCK_FILE) ? TASKS_LOCK_FILE : (defined('TEAMPASS_STORAGE') ? TEAMPASS_STORAGE . '/logs/teampass_background_tasks.lock' : __DIR__ . '/../../storage/logs/teampass_background_tasks.lock');
 
-        // Opening (or creating) the lock file failing is NOT a concurrency
-        // situation but a filesystem/permission problem (typically the web
-        // server user cannot write to storage/logs). Surface it via error_log()
-        // because LOG_TASKS may be disabled and the task log itself lives in the
-        // same directory, so the failure would otherwise be completely silent.
-        $fp = tpOpenRuntimeFile($lockFile);
-        if ($fp === false) {
-            error_log(
-                'Teampass Background Tasks: cannot open a valid lock file "' . $lockFile
-                . '" - check that the web server user can write to this directory.'
-            );
-            return false;
-        }
-
-        if (!flock($fp, LOCK_EX | LOCK_NB)) {
-            // Another handler instance already holds the lock: expected, not an error.
-            fclose($fp);
-            return false;
-        }
-
-        // A finishing handler may have unlinked the lock between our open and
-        // our flock: we would then own an orphaned inode while the next handler
-        // creates a fresh file, locks it too and runs beside us. Detaching the
-        // path is the only way that happens, so compare the descriptor with it.
-        $lockStat = fstat($fp);
-        if ($lockStat === false || tpRuntimeFileMatchesPath($lockFile, $lockStat) === false) {
-            fclose($fp);
-            return false;
-        }
-
-        // Only the lock owner may replace the PID; a contending handler must
-        // not truncate the running handler's file while trying to acquire it.
-        $pid = (string) getmypid();
-        if (ftruncate($fp, 0) === false || fwrite($fp, $pid) !== strlen($pid) || fflush($fp) === false) {
-            fclose($fp);
-            error_log('Teampass Background Tasks: cannot write lock file "' . $lockFile . '".');
-            return false;
-        }
-        $this->lockFileHandle = $fp;
-        return true;
+        $this->processLock ??= new BackgroundTaskLock($lockFile);
+        return $this->processLock->acquire();
     }
 
     /**
      * Release the lock file.
      */
     private function releaseProcessLock(): void {
-        if ($this->lockFileHandle === null) {
-            // The lock was never acquired, so the file on disk belongs to
-            // another handler: removing it would let a third one run beside it.
-            return;
-        }
-
-        // Unlink while the lock is still held, and only when the path still
-        // names the very inode we own. A contender cannot then acquire what we
-        // are about to detach, which closes the other half of the same race.
-        $lockFile = !empty(TASKS_LOCK_FILE) ? TASKS_LOCK_FILE : (defined('TEAMPASS_STORAGE') ? TEAMPASS_STORAGE . '/logs/teampass_background_tasks.lock' : __DIR__ . '/../../storage/logs/teampass_background_tasks.lock');
-        $lockStat = fstat($this->lockFileHandle);
-        if ($lockStat !== false && tpRuntimeFileMatchesPath($lockFile, $lockStat)) {
-            unlink($lockFile);
-        }
-
-        flock($this->lockFileHandle, LOCK_UN);
-        fclose($this->lockFileHandle);
-        $this->lockFileHandle = null;
+        $this->processLock?->release();
     }
 
     /**

--- a/app/scripts/taskLogger.php
+++ b/app/scripts/taskLogger.php
@@ -35,6 +35,7 @@ require_once __DIR__ . '/../sources/runtime_files.functions.php';
 class TaskLogger {
     private $settings;
     private $logFile;
+    private static bool $destinationFailureReported = false;
 
     public function __construct(array $settings, string $logFile = '') {
         $this->settings = $settings;
@@ -53,12 +54,14 @@ class TaskLogger {
                                 " - [$level] $message" . PHP_EOL;
 
             if (!empty($this->logFile)) {
-                // Write to the specified log file, with the runtime file
-                // permission policy so the log does not stay world readable.
-                tpAppendRuntimeFile(
-                    tpResolveRuntimeLogPath($this->logFile, __DIR__),
-                    $formattedMessage
-                );
+                $path = tpResolveRuntimeLogPath($this->logFile, __DIR__);
+                if (tpAppendRuntimeFile($path, $formattedMessage) === false && self::$destinationFailureReported === false) {
+                    self::$destinationFailureReported = true;
+                    // Task arguments may be sensitive: report the failure, not the lost entry.
+                    error_log('Teampass: cannot append to the protected task log "' . $path
+                        . '"; check its path, owner and permissions. The log entry was not recorded.'
+                        . ' Further destination failures are suppressed for this process.');
+                }
             } else {
                 // Use default error log
                 error_log($formattedMessage);

--- a/app/sources/runtime_files.functions.php
+++ b/app/sources/runtime_files.functions.php
@@ -51,7 +51,7 @@ function tpRuntimeFileMatchesPath(string $path, array $streamStat): bool
 }
 
 /**
- * Open a trusted local runtime lock or signal without truncating its contents.
+ * Open a trusted local runtime file without truncating its contents.
  *
  * Try to restrict POSIX permissions before callers write: an inherited umask of 0022
  * otherwise produces 0644 files and triggers the Health permission warning.
@@ -60,9 +60,10 @@ function tpRuntimeFileMatchesPath(string $path, array $streamStat): bool
  * and signals. Permission auditing still reports the unresolved permissions.
  * Do not change the process-wide umask in a web request.
  *
+ * @param bool $requireRestrictedPermissions Refuse world access; the log caller reports failures.
  * @return resource|false The caller owns the stream and its advisory locking.
  */
-function tpOpenRuntimeFile(string $path)
+function tpOpenRuntimeFile(string $path, bool $requireRestrictedPermissions = false)
 {
     clearstatcache(true, $path);
     if (
@@ -91,7 +92,8 @@ function tpOpenRuntimeFile(string $path)
 
     $currentMode = $stat['mode'] & 07777;
     $restrictedMode = ($currentMode & 0640) | 0600;
-    if ($currentMode !== $restrictedMode && @chmod($path, $restrictedMode) === false) {
+    if ($currentMode !== $restrictedMode && @chmod($path, $restrictedMode) === false && !$requireRestrictedPermissions) {
+        // Logs report failures once in TaskLogger, not once per attempted entry.
         error_log(
             'Teampass: cannot restrict runtime file permissions for "' . $path
             . '". Continuing with existing access; check the file owner and permissions.'
@@ -102,6 +104,14 @@ function tpOpenRuntimeFile(string $path)
     if (tpRuntimeFileMatchesPath($path, $stat) === false) {
         fclose($handle);
         return false;
+    }
+
+    if ($requireRestrictedPermissions) {
+        $securedStat = @fstat($handle);
+        if ($securedStat === false || ($securedStat['mode'] & 0007) !== 0) {
+            fclose($handle);
+            return false;
+        }
     }
 
     return $handle;
@@ -159,28 +169,46 @@ function tpResolveRuntimeLogPath(string $logFile, string $baseDirectory): string
 }
 
 /**
- * Append to a trusted local runtime log using the same permissions as locks.
+ * Append a protected log entry without truncating history or leaking its contents.
  *
- * Wait for a competing writer, unlike the signal writer: every producer is a
- * background CLI process, never a web request, and a dropped log line would
- * hide exactly what the log is read for.
+ * Background CLI writers wait for each other. Reopen once if rotation replaced
+ * the path while waiting; never retry an entry after any bytes were written.
+ * A chmod-only failure is acceptable when no POSIX "other" access remains.
+ * Callers report failures without forwarding the potentially sensitive entry.
  */
 function tpAppendRuntimeFile(string $path, string $contents): bool
 {
-    $handle = tpOpenRuntimeFile($path);
-    if ($handle === false) {
-        return false;
-    }
-
-    try {
-        // Seek under the lock: the open position is the start of the file.
-        if (@flock($handle, LOCK_EX) === false || @fseek($handle, 0, SEEK_END) !== 0) {
+    for ($attempt = 0; $attempt < 2; ++$attempt) {
+        $handle = tpOpenRuntimeFile($path, true);
+        if ($handle === false) {
             return false;
         }
 
-        return @fwrite($handle, $contents) === strlen($contents) && @fflush($handle);
-    } finally {
-        // Closing releases the advisory lock on both success and failure.
-        fclose($handle);
+        try {
+            if (@flock($handle, LOCK_EX) === false) {
+                return false;
+            }
+            $stat = @fstat($handle);
+            if ($stat === false) {
+                return false;
+            }
+            if (tpRuntimeFileMatchesPath($path, $stat) === false) {
+                // finally closes the old descriptor before the bounded retry.
+                continue;
+            }
+            if (PHP_OS_FAMILY !== 'Windows' && ($stat['mode'] & 0007) !== 0) {
+                return false;
+            }
+            // Seek only after acquiring the lock and validating its destination.
+            if (@fseek($handle, 0, SEEK_END) !== 0) {
+                return false;
+            }
+
+            return @fwrite($handle, $contents) === strlen($contents) && @fflush($handle);
+        } finally {
+            fclose($handle);
+        }
     }
+
+    return false;
 }

--- a/docs/install/file-permissions.md
+++ b/docs/install/file-permissions.md
@@ -328,16 +328,32 @@ find ${TEAMPASS} -not -path "*/vendor/*" ! -type l -perm -o+w -ls
 **Utilities → System Health → File integrity** starts a read-only background scan. Detailed findings are stored in `storage/logs/file-integrity-report.json`, while the Dashboard and Health polling read the bounded `storage/logs/file-integrity-summary.json`. Both files carry the same scan identifier, and detailed findings are rejected if the identifiers do not match.
 
 The background-task lock and trigger, the file-integrity scan/enqueue locks and
-the optional background-task log (`storage/logs/teampass_tasks.log`, written only
-when `enable_tasks_log` is on) are runtime files, not release-manifest entries. TeamPass attempts to restrict their
+the optional task journal (`LOG_TASKS_FILE`, normally `storage/logs/teampass_tasks.log`)
+are runtime files, not release-manifest entries. TeamPass attempts to restrict their
 POSIX permissions to `0640` or `0600` whenever it opens them for writing, including
 when a deleted file is recreated. Existing `0600` modes are preserved and owner
-read/write access is ensured; the process umask is not changed. If opening succeeds
-but `chmod` fails (for example, a group-writable file belongs to another account),
-TeamPass logs a warning and continues with the existing access. An invalid target
-or an actual open/write failure still prevents that operation. The permission scan still audits these files and
-reports unsafe permissions or access problems. No manual manifest update or
-permission-scan exclusion is needed for these locks.
+read/write access is ensured; the process umask is not changed.
+
+Locks and signals continue with existing access, with a warning, if opening
+succeeds but `chmod` fails. The journal is stricter because task arguments may be
+sensitive: after attempted repair it refuses any POSIX access for other users
+(`mode & 0007`). A group-writable `0660` journal owned by another account remains
+usable when `chmod` is denied; a `0664` journal does not. An invalid target or an
+actual open/write failure still prevents that operation. The permission scan
+continues to report unsafe permissions and access problems. No manual manifest
+update or permission-scan exclusion is needed.
+
+The journal is written only when `enable_tasks_log` is on. Absolute custom paths
+are used as-is; legacy relative paths resolve against `app/scripts/`. An empty
+log path retains the explicitly configured PHP error-log destination. A failed
+configured destination produces one diagnostic per process, without copying the
+lost entry into another log. Further writes are still attempted, so logging resumes
+if the destination is repaired; background processing is not stopped by a log failure.
+Concurrent appends preserve existing entries. Identity and permissions are checked
+again after waiting for the lock. If rotation replaced the journal during that wait,
+the writer reopens and retries once, before writing anything. Rotation must preserve
+the runtime owner/group and restricted permissions; this is not an atomic guarantee
+against arbitrary external replacements.
 
 Runtime directories must not be writable by untrusted users. Descriptor/path
 identity checks detect observed file replacements, but do not make path-based
@@ -345,11 +361,15 @@ identity checks detect observed file replacements, but do not make path-based
 contention is distinguished from an I/O error. The scan-status probe opens existing
 locks read-only and neither creates them nor changes their permissions.
 
-The background-task lock is also deleted by the handler that owns it. Deleting a
-file that carries an advisory lock detaches the inode from the path, so the handler
-unlinks it while still holding the lock and, after acquiring one, verifies that the
-descriptor still names the path. Without that check two handlers could hold two
-different inodes of the same lock and run at the same time.
+The background-task lock is deleted by the handler that owns it, while still
+holding the lock and only when the path still names its inode. After acquiring
+a lock, the handler checks the same identity before writing its PID or starting
+work: an already-open descriptor to a deleted file must not admit another handler.
+A failed acquisition or repeated release cannot delete another handler's file.
+After an abrupt stop, a leftover file is reusable when the next handler can open
+it; file presence or an old PID alone does not indicate activity. Run manual
+handlers as the normal background/web account: a root-owned leftover may require
+an administrator to correct its ownership.
 
 The scan compares protected files with `app/files_reference.txt` and reports separate categories for modified, missing, unknown, legacy-layout and Composer development files. Instance-owned data under `storage/`, `secrets/` and legacy runtime directories (`files/`, `upload/`, `backups/`) is excluded. Repository and development-only artifacts such as `.claude/`, `.github/`, `docs/`, `tests/` and their root tooling files are neutral: they do not affect integrity health, are not audited for runtime permissions and are not included in permission remediation. Any top-level hidden *directory* is treated the same way, so a tool directory added later is covered without updating the policy, and the same applies to repository metadata vendored inside dependencies (`app/vendor/*/.github/`, `.gitignore`, `.travis.yml`, `.editorconfig`, …). The release checksum generator consumes this same canonical policy, keeping those paths out of future manifests. This is an explicit path policy, not a blanket hidden-file exclusion; top-level hidden *files* stay in scope, and `.htaccess`, `.user.ini`, `.env*`, `.gitkeep`, `app/includes/.externals/`, Composer deployment metadata, Docker assets and application scripts remain protected. Ordinary avatar files are ignored, but executable files or symbolic links planted in the writable public avatar directory are reported as critical. A deliberately removed `public/install/` directory is accepted; when that directory exists, its files are fully checked. The reference manifest itself and generated configuration files are excluded from self-comparison.
 

--- a/tests/Fixtures/RuntimeProcessTestTrait.php
+++ b/tests/Fixtures/RuntimeProcessTestTrait.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+use Symfony\Component\Process\InputStream;
+use Symfony\Component\Process\Process;
+
+/** Isolated subprocesses with a request/response protocol and bounded lifetimes. */
+trait RuntimeProcessTestTrait
+{
+    private string $root;
+    /** @var list<Process> */
+    private array $processes = [];
+    private int $requestId = 0;
+
+    protected function setUp(): void
+    {
+        $this->root = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'teampass-task-runtime-test-' . bin2hex(random_bytes(8));
+        foreach (['storage/logs', 'app/scripts', 'app/sources'] as $directory) {
+            self::assertTrue(mkdir($this->root . '/' . $directory, 0700, true));
+        }
+    }
+
+    protected function tearDown(): void
+    {
+        foreach ($this->processes as $process) {
+            if ($process->isRunning()) {
+                $process->stop(0, 9);
+            }
+        }
+        $root = realpath($this->root);
+        $temporaryRoot = realpath(sys_get_temp_dir());
+        if ($root === false || $temporaryRoot === false
+            || !str_starts_with($root, $temporaryRoot . DIRECTORY_SEPARATOR . 'teampass-task-runtime-test-')) {
+            return;
+        }
+        $iterator = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($root, FilesystemIterator::SKIP_DOTS),
+            RecursiveIteratorIterator::CHILD_FIRST
+        );
+        foreach ($iterator as $entry) {
+            if (!$entry->isLink() && $entry->isDir()) {
+                rmdir($entry->getPathname());
+            } else {
+                unlink($entry->getPathname());
+            }
+        }
+        rmdir($root);
+    }
+
+    /** @return array{Process, InputStream} */
+    private function startLockProbe(string $path): array
+    {
+        $input = new InputStream();
+        $process = new Process([PHP_BINARY, __DIR__ . '/../Fixtures/background_task_lock_probe.php', $path]);
+        $process->setInput($input);
+        $process->setTimeout(15);
+        $this->processes[] = $process;
+        $process->start();
+        $this->waitForMatch($process, '/ready\r?\n/');
+        return [$process, $input];
+    }
+
+    /** @return array{id: int, result: bool, pid: int, inode: int|null, contents: string|null} */
+    private function command(Process $process, InputStream $input, string $action): array
+    {
+        $id = ++$this->requestId;
+        $input->write(json_encode(['id' => $id, 'action' => $action], JSON_THROW_ON_ERROR) . "\n");
+        $line = $this->waitForMatch($process, '/\{"id":' . $id . ',[^\r\n]+\}\r?\n/');
+        return json_decode(trim($line), true, 512, JSON_THROW_ON_ERROR);
+    }
+
+    /** Wait for a protocol response, never for an assumed scheduling delay. */
+    private function waitForMatch(Process $process, string $pattern): string
+    {
+        do {
+            $process->checkTimeout();
+            if (preg_match($pattern, $process->getOutput(), $matches) === 1) {
+                return $matches[0];
+            }
+            if (!$process->isRunning()) {
+                self::fail('Probe exited before replying: ' . $process->getErrorOutput());
+            }
+            usleep(1000);
+        } while (true);
+    }
+
+    /**
+     * @param list<string> $arguments
+     * @param list<string> $options
+     */
+    private function runPhp(string $code, array $arguments, array $options = []): Process
+    {
+        $process = new Process(array_merge([PHP_BINARY], $options, ['-r', $code, '--'], $arguments));
+        $process->setTimeout(15);
+        $this->processes[] = $process;
+        $process->run();
+        self::assertSame(0, $process->getExitCode(), $process->getErrorOutput());
+        return $process;
+    }
+
+    private function requirePosix(): void
+    {
+        if (PHP_OS_FAMILY !== 'Linux' || !function_exists('posix_geteuid')) {
+            self::markTestSkipped('Linux/POSIX permission semantics are required.');
+        }
+    }
+}

--- a/tests/Fixtures/background_task_lock_probe.php
+++ b/tests/Fixtures/background_task_lock_probe.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+// Test-only command protocol. The parent owns this process and bounds its lifetime.
+require_once __DIR__ . '/../../app/scripts/backgroundTaskLock.php';
+
+$path = $argv[1];
+$lock = new BackgroundTaskLock($path);
+$opened = null;
+$openedLocked = false;
+echo "ready\n";
+fflush(STDOUT);
+while (($line = fgets(STDIN)) !== false) {
+    $request = json_decode($line, true, 512, JSON_THROW_ON_ERROR);
+    $result = false;
+    switch ($request['action']) {
+        case 'acquire':
+            $result = $lock->acquire();
+            break;
+        case 'release':
+            $lock->release();
+            $result = true;
+            break;
+        case 'open':
+            $opened = tpOpenRuntimeFile($path);
+            $result = is_resource($opened);
+            break;
+        case 'lock_opened':
+            $result = is_resource($opened) && flock($opened, LOCK_EX | LOCK_NB);
+            $openedLocked = $result;
+            break;
+        case 'acquire_opened':
+            // Control open/flock ordering without copying the production guard.
+            $result = is_resource($opened)
+                && (new ReflectionMethod(BackgroundTaskLock::class, 'acquireHandle'))->invoke($lock, $opened);
+            $opened = null; // The real acquisition owns or closes the descriptor.
+            $openedLocked = false;
+            break;
+        case 'release_opened':
+            if (is_resource($opened)) {
+                fclose($opened);
+                $opened = null;
+            }
+            $openedLocked = false;
+            $result = true;
+            break;
+        default:
+            throw new RuntimeException('Unknown test command.');
+    }
+    // Read through the owner's descriptor: Windows locks prohibit reads by outsiders.
+    $handle = (new ReflectionProperty(BackgroundTaskLock::class, 'handle'))->getValue($lock);
+    if ($handle === null && $openedLocked) {
+        $handle = $opened;
+    }
+    $contents = null;
+    if (is_resource($handle)) {
+        $position = ftell($handle);
+        rewind($handle);
+        $contents = stream_get_contents($handle);
+        fseek($handle, $position);
+    }
+    clearstatcache(true, $path);
+    echo json_encode([
+        'id' => $request['id'],
+        'result' => $result,
+        'pid' => getmypid(),
+        'inode' => is_file($path) ? fileinode($path) : null,
+        'contents' => $contents,
+    ], JSON_THROW_ON_ERROR) . "\n";
+    fflush(STDOUT);
+}

--- a/tests/Fixtures/runtime_log_handoff_probe.php
+++ b/tests/Fixtures/runtime_log_handoff_probe.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+// This child injects changes at the flock return boundary. It never runs a handler.
+$path = $argv[2];
+$scenario = $argv[3];
+$attempts = 0;
+if (function_exists('flock')) {
+    throw new RuntimeException('The lock-handoff fixture was not enabled.');
+} else {
+    function flock($handle, int $operation): bool
+    {
+        global $path, $scenario, $attempts;
+        if ($operation !== LOCK_EX) {
+            throw new RuntimeException('Expected exclusive append locking.');
+        }
+        ++$attempts;
+        if ($scenario === 'permissions') {
+            chmod($path, 0664);
+        } elseif ($scenario === 'symlink') {
+            rename($path, $path . '.old-1');
+            file_put_contents($path . '.target', "untouched\n");
+            symlink($path . '.target', $path);
+        } elseif ($scenario === 'rotate_twice' || ($scenario === 'rotate_once' && $attempts === 1)) {
+            rename($path, $path . '.old-' . $attempts);
+            file_put_contents($path, "rotated\n");
+            chmod($path, 0640);
+        }
+        return true;
+    }
+}
+if ($scenario === 'partial') {
+    if (function_exists('fwrite')) {
+        throw new RuntimeException('The partial-write fixture was not enabled.');
+    } else {
+        function fwrite($handle, string $contents): int|false
+        {
+            return fputs($handle, substr($contents, 0, 3));
+        }
+    }
+}
+require_once __DIR__ . '/../../app/sources/runtime_files.functions.php';
+$result = tpAppendRuntimeFile($path, "private-entry\n");
+echo json_encode(['result' => $result, 'attempts' => $attempts], JSON_THROW_ON_ERROR);

--- a/tests/Unit/BackgroundTasksProcessLockTest.php
+++ b/tests/Unit/BackgroundTasksProcessLockTest.php
@@ -4,155 +4,229 @@ declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;
 
-require_once __DIR__ . '/../../app/sources/runtime_files.functions.php';
+require_once __DIR__ . '/../Fixtures/RuntimeProcessTestTrait.php';
+require_once __DIR__ . '/../../app/scripts/backgroundTaskLock.php';
 
-/**
- * The background handler serialises itself with an advisory lock on a file it
- * also deletes. Deleting a flocked file detaches the inode from the path, so
- * two handlers can end up holding two different inodes and run together.
- * These tests pin the two halves of the guard that closes that race.
- */
-class BackgroundTasksProcessLockTest extends TestCase
+final class BackgroundTasksProcessLockTest extends TestCase
 {
-    private string $root;
+    use RuntimeProcessTestTrait;
 
-    protected function setUp(): void
+    /** Observe real flock ownership at the unlink boundary, not source-text offsets. */
+    public function testReleaseUnlinksWhileItStillOwnsTheLock(): void
     {
-        $this->root = sys_get_temp_dir() . DIRECTORY_SEPARATOR
-            . 'teampass-process-lock-test-' . bin2hex(random_bytes(8));
-        self::assertTrue(mkdir($this->root, 0700, true));
-    }
-
-    protected function tearDown(): void
-    {
-        $root = realpath($this->root);
-        $temporaryRoot = realpath(sys_get_temp_dir());
-        if (
-            $root === false
-            || $temporaryRoot === false
-            || str_starts_with($root, $temporaryRoot . DIRECTORY_SEPARATOR . 'teampass-process-lock-test-') === false
-        ) {
-            return;
-        }
-
-        foreach ((array) glob($root . '/*') as $entry) {
-            if (is_string($entry)) {
-                unlink($entry);
-            }
-        }
-        rmdir($root);
-    }
-
-    private function handlerSource(): string
-    {
-        $source = file_get_contents(__DIR__ . '/../../app/scripts/background_tasks___handler.php');
-        self::assertIsString($source);
-
-        return $source;
-    }
-
-    /**
-     * Reproduce the race with the real primitives: an orphaned inode can still
-     * be locked, so lock ownership alone never proves exclusivity.
-     */
-    public function testAnOrphanedLockIsStillAcquirableAndMustBeRejectedByIdentity(): void
-    {
-        $path = $this->root . '/teampass_background_tasks.lock';
-
-        $running = tpOpenRuntimeFile($path);
-        self::assertIsResource($running);
-        self::assertTrue(flock($running, LOCK_EX | LOCK_NB));
-
-        // A second handler opens the very same inode before the first one exits.
-        $contender = tpOpenRuntimeFile($path);
-        self::assertIsResource($contender);
-        self::assertFalse(flock($contender, LOCK_EX | LOCK_NB), 'The lock must be exclusive while held.');
-
-        // The first handler finishes and detaches the inode from the path.
-        self::assertTrue(unlink($path));
-        self::assertTrue(flock($running, LOCK_UN));
-        fclose($running);
-
-        // The contender now acquires an inode no path names any more. This is
-        // the race: it believes it is the single handler.
-        self::assertTrue(flock($contender, LOCK_EX | LOCK_NB));
-        $contenderStat = fstat($contender);
-        self::assertIsArray($contenderStat);
-        self::assertFalse(
-            tpRuntimeFileMatchesPath($path, $contenderStat),
-            'The guard must reject a lock held on a detached inode.'
-        );
-
-        // A third handler legitimately creates and locks a fresh file, which is
-        // what would have made two handlers run side by side.
-        $next = tpOpenRuntimeFile($path);
-        self::assertIsResource($next);
-        self::assertTrue(flock($next, LOCK_EX | LOCK_NB));
-        $nextStat = fstat($next);
-        self::assertIsArray($nextStat);
-        self::assertTrue(tpRuntimeFileMatchesPath($path, $nextStat));
-
+        $this->requirePosix();
+        $path = $this->root . '/storage/logs/release-order.lock';
+        $probe = $this->runPhp(<<<'PHP'
+if (function_exists('unlink')) {
+    throw new RuntimeException('The unlink checkpoint was not enabled.');
+} else {
+    function unlink(string $path): bool {
+        $contender = fopen($path, 'c+b');
+        $acquired = flock($contender, LOCK_EX | LOCK_NB);
         fclose($contender);
-        fclose($next);
+        echo json_encode(['stillLocked' => !$acquired]);
+        return true;
+    }
+}
+require $argv[1];
+$lock = new BackgroundTaskLock($argv[2]);
+if (!$lock->acquire()) {
+    throw new RuntimeException('The owner must acquire the lock.');
+}
+$lock->release();
+PHP, [__DIR__ . '/../../app/scripts/backgroundTaskLock.php', $path], ['-d', 'disable_functions=unlink']);
+        self::assertSame(['stillLocked' => true], json_decode($probe->getOutput(), true));
+        self::assertSame('', $probe->getErrorOutput());
     }
 
-    /** An untouched lock keeps matching its path, so the guard costs no tick. */
-    public function testAHealthyLockPassesTheIdentityCheck(): void
+    /** The real acquisition rejects an orphan opened before the previous owner exited. */
+    public function testPreopenedContenderIsRejectedAfterLocking(): void
     {
-        $path = $this->root . '/teampass_background_tasks.lock';
-        $handle = tpOpenRuntimeFile($path);
-        self::assertIsResource($handle);
-        try {
-            self::assertTrue(flock($handle, LOCK_EX | LOCK_NB));
-            $stat = fstat($handle);
-            self::assertIsArray($stat);
-            self::assertTrue(tpRuntimeFileMatchesPath($path, $stat));
-            self::assertSame(5, fwrite($handle, '12345'));
-            self::assertTrue(fflush($handle));
-            self::assertTrue(tpRuntimeFileMatchesPath($path, $stat));
-        } finally {
-            fclose($handle);
+        $this->requirePosix();
+        $path = $this->root . '/storage/logs/teampass_background_tasks.lock';
+        [$first, $firstInput] = $this->startLockProbe($path);
+        $initial = $this->command($first, $firstInput, 'acquire');
+        self::assertTrue($initial['result']);
+        [$second, $secondInput] = $this->startLockProbe($path);
+        self::assertTrue($this->command($second, $secondInput, 'open')['result']);
+        self::assertFalse($this->command($second, $secondInput, 'lock_opened')['result']);
+        self::assertSame((string) $initial['pid'], $this->command($first, $firstInput, 'acquire')['contents']);
+        $this->command($first, $firstInput, 'release');
+        self::assertFileDoesNotExist($path);
+
+        // flock on the old inode succeeds, but the production identity check refuses it.
+        self::assertFalse($this->command($second, $secondInput, 'acquire_opened')['result']);
+        [$third, $thirdInput] = $this->startLockProbe($path);
+        $next = $this->command($third, $thirdInput, 'acquire');
+        self::assertTrue($next['result']);
+        self::assertSame((string) $next['pid'], $next['contents']);
+
+        $this->command($first, $firstInput, 'release');
+        $this->command($second, $secondInput, 'release');
+        self::assertFileExists($path);
+        self::assertFalse($this->command($first, $firstInput, 'acquire')['result']);
+        $this->command($third, $thirdInput, 'release');
+        self::assertFileDoesNotExist($path);
+    }
+
+    /** Exercise the same opened-descriptor path on a valid inode, not just the rejection. */
+    public function testPreopenedHealthyDescriptorCanBeAcquired(): void
+    {
+        $path = $this->root . '/storage/logs/healthy.lock';
+        [$probe, $input] = $this->startLockProbe($path);
+        self::assertTrue($this->command($probe, $input, 'open')['result']);
+        $acquired = $this->command($probe, $input, 'acquire_opened');
+        self::assertTrue($acquired['result']);
+        self::assertSame((string) $acquired['pid'], $acquired['contents']);
+        $this->command($probe, $input, 'release');
+        self::assertFileDoesNotExist($path);
+    }
+
+    /** Normal releases delete the file, preserve the active PID and admit the next handler. */
+    public function testNormalHandoffsRemoveTheFileAndKeepOneOwner(): void
+    {
+        $path = $this->root . '/storage/logs/teampass_background_tasks.lock';
+        [$first, $firstInput] = $this->startLockProbe($path);
+        [$second, $secondInput] = $this->startLockProbe($path);
+        for ($run = 0; $run < 3; ++$run) {
+            $initial = $this->command($first, $firstInput, 'acquire');
+            self::assertTrue($initial['result']);
+            self::assertFalse($this->command($second, $secondInput, 'acquire')['result']);
+            self::assertSame((string) $initial['pid'], $this->command($first, $firstInput, 'acquire')['contents']);
+            $this->command($first, $firstInput, 'release');
+            self::assertFileDoesNotExist($path);
+            $next = $this->command($second, $secondInput, 'acquire');
+            self::assertTrue($next['result']);
+            self::assertSame((string) $next['pid'], $next['contents']);
+            self::assertFalse($this->command($first, $firstInput, 'acquire')['result']);
+            $this->command($second, $secondInput, 'release');
+            self::assertFileDoesNotExist($path);
         }
     }
 
-    /** The acquiring handler must validate identity after taking the lock. */
-    public function testAcquireChecksDescriptorIdentityAfterLocking(): void
+    /** Releasing a detached owner must leave the replacement owner's path and PID alone. */
+    public function testReleaseDoesNotUnlinkAReplacementFile(): void
     {
-        $source = $this->handlerSource();
-
-        $lock = strpos($source, 'if (!flock($fp, LOCK_EX | LOCK_NB)) {');
-        $identity = strpos($source, 'tpRuntimeFileMatchesPath($lockFile, $lockStat) === false');
-        $write = strpos($source, '$pid = (string) getmypid();');
-
-        self::assertIsInt($lock);
-        self::assertIsInt($identity);
-        self::assertIsInt($write);
-        self::assertLessThan($identity, $lock, 'Identity must be checked after the lock is taken.');
-        self::assertLessThan($write, $identity, 'The PID must only be written on a validated lock.');
+        $this->requirePosix();
+        $path = $this->root . '/storage/logs/replaced.lock';
+        [$first, $firstInput] = $this->startLockProbe($path);
+        self::assertTrue($this->command($first, $firstInput, 'acquire')['result']);
+        self::assertTrue(rename($path, $path . '.old'));
+        [$second, $secondInput] = $this->startLockProbe($path);
+        $replacement = $this->command($second, $secondInput, 'acquire');
+        self::assertTrue($replacement['result']);
+        $this->command($first, $firstInput, 'release');
+        self::assertFileExists($path);
+        self::assertSame((string) $replacement['pid'], $this->command($second, $secondInput, 'acquire')['contents']);
+        self::assertFalse($this->command($first, $firstInput, 'acquire')['result']);
+        $this->command($second, $secondInput, 'release');
+        self::assertFileDoesNotExist($path);
     }
 
-    /**
-     * The releasing handler must unlink under its own lock, and never touch a
-     * lock file it does not own.
-     */
-    public function testReleaseUnlinksUnderTheLockAndOnlyWhenItOwnsIt(): void
+    /** Destruction follows normal release; a lock never acquired never deletes its target. */
+    public function testDestructionRemovesOnlyAnAcquiredLock(): void
     {
-        $source = $this->handlerSource();
-        $release = strpos($source, 'private function releaseProcessLock(): void {');
-        self::assertIsInt($release);
-        $body = substr($source, $release);
-
-        $guard = strpos($body, 'if ($this->lockFileHandle === null) {');
-        $ownership = strpos($body, 'tpRuntimeFileMatchesPath($lockFile, $lockStat)');
-        $unlink = strpos($body, 'unlink($lockFile);');
-        $unlock = strpos($body, 'flock($this->lockFileHandle, LOCK_UN);');
-
-        self::assertIsInt($guard);
-        self::assertIsInt($ownership);
-        self::assertIsInt($unlink);
-        self::assertIsInt($unlock);
-        self::assertLessThan($ownership, $guard, 'A handler that never acquired the lock must return early.');
-        self::assertLessThan($unlink, $ownership, 'Only the owned inode may be unlinked.');
-        self::assertLessThan($unlock, $unlink, 'Unlinking must happen while the lock is still held.');
+        $path = $this->root . '/storage/logs/destructor.lock';
+        $owner = new BackgroundTaskLock($path);
+        self::assertTrue($owner->acquire());
+        $idle = new BackgroundTaskLock($path);
+        unset($idle);
+        self::assertFileExists($path);
+        unset($owner);
+        self::assertFileDoesNotExist($path);
     }
+
+    /** A killed process leaves a reusable file when the next process has access. */
+    public function testAbruptExitAllowsRestartOnTheSameFile(): void
+    {
+        // A real POSIX SIGKILL must not run PHP destructors.
+        $this->requirePosix();
+        $path = $this->root . '/storage/logs/teampass_background_tasks.lock';
+        [$first, $firstInput] = $this->startLockProbe($path);
+        $acquired = $this->command($first, $firstInput, 'acquire');
+        self::assertTrue($acquired['result']);
+        $first->signal(9);
+        $first->wait();
+        self::assertFalse($first->isRunning());
+        self::assertTrue($first->hasBeenSignaled());
+        self::assertSame(9, $first->getTermSignal());
+        self::assertFileExists($path);
+        self::assertSame((string) $acquired['pid'], file_get_contents($path));
+        [$next, $nextInput] = $this->startLockProbe($path);
+        $restarted = $this->command($next, $nextInput, 'acquire');
+        self::assertTrue($restarted['result']);
+        self::assertSame($acquired['inode'], $restarted['inode']);
+        self::assertSame((string) $restarted['pid'], $restarted['contents']);
+    }
+
+    /** Coordination locks still tolerate chmod denial after successful opening. */
+    public function testLockRetainsBestEffortPermissionPolicy(): void
+    {
+        $this->requirePosix();
+        $path = $this->root . '/storage/logs/teampass_background_tasks.lock';
+        self::assertSame(5, file_put_contents($path, '12345'));
+        self::assertTrue(chmod($path, 0664));
+        clearstatcache(true, $path);
+        $probe = $this->runPhp(<<<'PHP'
+if (function_exists('chmod')) {
+    throw new RuntimeException('The chmod denial fixture was not enabled.');
+} else {
+    function chmod(string $path, int $mode): bool { return false; }
+}
+require $argv[1];
+$lock = new BackgroundTaskLock($argv[2]);
+$acquired = $lock->acquire();
+$mode = fileperms($argv[2]) & 0777;
+$pid = file_get_contents($argv[2]);
+$lock->release();
+echo json_encode(['acquired' => $acquired, 'mode' => $mode, 'pid' => $pid, 'expectedPid' => getmypid()]);
+PHP, [__DIR__ . '/../../app/scripts/backgroundTaskLock.php', $path], ['-d', 'disable_functions=chmod']);
+        $result = json_decode($probe->getOutput(), true, 512, JSON_THROW_ON_ERROR);
+        self::assertTrue($result['acquired']);
+        self::assertSame((string) $result['expectedPid'], $result['pid']);
+        self::assertSame(0664, $result['mode']);
+        self::assertFileDoesNotExist($path);
+        self::assertStringContainsString('Continuing with existing access', $probe->getErrorOutput());
+    }
+
+    /** Opening failures remain explicit and never remove a configured directory. */
+    public function testInvalidLockTargetsAreReportedWithoutDeletion(): void
+    {
+        foreach ([$this->root . '/missing/lock', $this->root . '/storage/logs'] as $path) {
+            $probe = $this->runPhp(
+                'require $argv[1]; $lock = new BackgroundTaskLock($argv[2]);'
+                . ' echo json_encode($lock->acquire()); $lock->release();',
+                [__DIR__ . '/../../app/scripts/backgroundTaskLock.php', $path]
+            );
+            self::assertSame('false', $probe->getOutput());
+            self::assertStringContainsString('cannot open a valid lock file', $probe->getErrorOutput());
+        }
+        self::assertDirectoryExists($this->root . '/storage/logs');
+        self::assertDirectoryDoesNotExist($this->root . '/missing');
+    }
+
+    /** Losing or releasing an unacquired lock must not disturb its target. */
+    public function testFailedAndRepeatedAcquisitionDoesNotLoseOwnership(): void
+    {
+        $path = $this->root . '/storage/logs/teampass_background_tasks.lock';
+        $owner = new BackgroundTaskLock($path);
+        $contender = new BackgroundTaskLock($path);
+        self::assertTrue($owner->acquire());
+        try {
+            self::assertTrue($owner->acquire());
+            self::assertFalse($contender->acquire());
+            $contender->release();
+            unset($contender);
+            self::assertFileExists($path);
+            $other = new BackgroundTaskLock($path);
+            self::assertFalse($other->acquire());
+            $owner->release();
+            self::assertTrue($other->acquire());
+            $other->release();
+            self::assertFileDoesNotExist($path);
+        } finally {
+            $owner->release();
+        }
+    }
+
 }

--- a/tests/Unit/TaskLoggerTest.php
+++ b/tests/Unit/TaskLoggerTest.php
@@ -3,126 +3,343 @@
 declare(strict_types=1);
 
 use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Symfony\Component\Process\Process;
 
-require_once __DIR__ . '/../../app/sources/runtime_files.functions.php';
+require_once __DIR__ . '/../Fixtures/RuntimeProcessTestTrait.php';
 require_once __DIR__ . '/../../app/scripts/taskLogger.php';
+require_once __DIR__ . '/../../app/sources/file_permissions.functions.php';
 
-class TaskLoggerTest extends TestCase
+final class TaskLoggerTest extends TestCase
 {
-    private string $root;
+    use RuntimeProcessTestTrait;
 
-    protected function setUp(): void
-    {
-        $this->root = sys_get_temp_dir() . DIRECTORY_SEPARATOR
-            . 'teampass-task-logger-test-' . bin2hex(random_bytes(8));
-        self::assertTrue(mkdir($this->root . '/storage/logs', 0700, true));
-    }
-
-    protected function tearDown(): void
-    {
-        $root = realpath($this->root);
-        $temporaryRoot = realpath(sys_get_temp_dir());
-        if (
-            $root === false
-            || $temporaryRoot === false
-            || str_starts_with($root, $temporaryRoot . DIRECTORY_SEPARATOR . 'teampass-task-logger-test-') === false
-        ) {
-            return;
-        }
-
-        $iterator = new RecursiveIteratorIterator(
-            new RecursiveDirectoryIterator($root, FilesystemIterator::SKIP_DOTS),
-            RecursiveIteratorIterator::CHILD_FIRST
-        );
-        foreach ($iterator as $entry) {
-            if ($entry->isLink() === false && $entry->isDir()) {
-                rmdir($entry->getPathname());
-            } else {
-                unlink($entry->getPathname());
-            }
-        }
-        rmdir($root);
-    }
-
-    /** @return array<string,mixed> */
-    private function settings(bool $enabled = true): array
-    {
-        return [
-            'enable_tasks_log' => $enabled ? '1' : '0',
-            'date_format' => 'd/m/Y',
-            'time_format' => 'H:i:s',
-        ];
-    }
-
-    /**
-     * LOG_TASKS_FILE became absolute when the storage/ layout landed, but the
-     * writer kept prepending app/scripts/ to it. The resulting path had no
-     * existing parent directory, so enable_tasks_log silently wrote nothing.
-     */
-    public function testAnAbsoluteLogPathIsUsedVerbatim(): void
-    {
-        $path = $this->root . '/storage/logs/teampass_tasks.log';
-
-        self::assertSame($path, tpResolveRuntimeLogPath($path, __DIR__ . '/../../app/scripts'));
-
-        (new TaskLogger($this->settings(), $path))->log('handler started', 'INFO');
-
-        self::assertFileExists($path);
-        self::assertStringContainsString('[INFO] handler started', (string) file_get_contents($path));
-        self::assertSame(
-            [],
-            glob($this->root . '/storage/logs/*' . DIRECTORY_SEPARATOR . '*') ?: [],
-            'No nested path may be built from an absolute log file.'
-        );
-    }
-
-    /** A pre-storage relative value must keep resolving against app/scripts/. */
-    public function testALegacyRelativeLogPathStillResolvesAgainstTheScriptDirectory(): void
+    /** Existing helper coverage must survive the test-suite consolidation. */
+    public function testLegacyAndWindowsPathsUseTheSharedResolver(): void
     {
         self::assertSame(
             '/opt/teampass/app/scripts' . DIRECTORY_SEPARATOR . '../files/teampass_tasks.log',
             tpResolveRuntimeLogPath('../files/teampass_tasks.log', '/opt/teampass/app/scripts/')
         );
-        self::assertSame('C:\\logs\\tasks.log', tpResolveRuntimeLogPath('C:\\logs\\tasks.log', '/opt/scripts'));
+        foreach (['C:\\logs\\tasks.log', 'C:/logs/tasks.log', '\\\\server\\logs\\tasks.log'] as $path) {
+            self::assertSame($path, tpResolveRuntimeLogPath($path, '/opt/scripts'));
+        }
     }
 
-    /** The task log is a runtime file: it must not be created world readable. */
-    public function testTheLogIsCreatedWithRestrictedPermissionsAndAppends(): void
+    /** @return array<string, array{int, bool}> */
+    public static function deniedModes(): array
     {
-        if (PHP_OS_FAMILY !== 'Linux') {
-            self::markTestSkipped('POSIX permission semantics are required.');
-        }
+        return [
+            'private' => [0600, true],
+            'group readable' => [0640, true],
+            'group writable' => [0660, true],
+            'other readable' => [0664, false],
+            'other writable' => [0662, false],
+            'other executable' => [0661, false],
+        ];
+    }
 
+    /** Chmod denial alone must not refuse a journal that has no other-user access. */
+    #[DataProvider('deniedModes')]
+    public function testStrictModeUsesOtherAccessRatherThanAnExactMode(int $mode, bool $allowed): void
+    {
+        $this->requirePosix();
+        $path = $this->root . '/storage/logs/group.log';
+        self::assertSame(8, file_put_contents($path, "history\n"));
+        self::assertTrue(chmod($path, $mode));
+        $probe = $this->runPhp(<<<'PHP'
+if (function_exists('chmod')) {
+    throw new RuntimeException('The chmod denial fixture was not enabled.');
+} else {
+    function chmod(string $path, int $mode): bool { return false; }
+}
+require $argv[1];
+$handle = tpOpenRuntimeFile($argv[3], true);
+$opened = is_resource($handle);
+if ($opened) {
+    fclose($handle);
+}
+for ($entry = 0; $entry < 5; ++$entry) {
+    (new TaskLogger(json_decode($argv[2], true), $argv[3]))->log('private-task-arguments');
+}
+echo json_encode(['opened' => $opened]);
+PHP, [__DIR__ . '/../../app/scripts/taskLogger.php', json_encode($this->settings()), $path], ['-d', 'disable_functions=chmod']);
+        self::assertSame($allowed, json_decode($probe->getOutput(), true)['opened']);
+        self::assertSame($allowed ? 0 : 1, substr_count($probe->getErrorOutput(), 'The log entry was not recorded'));
+        self::assertStringNotContainsString('private-task-arguments', $probe->getErrorOutput());
+        self::assertStringNotContainsString('cannot restrict runtime file permissions', $probe->getErrorOutput());
+        self::assertSame($allowed ? 5 : 0, substr_count(file_get_contents($path), 'private-task-arguments'));
+        self::assertStringStartsWith("history\n", file_get_contents($path));
+        clearstatcache(true, $path);
+        self::assertSame($mode, fileperms($path) & 0777);
+    }
+
+    /** A static diagnostic flag suppresses messages, never later attempts to write. */
+    public function testDestinationFailureIsReportedOnceAndRepairResumesLogging(): void
+    {
+        $path = $this->root . '/missing/recoverable.log';
+        $probe = $this->runPhp(<<<'PHP'
+require $argv[1];
+$settings = json_decode($argv[2], true);
+for ($entry = 0; $entry < 20; ++$entry) {
+    (new TaskLogger($settings, $argv[3]))->log('private-lost-entry');
+}
+mkdir(dirname($argv[3]), 0700);
+(new TaskLogger($settings, $argv[3]))->log('recovered');
+(new TaskLogger($settings, $argv[3] . '/invalid'))->log('another-private-lost-entry');
+(new TaskLogger($settings, $argv[3]))->log('still working');
+echo 'continued';
+PHP, [__DIR__ . '/../../app/scripts/taskLogger.php', json_encode($this->settings()), $path]);
+        self::assertSame('continued', $probe->getOutput());
+        self::assertSame(1, substr_count($probe->getErrorOutput(), 'The log entry was not recorded'));
+        self::assertStringNotContainsString('private-lost-entry', $probe->getErrorOutput());
+        self::assertStringNotContainsString('private-lost-entry', file_get_contents($path));
+        self::assertCount(2, file($path));
+        self::assertStringContainsString('recovered', file_get_contents($path));
+        self::assertStringContainsString('still working', file_get_contents($path));
+    }
+
+    /** @return array<string, array{string, bool, int}> */
+    public static function handoffs(): array
+    {
+        return [
+            'rotation once' => ['rotate_once', true, 2],
+            'rotation twice' => ['rotate_twice', false, 2],
+            'permissions changed while waiting' => ['permissions', false, 1],
+            'replacement symlink' => ['symlink', false, 1],
+            'partial write is not retried' => ['partial', false, 1],
+        ];
+    }
+
+    /**
+     * Inject a filesystem change exactly at the lock handoff, without timing races.
+     * Native flock/concurrent appends are exercised separately by the three writers.
+     */
+    #[DataProvider('handoffs')]
+    public function testLogHandoffRevalidatesAndRetriesAtMostOnce(string $scenario, bool $expected, int $attempts): void
+    {
+        $this->requirePosix();
+        $path = $this->root . '/storage/logs/handoff.log';
+        self::assertSame(8, file_put_contents($path, "history\n"));
+        self::assertTrue(chmod($path, 0640));
+        $probe = $this->runPhp(
+            'require $argv[1];',
+            [__DIR__ . '/../Fixtures/runtime_log_handoff_probe.php', $path, $scenario],
+            ['-d', 'disable_functions=flock' . ($scenario === 'partial' ? ',fwrite' : '')]
+        );
+        $result = json_decode($probe->getOutput(), true, 512, JSON_THROW_ON_ERROR);
+        self::assertSame($expected, $result['result']);
+        self::assertSame($attempts, $result['attempts']);
+        self::assertSame('', $probe->getErrorOutput());
+        if ($scenario === 'rotate_once') {
+            self::assertSame("history\n", file_get_contents($path . '.old-1'));
+            self::assertSame("rotated\nprivate-entry\n", file_get_contents($path));
+        } elseif ($scenario === 'rotate_twice') {
+            self::assertSame("history\n", file_get_contents($path . '.old-1'));
+            self::assertSame("rotated\n", file_get_contents($path . '.old-2'));
+            self::assertSame("rotated\n", file_get_contents($path));
+        } elseif ($scenario === 'symlink') {
+            self::assertSame("untouched\n", file_get_contents($path . '.target'));
+            self::assertSame("history\n", file_get_contents($path . '.old-1'));
+        } elseif ($scenario === 'partial') {
+            self::assertSame("history\npri", file_get_contents($path));
+        } else {
+            self::assertSame("history\n", file_get_contents($path));
+        }
+    }
+
+    /** @return array<string, string> */
+    private function settings(): array
+    {
+        return ['enable_tasks_log' => '1', 'date_format' => 'Y-m-d', 'time_format' => 'H:i:s'];
+    }
+
+    /** @return array<string, array{int, int}> */
+    public static function masks(): array
+    {
+        return [
+            'unrestricted' => [0000, 0640],
+            'group writable' => [0002, 0640],
+            'usual web default' => [0022, 0640],
+            'restricted' => [0027, 0640],
+            'private' => [0077, 0600],
+        ];
+    }
+
+    /** Verify the actual logger creates and recreates a protected append-only history. */
+    #[DataProvider('masks')]
+    public function testLogCreationRecreationAndPermissions(int $mask, int $expected): void
+    {
+        $this->requirePosix();
         $path = $this->root . '/storage/logs/teampass_tasks.log';
         $logger = new TaskLogger($this->settings(), $path);
-        $previousMask = umask(0022);
+        $previous = umask($mask);
         try {
-            $logger->log('first line');
-            clearstatcache(true, $path);
-            self::assertSame(0640, fileperms($path) & 0777);
-            $inode = fileinode($path);
-
-            $logger->log('second line', 'ERROR');
-            clearstatcache(true, $path);
-            self::assertSame(0640, fileperms($path) & 0777);
-            self::assertSame($inode, fileinode($path), 'Appending must not replace the log file.');
-            self::assertSame(0022, umask());
+            for ($run = 0; $run < 2; ++$run) {
+                $logger->log('first entry');
+                clearstatcache(true, $path);
+                $inode = fileinode($path);
+                $logger->log('second entry', 'WARNING');
+                clearstatcache(true, $path);
+                self::assertSame($expected, fileperms($path) & 07777);
+                self::assertSame($inode, fileinode($path));
+                self::assertSame($mask, umask());
+                $lines = file($path, FILE_IGNORE_NEW_LINES);
+                self::assertCount(2, $lines);
+                self::assertMatchesRegularExpression('/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} - \[INFO\] first entry$/', $lines[0]);
+                self::assertStringEndsWith(' - [WARNING] second entry', $lines[1]);
+                self::assertTrue(unlink($path));
+            }
         } finally {
-            umask($previousMask);
+            umask($previous);
         }
-
-        $contents = (string) file_get_contents($path);
-        self::assertStringContainsString('[INFO] first line', $contents);
-        self::assertStringContainsString('[ERROR] second line', $contents);
-        self::assertSame(2, substr_count($contents, PHP_EOL));
     }
 
-    /** Task logging stays opt-in: no file is created while the setting is off. */
-    public function testNothingIsWrittenWhenTaskLoggingIsDisabled(): void
+    /** Existing private logs stay private; a permissive log is repaired in place. */
+    public function testExistingLogModesAndAuditRemainConsistent(): void
     {
-        $path = $this->root . '/storage/logs/teampass_tasks.log';
-        (new TaskLogger($this->settings(false), $path))->log('must not appear');
-
-        self::assertFileDoesNotExist($path);
+        $this->requirePosix();
+        foreach ([0600, 0640, 0644, 0666] as $mode) {
+            $path = $this->root . '/storage/logs/log-' . $mode;
+            self::assertSame(8, file_put_contents($path, "history\n"));
+            self::assertTrue(chmod($path, $mode));
+            clearstatcache(true, $path);
+            $inode = fileinode($path);
+            (new TaskLogger($this->settings(), $path))->log('appended');
+            clearstatcache(true, $path);
+            self::assertSame($mode === 0600 ? 0600 : 0640, fileperms($path) & 07777);
+            self::assertSame($inode, fileinode($path));
+            self::assertStringStartsWith("history\n", file_get_contents($path));
+        }
+        $unsafe = $this->root . '/storage/logs/unmanaged.log';
+        self::assertSame(6, file_put_contents($unsafe, 'unsafe'));
+        self::assertTrue(chmod($unsafe, 0644));
+        $issues = array_values(array_filter(
+            tpFilePermissionsScan($this->root)['issues'],
+            static fn (array $issue): bool => $issue['reason'] === 'runtime_world_accessible'
+        ));
+        self::assertCount(1, $issues);
+        self::assertSame('storage/logs/unmanaged.log', $issues[0]['path']);
     }
+
+    /** Absolute paths are not prefixed with app/scripts, including native Windows drive paths. */
+    public function testAbsolutePathAndDisabledLogging(): void
+    {
+        $path = $this->root . '/storage/logs/absolute.log';
+        (new TaskLogger(['enable_tasks_log' => '0'], $path))->log('disabled');
+        self::assertFileDoesNotExist($path);
+        (new TaskLogger($this->settings(), $path))->log('enabled');
+        self::assertStringEndsWith(' - [INFO] enabled' . PHP_EOL, file_get_contents($path));
+        (new TaskLogger(['enable_tasks_log' => '0'], $path))->log('disabled again');
+        self::assertCount(1, file($path));
+    }
+
+    /** Exercise script-relative paths with unmodified production files in an isolated tree. */
+    public function testRelativePathAndExplicitErrorLogFallback(): void
+    {
+        self::assertTrue(copy(__DIR__ . '/../../app/scripts/taskLogger.php', $this->root . '/app/scripts/taskLogger.php'));
+        self::assertTrue(copy(__DIR__ . '/../../app/sources/runtime_files.functions.php', $this->root . '/app/sources/runtime_files.functions.php'));
+        $probe = $this->runPhp(
+            'require $argv[1]; $settings = json_decode($argv[2], true);'
+            . ' (new TaskLogger($settings, "../../storage/logs/relative.log"))->log("relative");'
+            . ' (new TaskLogger($settings))->log("explicit fallback");',
+            [$this->root . '/app/scripts/taskLogger.php', json_encode($this->settings())]
+        );
+        self::assertStringContainsString(' - [INFO] relative', file_get_contents($this->root . '/storage/logs/relative.log'));
+        self::assertStringContainsString('explicit fallback', $probe->getErrorOutput());
+    }
+
+    /** A failed configured destination must not leak the lost entry to another log. */
+    public function testInvalidLogDestinationsDoNotLeakContents(): void
+    {
+        foreach ([$this->root . '/missing/log', $this->root . '/storage/logs', 'php://memory'] as $path) {
+            $probe = $this->runPhp(
+                'require $argv[1]; (new TaskLogger(json_decode($argv[2], true), $argv[3]))->log("private-task-arguments"); echo "continued";',
+                [__DIR__ . '/../../app/scripts/taskLogger.php', json_encode($this->settings()), $path]
+            );
+            self::assertSame('continued', $probe->getOutput());
+            self::assertStringContainsString('The log entry was not recorded', $probe->getErrorOutput());
+            self::assertStringNotContainsString('private-task-arguments', $probe->getErrorOutput());
+        }
+    }
+
+    /** Sensitive log entries are refused when only chmod fails; the warning stays auditable. */
+    public function testLogPermissionFailureDoesNotStopTasksOrDiscloseContents(): void
+    {
+        $this->requirePosix();
+        $path = $this->root . '/storage/logs/teampass_tasks.log';
+        self::assertSame(8, file_put_contents($path, "history\n"));
+        self::assertTrue(chmod($path, 0664));
+        $probe = $this->runPhp(<<<'PHP'
+if (function_exists('chmod')) {
+    throw new RuntimeException('The chmod denial fixture was not enabled.');
+} else {
+    function chmod(string $path, int $mode): bool { return false; }
+}
+require $argv[1];
+for ($entry = 0; $entry < 20; ++$entry) {
+    (new TaskLogger(json_decode($argv[2], true), $argv[3]))->log('private-task-arguments');
+}
+echo 'continued';
+PHP, [__DIR__ . '/../../app/scripts/taskLogger.php', json_encode($this->settings()), $path], ['-d', 'disable_functions=chmod']);
+        self::assertSame('continued', $probe->getOutput());
+        self::assertSame(1, substr_count($probe->getErrorOutput(), 'The log entry was not recorded'));
+        self::assertStringNotContainsString('private-task-arguments', $probe->getErrorOutput());
+        self::assertStringNotContainsString('Continuing with existing access', $probe->getErrorOutput());
+        self::assertSame("history\n", file_get_contents($path));
+        clearstatcache(true, $path);
+        self::assertSame(0664, fileperms($path) & 0777);
+        $issues = array_filter(tpFilePermissionsScan($this->root)['issues'],
+            static fn (array $issue): bool => $issue['reason'] === 'runtime_world_accessible');
+        self::assertCount(1, $issues);
+    }
+
+    /** A symlink must not redirect task arguments or permission repair to another file. */
+    public function testLogSymlinkIsRejected(): void
+    {
+        $path = $this->root . '/storage/logs/linked.log';
+        $target = $this->root . '/storage/logs/target.log';
+        self::assertSame(9, file_put_contents($target, 'untouched'));
+        if (!@symlink($target, $path)) {
+            self::markTestSkipped('Symbolic links are unavailable.');
+        }
+        $mode = fileperms($target);
+        $this->runPhp('require $argv[1]; (new TaskLogger(json_decode($argv[2], true), $argv[3]))->log("secret");',
+            [__DIR__ . '/../../app/scripts/taskLogger.php', json_encode($this->settings()), $path]);
+        self::assertSame('untouched', file_get_contents($target));
+        clearstatcache(true, $target);
+        self::assertSame($mode, fileperms($target));
+    }
+
+    /** Multiple workers must append every complete entry without overwriting each other. */
+    public function testConcurrentLogWritersPreserveEveryEntry(): void
+    {
+        $path = $this->root . '/storage/logs/concurrent.log';
+        $writers = [];
+        for ($writer = 0; $writer < 3; ++$writer) {
+            $process = new Process([
+                PHP_BINARY, '-r',
+                'require $argv[1]; $logger = new TaskLogger(json_decode($argv[2], true), $argv[3]);'
+                . ' for ($entry = 0; $entry < 80; ++$entry) { $logger->log($argv[4] . ":" . $entry . ":" . str_repeat("x", 1024)); }',
+                '--', __DIR__ . '/../../app/scripts/taskLogger.php', json_encode($this->settings()), $path, (string) $writer,
+            ]);
+            $process->setTimeout(15);
+            $this->processes[] = $process;
+            $process->start();
+            $writers[] = $process;
+        }
+        foreach ($writers as $writer) {
+            self::assertSame(0, $writer->wait(), $writer->getErrorOutput());
+            self::assertSame('', $writer->getErrorOutput());
+        }
+        $lines = file($path, FILE_IGNORE_NEW_LINES);
+        self::assertCount(240, $lines);
+        $identifiers = [];
+        foreach ($lines as $line) {
+            self::assertSame(1, preg_match('/ - \[INFO\] ([0-2]):([0-9]+):(x{1024})$/', $line, $matches));
+            $identifiers[] = $matches[1] . ':' . $matches[2];
+        }
+        self::assertCount(240, array_unique($identifiers));
+    }
+
 }


### PR DESCRIPTION
## Description

This implements follow-up points 7 and 8 from the review of #5366.

**Prerequisite:** this branch includes #5366 at `de5a9e5e28cfd74f4231b1935bbcb3b5b9423e3c`. Merge that PR first; the changes described below are the additional work. The `Fix_5364` branch was not modified.

### Task journal

- Fix `TaskLogger` path resolution: `LOG_TASKS_FILE` is normally absolute and must not be prefixed with `app/scripts/`. Custom absolute paths, native Windows paths and legacy script-relative paths are preserved.
- Reuse the runtime-file helper with an opt-in strict permission policy for log entries. Preserve `0600`, restrict permissive files to `0640` and do not change the process-wide umask.
- Append under an exclusive lock, seek to the current end only after acquiring it, and preserve existing entries. Recheck file identity and permissions after waiting for the lock.
- A configured destination that cannot be opened, secured or written produces an explicit PHP error-log diagnostic. Do not copy potentially sensitive task arguments to that fallback destination; background processing continues.
- Keep disabled logging and the explicitly configured empty-path PHP error-log destination unchanged.
- Preserve the best-effort chmod policy for locks/signals introduced in #5366. No scanner exclusion or release-manifest change.

### Persistent handler lock

- Isolate the existing acquisition/release logic in the DB-free `app/scripts/backgroundTaskLock.php` class so the real implementation can be tested across processes. The handler delegates only those two operations; scheduling and task execution are unchanged.
- Keep the lock file and its inode after release; never unlink it on success, failure or destruction.
- Acquire non-blockingly and write the PID only after exclusive ownership. Preserve explicit unlocking before closing the descriptor (including compatibility with inherited descriptors); an old PID/file does not indicate a running handler.
- Preserve diagnostics for actual open/write failures and tolerate chmod-only failures on otherwise accessible locks.
- Document deployment coordination: old handlers must finish before new code starts because the old release code can still unlink the file.

## Related issue

Follow-up to #5366, review points 7 and 8; related to #5364.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (existing behaviour changes)
- [x] Documentation
- [ ] Translation
- [ ] Refactor / maintenance

## How has this been tested?

Local Windows validation with PHP 8.2.33 and 8.3.33:

- PHP syntax checks: passed on both versions.
- Targeted tests: **63 tests, 859 assertions, no failures, errors, warnings or notices**, with **28 platform-dependent skips**, on each version. Executed with `--fail-on-warning --fail-on-notice --fail-on-risky`.
- New regression coverage adds 18 cases: logging enabled/disabled, native absolute and legacy relative paths, explicit error-log fallback, creation/recreation under five umasks, mode repair and preservation of 0600/history/inode, unsafe files still reported by the audit, invalid targets/symlinks, and different chmod-failure policies for journals and coordination locks.
- Concurrent append test: three writers, 240 complete distinct entries.
- Persistent-lock tests use real PHP subprocesses and a request/response protocol with a 15-second process timeout, not timing assumptions. Cases cover a pre-opened contender, a third contender, repeated handoffs, preservation of the active PID, repeated/failed acquisition, normal release, and forced termination followed by restart on the same inode.
- The test fixture reads the PID through the owner's descriptor because Windows mandatory locks prevent outsider reads. The same assertions run on Linux.
- Full configured PHPStan level 4: passed. A temporary copy of `settings.sample.php` was used and removed afterwards; no credentials or production configuration were created.
- Table-prefix guard: passed (81 table names checked). Production autoloader checked: no development-package mappings.
- Full suite on both versions: **1,750 tests, 59,820 assertions, 9 failures, 1 warning, 28 skips**. The Windows full suite is **not green**; these are the platform-sensitive failures also encountered before this follow-up, not failures of the targeted runtime tests.
- `git diff --check`: passed. Release manifest, scope/permission-audit rules, Composer metadata and dependencies unchanged.

**Linux CI for this follow-up is pending.** POSIX permissions and symbolic-link cases cannot be fully validated on this Windows workstation. Chmod denial is simulated in an isolated PHP subprocess; a real multi-account ownership scenario is not exercised locally.

No live-instance database/UI tests were run. Admin, manager, standard/read-only roles and personal-folder settings are unaffected and were not exercised through the UI.

### Suggested lab validation

1. Pause cron/other handler launchers and incoming requests that can start background work. Let old handlers and workers finish, then deploy the complete branch, including the new `app/scripts/backgroundTaskLock.php`, and resume operation.
2. Enable task logging and trigger ordinary background work under the normal web/cron account. Confirm the configured journal is written in its intended location, new lines append, and its mode is `0640` or an existing `0600`.
3. Run a Health permissions scan. The managed journal and locks should no longer raise world-access warnings after successful permission repair; an unrelated unsafe runtime file must remain detectable.
4. After normal completion, confirm that the handler lock remains on disk. Start work again and verify it can acquire that same file and update its PID. Do not infer activity from file presence or the saved PID.
5. Run `php _tools/phpunit.phar --do-not-cache-result --filter BackgroundTaskRuntimeTest` on Linux to exercise the permission and deterministic subprocess scenarios. The forced-termination case kills only a test subprocess, never a live task handler.
6. If checking recreation or log rotation manually, stop all writers first. Never remove a lock while a handler can run.

## Checklist

- [x] PHPStan level 4 passes (`php app/vendor/bin/phpstan analyse --memory-limit=2G`)
- [ ] The test suite passes (`php _tools/phpunit.phar` — Linux CI pending; Windows limitations documented above)
- [x] Every new public function has a docblock
- [x] Variable names and comments are in English
- [x] No `var_dump()` or `console.log()` left in the code
- [ ] New `app/sources/*.queries.php` files have a matching `public/sources/` proxy shim — not applicable
- [ ] Changes to `teampassclasses` were applied to **both** copies — not applicable
- [x] `app/vendor/composer/` is in its production form — unchanged

## Impact on install / upgrade

- [x] No schema change
- [ ] Schema change — an `install/upgrade_run_X.X.X.php` script is included and the fresh install path was tested

No migration or manifest regeneration is needed for this change. Existing accessible locks and journals are repaired on use when possible. Invalid ownership/path settings still require administrator correction.

The installer and historical upgrade initializers only create missing legacy lock/trigger files; they do not remove the retained runtime lock. They are unchanged by this follow-up.

Deploy with old handlers drained as described above. Keep runtime directories protected against untrusted writers: path-based chmod checks are not atomic and this patch does not claim to make arbitrary external unlink/replacement safe.

## Screenshots

Not applicable: no UI change.
